### PR TITLE
Display title and extras differently

### DIFF
--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -18,7 +18,6 @@
         word-wrap: break-word;
 
         a {
-            display: block;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -29,11 +28,19 @@
         margin-bottom: 1px;
         font-size: .9230em;
         font-weight: 800;
+
+        a {
+            display: block;
+        }
     }
 
     #{$extras} {
         color: $type-gray;
         font-size: .8462em;
+
+        a {
+            display: inline;
+        }
     }
 
     &.project {


### PR DESCRIPTION
Changes this:
<img width="954" alt="screen shot 2015-10-23 at 9 01 41 am" src="https://cloud.githubusercontent.com/assets/1815772/10693185/b97aef62-7964-11e5-88d7-57292629809d.png">

To this:
<img width="987" alt="screen shot 2015-10-23 at 9 01 28 am" src="https://cloud.githubusercontent.com/assets/1815772/10693190/be76c540-7964-11e5-8a3d-4f4a37ffcd0c.png">
