### PR TITLE
Deploy hotfix and release branches to staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,10 @@ deploy:
   env: scratch-www-staging
   on:
     repo: LLK/scratch-www
-    branch: develop
+    branch:
+    - develop
+    - hotfix/*
+    - release/*
 - provider: elasticbeanstalk
   access_key_id: $EB_AWS_ACCESS_KEY_ID
   secret_access_key: $EB_AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Tested this with a hotfix branch — it deployed hotfix/travis-staging to staging after it built.  This should allow us to make temporary hotfix and release branches and see them on staging.scratch.mit.edu, which will be helpful during freezes.

/cc @thisandagain
