### PR TITLE
Fix GH-251: log error for session request if there

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -37,10 +37,14 @@ var translations = require('../locales/translations.json');
             host: '',
             uri: '/session/'
         }, function (err, body) {
-            if (body.banned) {
-                return window.location = body.redirectUrl;
-            } else {
-                window.updateSession(body);
+            if (err) return;
+
+            if (typeof body !== 'undefined') {
+                if (body.banned) {
+                    return window.location = body.redirectUrl;
+                } else {
+                    window.updateSession(body);
+                }
             }
         });
     };


### PR DESCRIPTION
And only try to update the session if a body is present. Fixes #251 
### Test Cases
- The error should no longer go to sentry
- Users should still get sessions
