### PR TITLE
Add deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ npm-*
 
 # Build
 /build
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,27 @@ clean:
 static:
 	cp -a ./static/. ./build/
 
-nginx_conf:
-	@make static
-	node server/nginx.js
-
 webpack:
 	$(WEBPACK)
+
+# ------------------------------------
+
+watch:
+	$(WATCH) "make clean && make static" ./static &
+	$(WEBPACK) -d --watch &
+	wait
+
+stop:
+	pkill -f "node $(WEBPACK) -d --watch"
+	pkill -f "node $(WATCH) make clean && make static ./static"
+
+start:
+	$(NODE) ./server/index.js
+
+# ------------------------------------
+
+nginx_conf:
+	node server/nginx.js
 
 # ------------------------------------
 
@@ -39,18 +54,4 @@ lint:
 
 # ------------------------------------
 
-watch:
-	$(WATCH) "make clean && make static" ./static &
-	$(WEBPACK) -d --watch &
-	wait
-
-stop-watch:
-	pkill -f "node $(WATCH) make clean && make static ./static"
-	pkill -f "node $(WEBPACK) -d --watch"
-
-start:
-	$(NODE) ./server/index.js
-
-# ------------------------------------
-
-.PHONY: build clean static webpack test lint watch start
+.PHONY: build clean static webpack watch stop start nginx_conf test lint

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "www",
   "version": "1.0.0",
   "description": "Standalone WWW client for Scratch",
-  "main": "index.js",
   "scripts": {
     "start": "make start",
     "test": "make test",
     "watch": "make watch",
     "stop-watch": "make stop-watch",
-    "build": "make build"
+    "build": "make build",
+    "prestart": "make build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Super trivial, but adding these to the `develop` branch to keep it in-sync with deployment
- Adds Elastic Beanstalk configuration files to `.gitignore`
- Some minor cleanup of the makefile
- Add an `npm` script called `prestart` for Elastic Beanstalk
