### PR TITLE
[Master] Fix GH-381: add languages to custom config

### DIFF
--- a/custom-locales.json
+++ b/custom-locales.json
@@ -3,9 +3,17 @@
         "locale": "an",
         "parentLocale": "ca"
     },
+    "cat": {
+        "locale": "cat",
+        "parentLocale": "en"
+    },
     "ht": {
         "locale": "ht",
         "parentLocale": "fr"
+    },
+    "ja-hr": {
+        "locale": "ja-hr",
+        "parentLocale": "ja"
     },
     "la": {
         "locale": "la",
@@ -15,8 +23,12 @@
         "locale": "yum",
         "parentLocale": "en"
     },
-    "cat": {
-        "locale": "cat",
-        "parentLocale": "en"
+    "zh-cn": {
+        "locale": "zh-cn",
+        "parentLocale": "zh"
+    },
+    "zh-tw": {
+        "locale": "zh-tw",
+        "parentLocale": "zh"
     }
 }


### PR DESCRIPTION
It seems that some languages have been removed from `intl-messageformat`'s locale-data configuration, so we need to add them manually. Fixes #381.