### PR TITLE
Fix gh-263: Set width in viewport tag to desktop width

### DIFF
--- a/server/template.html
+++ b/server/template.html
@@ -7,7 +7,7 @@
 
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta http-equiv="x-frame-options" content="deny">
-        <meta name="viewport" content="initial-scale=1">
+        <meta name="viewport" content="width=942, initial-scale=1">
 
         <title>Scratch - {{title}}</title>
 


### PR DESCRIPTION
Desktop width retrieved from `_frameless`. Fixes #263 again.
