### PR TITLE
Create locale directory if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 clean:
 	rm -rf ./build
 	mkdir -p build
+	mkdir -p locales
 
 static:
 	cp -a ./static/. ./build/


### PR DESCRIPTION
Resolves `make build` failure on a clean clone of the repo.
