### PR TITLE
Remove the session listener on unmount

### DIFF
--- a/src/mixins/session.jsx
+++ b/src/mixins/session.jsx
@@ -9,6 +9,9 @@ var Session = {
     },
     componentWillMount: function () {
         window.addEventListener('session', this.updateSession);
+    },
+    componentWillUnmount: function () {
+        window.removeEventListener('session', this.updateSession);
     }
 };
 


### PR DESCRIPTION
This will prevent bugs if we ever use the mixin on a component that isn't a view
