### PR TITLE
Reduce browser cachiness to 1h from 1y

### DIFF
--- a/server/handler.js
+++ b/server/handler.js
@@ -22,7 +22,7 @@ function Handler (route) {
     return function (req, res) {
         res.set({
             'Content-Type': 'text/html',
-            'Cache-Control': 'public, max-age=31536000',
+            'Cache-Control': 'public, max-age=3600',
             'Etag': 'W/"' + checksum + '"'
         });
         res.send(output);

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ app.use(log());
 app.use(compression());
 app.use(express.static(path.resolve(__dirname, '../build'), {
     lastModified: true,
-    maxAge: '1y'
+    maxAge: '1h'
 }));
 app.use(function (req, res, next) {
     req._path = url.parse(req.url).path;


### PR DESCRIPTION
I assumed we would want html and static assets to match.

Background: During the 2.2.3 deploy, there was a temporary issue that seemed to be caused by browsers caching the html files — to combat this issue, reduce the amount of time they are cached by the browser.  Fastly will still cache them like usual.
