### PR TITLE
Fix gh-457: Log In Margin

### DIFF
--- a/src/components/login/login.scss
+++ b/src/components/login/login.scss
@@ -7,7 +7,11 @@
         padding-top: 5px;
         font-weight: bold;
     }
-
+    
+    .right {
+        float: right;
+    }
+    
     .spinner {
         margin: 0 .8rem;
         width: 1rem;
@@ -16,7 +20,6 @@
 
     .submit-button {
         margin-top: 5px;
-        margin-right: 4.4px;
     }
 
     a {

--- a/src/components/login/login.scss
+++ b/src/components/login/login.scss
@@ -16,6 +16,7 @@
 
     .submit-button {
         margin-top: 5px;
+        margin-right: 4.4px;
     }
 
     a {


### PR DESCRIPTION
Fix cosmetic issue reported in #457 

Tested locally on Chrome.

4.4px is the max margin to the right of the button without the "Forgot password?" text wrapping to the next line.