### PR TITLE
default to pt-br if browser is set to pt

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -64,6 +64,9 @@ var translations = require('../locales/translations.json');
         var obj = jar.get('scratchlanguage');
         if (typeof obj === 'undefined') {
             obj = window.navigator.userLanguage || window.navigator.language;
+            if (['pt','pt-pt','PT','PT-PT'].indexOf(obj) !== -1) {
+                obj = 'pt-br'; // default Portuguese users to Brazilian Portuguese due to our user base. Added in 2.2.5.
+            }
         }
         if (typeof translations[obj] === 'undefined') {
             // Fall back on the split


### PR DESCRIPTION
If the user has not yet set their own language, but has pt in their browser, use pt-br for now, to accommodate for our large Brasilian base. Fixes #273.

Lingering question is if we want to include this in scratchr2 as well, or if having it in www only is acceptable, since it contains the homepage.
