### PR TITLE
Expand #view to wrap contents on small screens

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -68,10 +68,12 @@ a:hover {
 }
 
 #view {
+    display: inline-block;
+
     /* NOTE: Margin should match height in navigation.scss */
     margin-top: 50px;
     background-color: $background-color;
-
-    padding: 20px 0;
+    padding: 20px 1px;
+    min-width: 100%;
     min-height: 768px;
 }


### PR DESCRIPTION
I noticed the cut off background color on iOS and every other small screen I tested so I figured we should fix it if it's easy.

`inline-block` causes #view width to expand to its children's width.

`min-width: 100%` is necessary for larger screens, so that the `inline-block` element is still grows to contain all the available width.

The 1px of padding is apparently needed for Android Chrome, otherwise the right edge has blue from the body background showing.

Fixes GH-91
