### PR TITLE
Fix GH-289: Allow white space to wrap in welcome text

### DIFF
--- a/src/components/news/news.scss
+++ b/src/components/news/news.scss
@@ -19,7 +19,6 @@
         a {
             display: block;
             text-decoration: none;
-            white-space: normal;
 
             &:hover {
                 text-decoration: none;

--- a/src/components/welcome/welcome.scss
+++ b/src/components/welcome/welcome.scss
@@ -14,10 +14,6 @@
             margin-top: 12px;
             padding: 0;
             font-weight: 200;
-
-            a {
-                white-space: normal;
-            }
         }
 
         > a {

--- a/src/main.scss
+++ b/src/main.scss
@@ -40,8 +40,10 @@ p.legal {
 }
 
 /* Links */
-a {
-    white-space: nowrap;
+p {
+    a {
+        white-space: nowrap;
+    }
 }
 
 a:link,

--- a/src/views/hoc/hoc.scss
+++ b/src/views/hoc/hoc.scss
@@ -77,10 +77,6 @@ $base-bg: $ui-white;
             min-width: 200px;
             max-width: 230px;
 
-            a {
-                white-space: normal;
-            }
-
             .card-info {
                 border-radius: 5px;
                 background-color: $base-bg;
@@ -203,10 +199,6 @@ $base-bg: $ui-white;
     .studio {
         width: 50%;
 
-        a {
-            white-space: normal;
-        }
-
         h5 {
             width: 200px;
         }
@@ -238,10 +230,6 @@ $base-bg: $ui-white;
     .logos {
         margin: 20px 0;
         width: 100%;
-
-        a {
-            white-space: normal;
-        }
 
         img {
             margin: 20px;


### PR DESCRIPTION
It's in an href, so override the default and include wrapping. Fixes #289.
### Test Cases
- Welcome text should still be links
- Welcome text should not overlap
