### PR TITLE
Fix gh-265: Default to msgid string if no localization found

### DIFF
--- a/lib/bin/build-locales
+++ b/lib/bin/build-locales
@@ -57,16 +57,17 @@ glob(poUiDir + '/*', function (err, files) {
         var pyFile = path.resolve(file, 'LC_MESSAGES/django.po');
 
         var translations = {};
+
         try {
             var jsTranslations = po2icu.poFileToICUSync(lang, jsFile);
-            translations = localeCompare.mergeNewTranslations(translations, jsTranslations, md5WithIds);
+            translations = localeCompare.mergeNewTranslations(translations, jsTranslations, idsWithICU, md5WithIds);
         } catch (err) {
             process.stdout.write(lang + ': ' + err + '\n');
         }
 
         try {
             var pyTranslations = po2icu.poFileToICUSync(lang, pyFile);
-            translations = localeCompare.mergeNewTranslations(translations, pyTranslations, md5WithIds);
+            translations = localeCompare.mergeNewTranslations(translations, pyTranslations, idsWithICU, md5WithIds);
         } catch (err) {
             process.stdout.write(lang + ': ' + err + '\n');
         }

--- a/lib/locale-compare.js
+++ b/lib/locale-compare.js
@@ -26,12 +26,17 @@ Helpers.getMD5 = function (string) {
     ICU Map is an object in the reverse react-intl formatting (icu string as key), which will
     help determine if the translation belongs in www currently.
 */
-Helpers.mergeNewTranslations = function (existingTranslations, newTranslations, md5Map) {
+Helpers.mergeNewTranslations = function (existingTranslations, newTranslations, icuTemplate, md5Map) {
     for (var id in newTranslations) {
         var md5 = Helpers.getMD5(id);
         if (md5Map.hasOwnProperty(md5) && newTranslations[id].length > 0) {
             existingTranslations[md5Map[md5]] = newTranslations[id];
         }
+    }
+
+    //Fill in defaults
+    for (var id in icuTemplate) {
+        if (!existingTranslations.hasOwnProperty(id)) existingTranslations[id] = icuTemplate[id];
     }
     return existingTranslations;
 };

--- a/test/functional/build_locales_complex_strings.js
+++ b/test/functional/build_locales_complex_strings.js
@@ -8,7 +8,7 @@ var buildLocales = require('../../lib/locale-compare');
 tap.test('buildLocalesFile', function (t) {
     var md5map = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/test_es_md5map.json'), 'utf8'));
     var newTranslations = po2icu.poFileToICUSync('es', path.resolve(__dirname, '../fixtures/test_es.po'));
-    var translations = buildLocales.mergeNewTranslations({}, newTranslations, md5map);
+    var translations = buildLocales.mergeNewTranslations({}, newTranslations, {}, md5map);
 
     t.ok(translations['test.id1'] !== undefined);
     t.ok(translations['test.id2'] !== undefined);

--- a/test/functional/build_locales_mergeTranslations.js
+++ b/test/functional/build_locales_mergeTranslations.js
@@ -16,7 +16,7 @@ tap.test('buildLocalesMergeTranslations', function (t) {
         '6885a345adafb3a9dd43d9f549430c88': 'test.test3'
     };
 
-    var mergedTranslations = buildLocales.mergeNewTranslations(existingTranslations, newTranslations, md5map);
+    var mergedTranslations = buildLocales.mergeNewTranslations(existingTranslations, newTranslations, {}, md5map);
     t.ok(mergedTranslations['test.test3'] !== undefined);
     t.ok(mergedTranslations['test.test2'] !== undefined);
     t.end();


### PR DESCRIPTION
This fills in all language objects in `translations.json` to use the default english string for the language if no localization is found. This will allow us to use `FormattedMessage` components without having to include the default string inline, allowing us to only refer to it by component's id.

There is probably a better way to do this, but I'm going to hold off on majorly refactoring this script until the localization sprint in which I split up files by component since there will need to be significant changes then anyways.
