### PR TITLE
GH-406: Add community counselor job

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -46,6 +46,14 @@ var Jobs = React.createClass({
                                     (MIT Media Lab, Cambridge, MA)
                                 </span>
                             </li>
+                            <li>
+                                <a href="/jobs/community-counselor/">
+                                    Community Counselor
+                                </a>
+                                <span>
+                                    (MIT Media Lab, Cambridge, MA or Remote)
+                                </span>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #406. The page linked to is currently non-existent, as it is implemented for this release in scratchr2. Assuming we deploy scratchr2 first, as usual, it will exist by the time this is live.

/cc @rschamp 