### PR TITLE
Fix GH-398: Add page component to jobs view

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -2,6 +2,8 @@ var React = require('react');
 var render = require('../../lib/render.jsx');
 var FormattedMessage = require('react-intl').FormattedMessage;
 
+var Page = require('../../components/page/page.jsx');
+
 require('./jobs.scss');
 
 var Jobs = React.createClass({
@@ -52,4 +54,4 @@ var Jobs = React.createClass({
     }
 });
 
-render(<Jobs />, document.getElementById('view'));
+render(<Page><Jobs /></Page>, document.getElementById('app'));


### PR DESCRIPTION
Fixes #398 by adding the new `Page` component introduced this iteration

### Test Cases ###
* Visit `/jobs` page – the page should display correctly