### PR TITLE
Fix gh-263: Remove `width=device-width` until mobile nav/footer completed

### DIFF
--- a/server/template.html
+++ b/server/template.html
@@ -7,7 +7,7 @@
 
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta http-equiv="x-frame-options" content="deny">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="initial-scale=1">
 
         <title>Scratch - {{title}}</title>
 


### PR DESCRIPTION
Mobile compatible meta tag is breaking our homepage view since we don't have mobile formatting for our homepage, nav, or footer. This should be removed so that mobile defaults to a zoomed out view until we get our nav and footer to work correctly.

Fixes #263.
