### PR TITLE
Fix error in parsing count from updated API route

### DIFF
--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -100,7 +100,7 @@ var Navigation = React.createClass({
         }, function (err, body) {
             if (err) return this.setState({'unreadMessageCount': 0});
             if (body) {
-                var count = parseInt(body.msg_count, this.state.unreadMessageCount);
+                var count = parseInt(body.count, 10);
                 return this.setState({'unreadMessageCount': count});
             }
         }.bind(this));


### PR DESCRIPTION
Re: GH-316
- Fixes issue where count will not display
- Fixes long-standing issue with `parseInt` which was likely part of the root cause for #95 
