### PR TITLE
Retrieve session data from session cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash.range": "3.0.1",
     "minilog": "2.0.8",
     "node-sass": "3.3.3",
+    "pako": "0.2.8",
     "po2icu": "git://github.com/LLK/po2icu.git#develop",
     "react": "0.14.0",
     "react-addons-test-utils": "0.14.0",

--- a/src/init.js
+++ b/src/init.js
@@ -1,5 +1,6 @@
-var api = require('./mixins/api.jsx').api;
 var jar = require('./lib/jar');
+var log = require('./lib/log');
+var translations = require('../locales/translations.json');
 
 /**
  * -----------------------------------------------------------------------------
@@ -31,19 +32,18 @@ var jar = require('./lib/jar');
      * @return {void}
      */
     window.refreshSession = function () {
-        api({
-            host: '',
-            uri: '/session/'
-        }, function (err, body) {
-            if (err) return;
-
-            if (typeof body !== 'undefined') {
-                if (body.banned) {
-                    return window.location = body.redirectUrl;
-                } else {
-                    window.updateSession(body);
+        jar.get('scratchsessionsid', function (err, value) {
+            if (err) return log.error('Error while fetching session cookie:', err);
+            jar.unsign(value, function (err, contents) {
+                if (err) return log.error('Error while unsigning session cookie:', err);
+                try {
+                    var sessionData = JSON.parse(contents);
+                } catch (e) {
+                    log.error('Could not deserialize session:', e);
+                    sessionData = {};
                 }
-            }
+                window.updateSession(sessionData);
+            });
         });
     };
 

--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -9,41 +9,39 @@ var xhr = require('xhr');
  * set(name, value) – synchronously sets the cookie
  * use(name, uri, callback) – can by sync or async, gets cookie from the uri if not there.
  */
-var Jar = {};
-
-Jar.get = function (name, callback) {
+var Jar = {
+    get: function (name, callback) {
     // Get cookie by name
     var obj = cookie.parse(document.cookie) || {};
 
-    // Handle optional callback
-    if (typeof callback === 'function') {
-        if (typeof obj === 'undefined') return callback('Cookie not found.');
-        return callback(null, obj[name]);
-    }
+        // Handle optional callback
+        if (typeof callback === 'function') {
+            if (typeof obj === 'undefined') return callback('Cookie not found.');
+            return callback(null, obj[name]);
+        }
 
-    return obj[name];
-};
+        return obj[name];
+    },
+    use: function (name, uri, callback) {
+        // Attempt to get cookie
+        Jar.get(name, function (err, obj) {
+            if (typeof obj !== 'undefined') return callback(null, obj);
 
-Jar.use = function (name, uri, callback) {
-    // Attempt to get cookie
-    Jar.get(name, function (err, obj) {
-        if (typeof obj !== 'undefined') return callback(null, obj);
-
-        // Make XHR request to cookie setter uri
-        xhr({
-            uri: uri
-        }, function (err) {
-            if (err) return callback(err);
-            Jar.get(name, callback);
+            // Make XHR request to cookie setter uri
+            xhr({
+                uri: uri
+            }, function (err) {
+                if (err) return callback(err);
+                Jar.get(name, callback);
+            });
         });
-    });
-};
-
-Jar.set = function (name, value) {
-    var obj = cookie.serialize(name, value);
-    var expires = '; expires=' + new Date(new Date().setYear(new Date().getFullYear() + 1)).toUTCString();
-    var path = '; path=/';
-    document.cookie = obj + expires + path;
+    },
+    set: function (name, value) {
+        var obj = cookie.serialize(name, value);
+        var expires = '; expires=' + new Date(new Date().setYear(new Date().getFullYear() + 1)).toUTCString();
+        var path = '; path=/';
+        document.cookie = obj + expires + path;
+    }
 };
 
 module.exports = Jar;

--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -1,5 +1,6 @@
 var cookie = require('cookie');
 var xhr = require('xhr');
+var pako = require('pako');
 
 /**
  * Module that handles coookie interactions.
@@ -10,6 +11,33 @@ var xhr = require('xhr');
  * use(name, uri, callback) – can by sync or async, gets cookie from the uri if not there.
  */
 var Jar = {
+    unsign: function (value, callback) {
+        // Return the usable content portion of a signed, compressed cookie
+        if (!value) return callback('No value to unsign');
+        try {
+            var b64Data = value.split(':')[0];
+            var decompress = false;
+            if (b64Data[0] === '.') {
+                decompress = true;
+                b64Data = b64Data.substring(1);
+            }
+
+            // Django makes its base64 strings url safe by replacing + and / with - and _ respectively
+            b64Data = b64Data.replace(/[-_]/g, function (c) {return {'-':'+', '_':'/'}[c]; });
+            var strData = atob(b64Data);
+
+            if (decompress) {
+                var charData = strData.split('').map(function (c) { return c.charCodeAt(0); });
+                var binData = new Uint8Array(charData);
+                var data = pako.inflate(binData);
+                strData = String.fromCharCode.apply(null, new Uint16Array(data));
+            }
+
+            return callback(null, strData);
+        } catch (e) {
+            return callback(e);
+        }
+    },
     get: function (name, callback) {
     // Get cookie by name
     var obj = cookie.parse(document.cookie) || {};

--- a/static/js/lib/polyfill.min.js
+++ b/static/js/lib/polyfill.min.js
@@ -27,6 +27,12 @@
 (function(){try{new e("test")}catch(t){var e=function(t,e){var n;return e=e||{bubbles:!1,cancelable:!1,detail:void 0},n=document.createEvent("CustomEvent"),n.initCustomEvent(t,e.bubbles,e.cancelable,e.detail),n};e.prototype=window.Event.prototype,window.CustomEvent=e}})();
 
 /*!
+ * https://github.com/davidchambers/Base64.js
+ * see https://github.com/davidchambers/Base64.js/blob/master/LICENSE
+ */
+!function(){function t(t){this.message=t}var r="undefined"!=typeof exports?exports:this,e="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";t.prototype=new Error,t.prototype.name="InvalidCharacterError",r.btoa||(r.btoa=function(r){for(var o,n,a=String(r),i=0,c=e,d="";a.charAt(0|i)||(c="=",i%1);d+=c.charAt(63&o>>8-i%1*8)){if(n=a.charCodeAt(i+=.75),n>255)throw new t("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");o=o<<8|n}return d}),r.atob||(r.atob=function(r){var o=String(r).replace(/=+$/,"");if(o.length%4==1)throw new t("'atob' failed: The string to be decoded is not correctly encoded.");for(var n,a,i=0,c=0,d="";a=o.charAt(c++);~a&&(n=i%4?64*n+a:a,i++%4)?d+=String.fromCharCode(255&n>>(-2*i&6)):0)a=e.indexOf(a);return d})}();
+
+/*!
  * https://github.com/andyearnshaw/Intl.js
  * @license  The MIT License (MIT) Copyright (c) 2013 Andy Earnshaw
  * see https://github.com/andyearnshaw/Intl.js/blob/master/LICENSE.txt


### PR DESCRIPTION
(Previously #282)

Assumes the session cookie is stored as JSON, which may or may not have been compressed via zlib (indicated by a leading `.`), which is then base64-encoded, and made URL-safe by replacing all `+` and `/` characters with `-` and `_` respectively.  The cookie may or may not be signed as well. The `Jar.unsign` method should work with URL-unsafe, uncompressed, unsigned values.

I had a lot of trouble using `browserify-zlib`, it never seemed to like the format I gave it. When I tried `pako` it just worked the first time, so I liked that feature.

This requires an update to scratchr2 to send the session cookie down in this format as non-HTTP-only. It also requires that we put what www expects into the session.

Halfway through doing this I had the thought that someone must have made a module for using Django session cookies in JS, but I couldn't find anything. It might be nice to split that out into its own package and use it that way — sessions aren't the only signed cookies you can use with Django, so it might be useful for others.