### PR TITLE
Fix 'M' issue in Firefox

### DIFF
--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -155,7 +155,7 @@
                 padding-left: 10px;
                 width: 30px;
                 overflow: hidden;
-                text-indent: 100%;
+                text-indent: 50px;
                 white-space: nowrap;
             }
 


### PR DESCRIPTION
Set fixed 'text-indent' to push content out of the navigation element.

https://github.com/LLK/scratch-www/issues/51
