### PR TITLE
Fix gh-300: Horizontal Scroll Bar Shows on Front Page

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -10,7 +10,6 @@ body {
     padding: 0;
     color: $type-gray;
     font-family: "Helvetica Neue", "Helvetica", Arial, sans-serif;
-    overflow-x: hidden;
 }
 
 /* Typography */
@@ -81,7 +80,7 @@ a:hover {
     /* NOTE: Margin should match height in navigation.scss */
     margin-top: 50px;
     background-color: $background-color;
-    padding: 20px 1px;
+    padding: 20px 0px;
     min-width: 100%;
     min-height: 768px;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -80,7 +80,7 @@ a:hover {
     /* NOTE: Margin should match height in navigation.scss */
     margin-top: 50px;
     background-color: $background-color;
-    padding: 20px 0px;
+    padding: 20px 0;
     min-width: 100%;
     min-height: 768px;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -10,6 +10,7 @@ body {
     padding: 0;
     color: $type-gray;
     font-family: "Helvetica Neue", "Helvetica", Arial, sans-serif;
+    overflow-x: hidden;
 }
 
 /* Typography */


### PR DESCRIPTION
Fixes issue #300.

To fix the horizontal scrollbar showing on the homepage (and other pages), I've set the horizontal padding on the view element to 0 in main.scss.



**Test Cases**
To test the fix, I checked that when scrolling vertically and attempting to scroll horizontally, no horizontal scrollbar appeared on the front page and credits page. My tests succeeded on Chrome 50, Firefox 44, and Safari 9.0.3 on OS X 10.11.3. 


~~**Possible problems**
I applied the fix to the main.scss file, which might cause problems if a horizontal scrollbar is desired on other pages that inherit from that file. I can't think of any page that would need a horizontal scrollbar, though.~~