### PR TITLE
Fix GH-177: Lower z-index for banners to 9

### DIFF
--- a/src/components/banner/banner.scss
+++ b/src/components/banner/banner.scss
@@ -5,7 +5,7 @@ $navigation-height: 50px;
 .banner {
     position: fixed;
     top: $navigation-height;
-    z-index: 99;
+    z-index: 9;
     box-shadow: 0 1px 1px $ui-dark-gray;
     background-color: $ui-orange;
     width: 100%;


### PR DESCRIPTION
The navigation is at 10, so we want the banners to be underneath that.
