### PR TITLE
Fix gh-354: 'Supported Organizations' in credits overflows

### DIFF
--- a/src/views/credits/credits.scss
+++ b/src/views/credits/credits.scss
@@ -3,10 +3,9 @@
 #view {
     p {
         line-height: 1.5rem;
-    }
-
-    a {
-       word-wrap: break-word; /* Overrides: https://github.com/LLK/scratch-www/blob/develop/src/main.scss#L43-L47 */
+        a {
+            word-wrap: break-word; /* Overrides: https://github.com/LLK/scratch-www/blob/develop/src/main.scss#L43-L47 */
+        }
     }
     
     ul {

--- a/src/views/credits/credits.scss
+++ b/src/views/credits/credits.scss
@@ -3,6 +3,7 @@
 #view {
     p {
         line-height: 1.5rem;
+        word-wrap: break-word;
     }
 
     ul {

--- a/src/views/credits/credits.scss
+++ b/src/views/credits/credits.scss
@@ -3,9 +3,12 @@
 #view {
     p {
         line-height: 1.5rem;
-        word-wrap: break-word;
     }
 
+    a {
+       word-wrap: break-word; /* Overrides: https://github.com/LLK/scratch-www/blob/develop/src/main.scss#L43-L47 */
+    }
+    
     ul {
         display: flex;
         margin: 0;


### PR DESCRIPTION
Should fix #354.
Can someone test this on Firefox? (I only have Chrome)