### PR TITLE
Support redirect responses from API calls

### DIFF
--- a/src/mixins/api.jsx
+++ b/src/mixins/api.jsx
@@ -34,6 +34,8 @@ var Api = {
             }
             xhr(opts, function (err, res, body) {
                 if (err) log.error(err);
+                // Legacy API responses come as lists, and indicate to redirect the client like
+                // [{success: true, redirect: "/location/to/redirect"}]
                 if (body && body[0] && 'redirect' in body[0]) window.location = body[0].redirect;
                 callback(err, body);
             });


### PR DESCRIPTION
Several scratchr2 views do a thing and then redirect (project, studio creation, the student password reset middleware). This allows the client to redirect to that response.

Fixes GH-238. Requires LLK/scratchr2@bf451a95ea5f1af224c50953074cdb24d1e1492e
