### PR TITLE
Upgrade css-loader and autoprefixer-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "raven": "0.10.0"
   },
   "devDependencies": {
-    "autoprefixer-loader": "2.1.0",
+    "autoprefixer": "6.3.6",
     "classnames": "2.1.3",
     "cookie": "0.2.2",
     "copy-webpack-plugin": "0.2.0",
-    "css-loader": "0.17.0",
+    "css-loader": "0.23.1",
     "eslint": "1.3.1",
     "eslint-plugin-react": "3.3.1",
     "exenv": "1.2.0",
@@ -54,6 +54,7 @@
     "node-sass": "3.3.3",
     "pako": "0.2.8",
     "po2icu": "git://github.com/LLK/po2icu.git#develop",
+    "postcss-loader": "0.8.2",
     "react-addons-test-utils": "0.14.7",
     "react-modal": "0.6.1",
     "react-onclickoutside": "4.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+var autoprefixer = require('autoprefixer');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var path = require('path');
 var webpack = require('webpack');
@@ -40,13 +41,16 @@ module.exports = {
             },
             {
                 test: /\.scss$/,
-                loader: 'style!css!autoprefixer-loader?browsers=last 3 versions!sass'
+                loader: 'style!css!postcss-loader!sass'
             },
             {
                 test: /\.(png|jpg|gif|eot|svg|ttf|woff)$/,
                 loader: 'url-loader'
             }
         ]
+    },
+    postcss: function () {
+        return [autoprefixer({browsers: ['last 3 versions']})];
     },
     node: {
         fs: 'empty'


### PR DESCRIPTION
These depended on postcss<5, which caused webpack to output the errors like

```shell
Container#eachAtRule is deprecated. Use Container#walkAtRules instead.
Container#eachRule is deprecated. Use Container#walkRules instead.
Container#eachDecl is deprecated. Use Container#walkDecls instead.
Node#style() is deprecated. Use Node#raw()
Node#_value was deprecated. Use Node#raws.value
Container#remove is deprecated. Use Container#removeChild
```

The autoprefixer-loader package is deprecated now and recommends using postcss-loader + autoprefixer itself.