### PR TITLE
Remove fr-ca from language list

### DIFF
--- a/en.json
+++ b/en.json
@@ -67,7 +67,7 @@
     "hoc.title": "Get Creative with Coding",
     "intro.aboutScratch": "ABOUT SCRATCH",
     "intro.forEducators": "FOR EDUCATORS",
-    "infro.forParents": "FOR PARENTS",
+    "intro.forParents": "FOR PARENTS",
     "intro.joinScratch": "JOIN SCRATCH",
     "intro.seeExamples": "SEE EXAMPLES",
     "intro.tagLine": "Create stories, games, and animations<br /> Share with others around the world",

--- a/languages.json
+++ b/languages.json
@@ -16,7 +16,6 @@
     "es": "Español",
     "eu": "Euskara",
     "fr": "Français",
-    "fr-ca": "Français (Canada)",
     "ga": "Gaeilge",
     "gd": "Gàidhlig",
     "gl": "Galego",


### PR DESCRIPTION
See https://github.com/LLK/scratchr2/pull/3108. Also fix typo with `forParents` intro string.
### Test Cases
- `fr-ca` should not be a selectable language option anymore
