### PR TITLE
Fix gh-427: Footer Wiki Link not working

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -83,7 +83,7 @@ var Footer = React.createClass({
                             </a>
                         </dd>
                         <dd>
-                            <a href="https://wiki.scratch.mit.edu/">
+                            <a href="http://wiki.scratch.mit.edu/">
                                 <FormattedMessage
                                     id='general.wiki'
                                     defaultMessage={'Scratch Wiki'} />


### PR DESCRIPTION
Redo of #428 to fix the conflicts, as per https://github.com/LLK/scratch-www/pull/428#issuecomment-213577987


Fixes #427

Tested locally on Chrome.

Summary of change: 
https://wiki.scratch.mit.edu/ -> http://wiki.scratch.mit.edu/