### PR TITLE
Use XDR when making cross-origin api requests

### DIFF
--- a/src/mixins/api.jsx
+++ b/src/mixins/api.jsx
@@ -26,6 +26,12 @@ var Api = {
         opts.uri = opts.host + opts.uri;
 
         var apiRequest = function (opts) {
+            if (opts.host !== '') {
+                // For IE < 10, we must use XDR for cross-domain requests. XDR does not support
+                // custom headers.
+                defaults(opts, {useXDR: true});
+                opts.headers = {};
+            }
             xhr(opts, function (err, res, body) {
                 if (err) log.error(err);
                 callback(err, body);


### PR DESCRIPTION
Fixes GH-224. IE < 10 needs to use "cross domain requests" for cross-origin XHR requests.  These don't support custom headers which doesn't affect us at the moment, but might become annoying later.
