### PR TITLE
Fix gh-333: Add/Remove Moderators on Credits Page

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -158,11 +158,6 @@ var Credits = React.createClass({
                     </li>
 
                     <li>
-                        <img src="//cdn.scratch.mit.edu/get_image/user/586054_170x170.png" alt="Megan Avatar" />
-                        <span className="name">Megan Haddadi</span>
-                    </li>
-
-                    <li>
                         <img src="//cdn.scratch.mit.edu/get_image/user/4836354_170x170.png" alt="Christina Avatar" />
                         <span className="name">Christina Huang</span>
                     </li>
@@ -170,6 +165,16 @@ var Credits = React.createClass({
                     <li>
                         <img src="//cdn.scratch.mit.edu/get_image/user/4747093_170x170.png" alt="Annie Avatar" />
                         <span className="name">Annie Whitehouse</span>
+                    </li>
+
+                    <li>
+                        <img src="//cdn.scratch.mit.edu/get_image/user/1048810_170x170.png" alt="Linda Avatar" />
+                        <span className="name">Linda Fernsel</span>
+                    </li>
+
+                    <li>
+                        <img src="//cdn.scratch.mit.edu/get_image/user/14110644_170x170.png" alt="Lily Avatar" />
+                        <span className="name">Lily Kim</span>
                     </li>
                 </ul>
 
@@ -180,7 +185,7 @@ var Credits = React.createClass({
                     Andrés Monroy-Hernández (who led the development of the first Scratch community website),
                     Amos Blanton, Champika Fernando, Shane Clements, Abdulrahman idlbi, Evelyn Eastmond,
                     Amon Millner, Eric Rosenbaum, Jay Silver, Karen Brennan, Leo Burd, Oren Zuckerman, Gaia Carini,
-                    Michelle Chung, Margarita Dekoli, Dave Feinberg, Chris Graves, Tony Hwang, Di Liu, Tammy Stern,
+                    Michelle Chung, Margarita Dekoli, Dave Feinberg, Megan Haddadi, Chris Graves, Tony Hwang, Di Liu, Tammy Stern,
                     Lis Sylvan, and Claudia Urrea.
                 </p>
 


### PR DESCRIPTION
I removed Megan Haddadi from the Community Moderators section, and added her name to the Previous Scratch Team Members section, and added Linda Fernsel and Lily Kim (along with Scratch avatars) in the Community Moderators section (as per issue #333 ).

Tested on Chrome 50.0.2636.0 (canary) and Safari 9.0.3 on OS X 10.11.3 and found no issues regarding functionality.


I wasn't sure if there was a specific order for the people on the credits page, so I added Linda and Lily at the end of the Moderators section and put Megan Haddadi somewhere in the middle of the previous members section.