### PR TITLE
#243 – Remove Dedupe plugin from webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,6 @@ module.exports = {
                 warnings: false
             }
         }),
-        new webpack.optimize.OccurenceOrderPlugin(),
-        new webpack.optimize.DedupePlugin()
+        new webpack.optimize.OccurenceOrderPlugin()
     ]
 };


### PR DESCRIPTION
https://webpack.github.io/docs/list-of-plugins.html#dedupeplugin – it's still experimental, and breaks watch updates. This allows `make watch` to update correctly. Fixes #243.
### Test Cases
- start nodemon in one terminal window, and call `make watch` in another. Make an edit to any jsx component or view, and allow watch to reload the necessary bundles. Refresh the local page – it should load correctly.
