### PR TITLE
[Master] Fix GH-374: Add tips to create link for logged out user

### DIFF
--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -191,13 +191,14 @@ var Navigation = React.createClass({
             'show': this.state.unreadMessageCount > 0
         });
         var formatMessage = this.props.intl.formatMessage;
+        var createLink = this.state.session.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
         return (
             <div className={classes}>
                 <ul>
                     <li className="logo"><a href="/" aria-label="Scratch"></a></li>
 
                     <li className="link create">
-                        <a href="/projects/editor">
+                        <a href={createLink}>
                             <FormattedMessage
                                 id="general.create"
                                 defaultMessage={'Create'} />


### PR DESCRIPTION
Fixes #374 by adding the tips url kwarg to the "Create" url if the user has no session state.

### Test Cases ###
* Log out. Click create – it should lead you to the editor, and tips should open automatically for you
* Log in. Click create – it should lead you to the editor, and tips should not open automatically.