### PR TITLE
Fix GH-128: Make video float right of the intro

### DIFF
--- a/src/components/intro/intro.scss
+++ b/src/components/intro/intro.scss
@@ -11,7 +11,8 @@
 
     .content {
         display: inline-block;
-        width: calc(66% - 20px);
+        width: calc(66% - 30px);
+        vertical-align: top;
 
         h1 {
             color: $ui-orange;


### PR DESCRIPTION
Fixes GH-128.

I don't know why the 20px offset wasn't enough fro IE 9, but the extra 10px doesn't hurt other browsers, so...
