### PR TITLE
Revise focus of CONTRIBUTING, README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,12 @@
-### Where am I? ###
-Physically? No idea.
+## I wanna contribute!
+Sweet! The transition from existing to new codebase is an ongoing process, and we love to have people in the Scratch and Open Source communities help us along the way, and even afterwards as we develop new features for Scratch here.
 
-Digitally? You’re at Scratch’s open source Web Client! 
+Here are some ways you can contribute:
+* [Report bugs](https://github.com/LLK/scratch-www/wiki/Reporting-Bugs)
+* [Work on bugs and make pull requests](https://github.com/LLK/scratch-www/wiki/Workflow-for-Repo-Contributions)
+  * Make sure to check out how to [assign yourself bugs](https://github.com/LLK/scratch-www/wiki/Assigning-Yourself-Bugs) too.
 
-At Scratch, we’re working to update our UI to use a new codebase, which will be contained in this repository. The transition from existing to new codebase is an ongoing process, and we love to have people in the Scratch and Open Source communities help us along the way, and even afterwards as we develop new features for Scratch here.
-
-
-### Who and what will I find here? ###
-We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here, and looking to jump into our wonderful community, we have some wonderful resources for you to take a look at:
+We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here, and looking to jump into our wonderful community, we have some resources for you to take a look at:
 
 * [README](https://github.com/LLK/scratch-www/blob/develop/README.md) (if you’re to read only one me in this repo, make it this one – it has all of the necessary information for getting a local Scratch UI running on your machine!)
 * [Community Guidelines](https://github.com/LLK/scratch-www/wiki/Community-Guidelines) (we find it important to maintain a constructive and welcoming community, just like on Scratch)
@@ -21,15 +20,3 @@ Beyond this repo, there are also some other resources that you might want to tak
 [Advanced Topics forum](https://scratch.mit.edu/discuss/31/) on Scratch (like Topics, but more complex-y)
 
 
-### I wanna contribute! ###
-Sweet! Here are some ways you can contribute:
-* [Report bugs](https://github.com/LLK/scratch-www/wiki/Reporting-Bugs)
-* [Work on bugs](https://github.com/LLK/scratch-www/wiki/Workflow-for-Repo-Contributions)
-  * Make sure to check out how to [assign yourself bugs](https://github.com/LLK/scratch-www/wiki/Assigning-Yourself-Bugs) too.
-
-
-We’re currently building Scratch using [React](https://facebook.github.io/react/) and [SCSS](http://sass-lang.com/documentation/file.SASS_REFERENCE.html). Here are some resources to help you get acquainted with how we’re working on the Scratch codebase:
-* [Style Guide](https://github.com/LLK/scratch-www/wiki/Style-Guide)
-* [Testing Guide](https://github.com/LLK/scratch-www/wiki/Testing-Guide)
-* [Localization Guide](https://github.com/LLK/scratch-www/wiki/Localization-Guide)
-* [Map of the repository](https://github.com/LLK/scratch-www/wiki/Repo-Map)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@
 
 [![Build Status](https://magnum.travis-ci.com/LLK/scratch-www.svg?token=xzzHj4ct3SyBTpeqxnx1)](https://magnum.travis-ci.com/LLK/scratch-www)
 
+### Where am I?
+Physically? No idea.
+
+Digitally? You’re at Scratch’s open source web client! 
+
+We’re working to update the [Scratch website](https://scratch.mit.edu) to use a new codebase, contained in this repository.
+
+We’re currently building Scratch using [React](https://facebook.github.io/react/) and [SCSS](http://sass-lang.com/documentation/file.SASS_REFERENCE.html). Here are some resources to help you get acquainted with how we’re working on the Scratch codebase:
+
+* [Style Guide](https://github.com/LLK/scratch-www/wiki/Style-Guide)
+* [Testing Guide](https://github.com/LLK/scratch-www/wiki/Testing-Guide)
+* [Localization Guide](https://github.com/LLK/scratch-www/wiki/Localization-Guide)
+* [Map of the repository](https://github.com/LLK/scratch-www/wiki/Repo-Map)
+
+
 ### Before Getting Started
 * make sure you have node and npm [installed](https://docs.npmjs.com/getting-started/installing-node)
 


### PR DESCRIPTION
Introduce the repo in README, and point people to guidelines more quickly in CONTRIBUTING, since that is linked to from the pages for new issues and new pull requests
