### PR TITLE
Fix gh-356: Facetime Phone Numbers

### DIFF
--- a/server/template.html
+++ b/server/template.html
@@ -10,7 +10,10 @@
         <meta name="viewport" content="width=942, initial-scale=1">
 
         <title>Scratch - {{title}}</title>
-
+        
+        <!-- Prevent mobile Safari from making phone numbers -->
+        <meta name="format-detection" content="telephone=no">
+        
         <!-- Search & Open Graph-->
         <meta name="description" content="{{description}}" />
         <meta name="google-site-verification" content="m_3TAXDreGTFyoYnEmU9mcKB4Xtw5mw6yRkuJtXRKxM" />


### PR DESCRIPTION
Fixes mobile side of #356.

[Documentation of meta tag here](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW5)

As per https://github.com/LLK/scratch-www/pull/373#issuecomment-193934786
@mewtaylor 
Tested locally on Chrome.