### PR TITLE
Redirect to ban appeal if the user is banned

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -34,7 +34,11 @@ require('custom-event-polyfill');
             host: '',
             uri: '/session/'
         }, function (err, body) {
-            window.updateSession(body);
+            if (body.banned) {
+                return window.location = body.redirectUrl;
+            } else {
+                window.updateSession(body);
+            }
         });
     };
 


### PR DESCRIPTION
The default behavior is for the `/session/` request to be redirected to the ban appeal page. Unfortunately we can't detect this 302 response, as the browser transparently handles it and javascript just sees a 200 response with a weird body.  So I've updated scratchr2 to return a special response for banned `/session/` requests.
