### PR TITLE
#240 – Don't parse `index.html` from older browsers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -43,7 +43,7 @@ if (isProduction) {
     }));
 }
 app.use(function (req, res, next) {
-    req._path = url.parse(req.url).path;
+    req._path = url.parse(req.url).path.replace('index\.html', '');
     next();
 });
 


### PR DESCRIPTION
Takes out any part of the url that contains `index.html`. I wasn't sure if this was the best way to fix #240, since most of my research found this sort of thing being done in Apache or Nginx. And this won't rewrite the url like those, but just serve the same content. @thisandagain is this the best way, in your opinion, to handle this?
