### PR TITLE
#180 – Use xhr to clear cache instead of form

### DIFF
--- a/server/proxies.json
+++ b/server/proxies.json
@@ -6,6 +6,7 @@
     "/i18n/setlang/",
     "/login_retry/",
     "/media/",
+    "/scratch_admin/homepage/clear-cache/",
     "/session/",
     "/site-api",
     "/static/"

--- a/src/components/adminpanel/adminpanel.scss
+++ b/src/components/adminpanel/adminpanel.scss
@@ -58,8 +58,12 @@
                     justify-content: space-between;
 
                     .button {
-                        background-color: $ui-dark-gray;
                         padding: .5rem 1rem;
+
+                        &.inprogress {
+                            background-color: $ui-dark-gray;
+                            color: $type-gray;
+                        }
                     }
                 }
             }

--- a/src/components/forms/button.scss
+++ b/src/components/forms/button.scss
@@ -1,6 +1,8 @@
 @import "../../colors";
 
 $base-bg: $ui-white;
+$fail-bg: $ui-orange;
+$pass-bg: $ui-aqua;
 
 .button {
     display: inline-block;
@@ -15,12 +17,7 @@ $base-bg: $ui-white;
     font-size: .8rem;
     font-weight: bold;
 
-    &.white {
-        border-top: 1px inset $active-gray;
-        background-color: $base-bg;
-        color: $ui-blue;
-    }
-
+    /* USER BUTTON STATES */
     &:hover {
         box-shadow: 0 2px 2px $box-shadow-gray;
     }
@@ -31,5 +28,24 @@ $base-bg: $ui-white;
 
     &:focus {
         outline: none;
+    }
+
+    /* DATA BUTTON STATES */
+    &.white {
+        border-top: 1px inset $active-gray;
+        background-color: $base-bg;
+        color: $ui-blue;
+    }
+
+    &.pass {
+        background-color: $pass-bg;
+    }
+
+    &.fail {
+        background-color: $fail-bg;
+    }
+
+    &:disabled {
+        box-shadow: none;
     }
 }

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -32,7 +32,8 @@ var Splash = injectIntl(React.createClass({
             news: [],
             featuredCustom: {},
             featuredGlobal: {},
-            showEmailConfirmationModal: false
+            showEmailConfirmationModal: false,
+            refreshCacheStatus: 'notrequested'
         };
     },
     componentDidUpdate: function (prevProps, prevState) {
@@ -114,6 +115,35 @@ var Splash = injectIntl(React.createClass({
         }, function (err, body) {
             if (!err) this.setState({projectCount: body.count});
         }.bind(this));
+    },
+    refreshHomepageCache: function () {
+        this.api({
+            uri: '/scratch_admin/homepage/clear-cache/',
+            method: 'post',
+            useCsrf: true
+        }, function (err, body) {
+            if (err) return this.setState({refreshCacheStatus: 'fail'});
+            if (!body.success) return this.setState({refreshCacheStatus: 'inprogress'});
+            return this.setState({refreshCacheStatus: 'pass'});
+        }.bind(this));
+    },
+    getHomepageRefreshStatus: function () {
+        var status = {
+            status: this.state.refreshCacheStatus,
+            disabled: false,
+            content: 'Refresh'
+        };
+        if (this.state.refreshCacheStatus === 'inprogress') {
+            status.disabled = true;
+            status.content = 'In Progress';
+        } else if (this.state.refreshCacheStatus === 'pass') {
+            status.disabled = true;
+            status.content = 'Requested';
+        } else if (this.state.refreshCacheStatus == 'fail') {
+            status.disabled = false;
+            status.content = 'Error';
+        }
+        return status;
     },
     showEmailConfirmationModal: function () {
         this.setState({emailConfirmationModalOpen: true});
@@ -286,6 +316,7 @@ var Splash = injectIntl(React.createClass({
     render: function () {
         var featured = this.renderHomepageRows();
         var emailConfirmationStyle = {width: 500, height: 330, padding: 1};
+        var homepageCacheState = this.getHomepageRefreshStatus();
         return (
             <div className="splash">
                 {this.shouldShowEmailConfirmation() ? [
@@ -340,18 +371,14 @@ var Splash = injectIntl(React.createClass({
                         <dd>
                             <ul className="cache-list">
                                 <li>
-                                    <form
-                                        id="homepage-refresh-form"
-                                        method="post"
-                                        action="/scratch_admin/homepage/clear-cache/">
-                                        
-                                        <div className="button-row">
-                                            <span>Refresh row data:</span>
-                                            <Button type="submit">
-                                                <span>Refresh</span>
-                                            </Button>
-                                        </div>
-                                    </form>
+                                    <div className="button-row">
+                                        <span>Refresh row data:</span>
+                                        <Button onClick={this.refreshHomepageCache}
+                                                className={homepageCacheState.status}
+                                                diabled={homepageCacheState.disabled}>
+                                            <span>{homepageCacheState.content}</span>
+                                        </Button>
+                                    </div>
                                 </li>
                             </ul>
                         </dd>


### PR DESCRIPTION
Because csrf.

Also, since we don't have a definite message/banner system in place yet, use the button itself for feedback rather than messages. The button will disable if it has been successfully used, or turn pink if there was an error (and it will not be disabled in that case).

Fixes #180.
