### PR TITLE
Fix GH-358: Add new travis badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## scratch-www
 #### Standalone web client for Scratch
 
-[![Build Status](https://magnum.travis-ci.com/LLK/scratch-www.svg?token=xzzHj4ct3SyBTpeqxnx1)](https://magnum.travis-ci.com/LLK/scratch-www)
+[![Build Status](https://travis-ci.org/LLK/scratch-www.svg)](https://travis-ci.org/LLK/scratch-www)
 
 ### Where am I?
 Physically? No idea.


### PR DESCRIPTION
Fixes #358 by changing the svg url.

### Test Cases ###
* visit https://github.com/mewtaylor/scratch-www/tree/issue/gh-358-travis-badge to see the badge working correctly, compared with  https://github.com/LLK/scratch-www