### PR TITLE
Improve performance of Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
   - secure: EX1fyov+f6ytWN2ZSL4dLslwrVkp6Ho/uoSLO38/qNG3XdGmBN4VprxddcQiWfo+Mrg3GdWcfcM/VazhhStBi1uLfZiw3RHZaSGuWbiuD2EtzqtlC+OVvoajgy91QFajh9Zzuwa0rYbEPd/sw01R53NoWJYl0GSteWk7C8Wv6anl4FUJCqgvvTV2ZEcyTtGcVJgUhKi1MfNpTSM6JWBy0DWszcyxj7C8LSs1+l9ZjAtnlUBWY13HsrNu8G5d+FwqGHZLUAjdu2O602wxV897/xLARLduZ+01ALpVefNEEGMB1Wd+xMw4dm2B0Uk86a4TBRCeOgJZ1yoJoPpGPOHTo+dgNXcU8ReszGVoy7uOjFWwu82FQq8gzfcf75yzaRJgG8/BJ6BkJfa0EmFg3iO5CwixQyHR5+CqsedtoLAWVT8zlOfQ/Z6yx4Pm7jXQSOkyvo09YJ2QIn4IFGPvwOVS7Firzi+fLl8GYApeSV9G10e1IzA4pPrKdJMRA4qRMPt9zJGq7ZO1J/d9aW/5KIsJUDnodnl7yXJyDMOyNeljT9I82ciHZcURxRRY080vrW6dgNJE1V9jxBhWEvr2iCeWMMedWaGuC41I7K9L79eW8lmaE+cQ+OZrzpOJP4GbfmIiXrh+0M4ChL/xBpjtiFwpNdkCXXhzWMnjJ4wCrii4yuc=
   - AWS_ACCESS_KEY_ID=$EB_AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY=$EB_AWS_SECRET_ACCESS_KEY
-  - CXX=g++-4.8
   - FASTLY_ACTIVATE_CHANGES=true
   # FASTLY_API_KEY
   - secure: XNWcCnqSAd4MpKg6FVe3WeFmdqfdH753+PBCOEkJrHS+AHmLMuWsjIQFJ3LUR9ylEQRVPR2OyXJW/R8NI9toStREgwE4fwIVo0l4fwYqLStxYpEKlcWfkJ3uNpRZhvcVmUBycelrnjJqXVdrtlxPCKX0tNkpcKH2b98We7A2/r7HxKv13upDxWTQ/qRUv0+SJCRTB4n/QInABi87Ef8Q2rNGrL0WQzQvVBeiEXOP0JSkyYK4+q65gswMKPehgiFagnYVgJN9J9Q1VrBDc06gidbznBcEpPaBAYvsTTY9dWTJxaaKNSrmOIe/OiuJUEHjb+8NL+j6Lp7wX8lzEjbr0FkVlFnxS9VbftS2KFkN7+c3RF57+tsq0xwJ6vgomIVS5FupHgl/oCJicnH/FLfynditOLZhmhF+Ed5GCAoIEamRRzcVHdjvglsEtYsDX1/z2t+HKYtPQuXYOywDRVTSPf88eEbu8ehfgNcYaIAuD6eedyDnKTOIv7owWs3Y7GsxQ2jBLGXq1YoUEkPtB0vfaHi72CeEhDQ53mEn2Ure47UMGMgUjKtiIhDBNTbECwP/ZDJv1accGRljKjDy93aCJeRi1T7Op7tDbHSl4ScieeOwOeKJMcD1U5JGdA/sRnjjgSKb24P2ys4NYr95dgqWNNGPGMxca+lGufzdEaTQT44=
@@ -50,12 +49,6 @@ env:
   - SKIP_CLEANUP=true
   - NODE_ENV=production
   - WWW_VERSION=${TRAVIS_COMMIT:0:5}
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
 install:
   - sudo -H pip install -r requirements.txt
   - npm --production=false install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 sudo: required
 cache:
   directories:
+  - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
   - node_modules
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ addons:
     - g++-4.8
 install:
   - sudo -H pip install -r requirements.txt
-  - npm install
+  - npm --production=false install
 deploy:
 - provider: script
   skip_cleanup: $SKIP_CLEANUP

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "minilog": "2.0.8",
     "node-sass": "3.3.3",
     "pako": "0.2.8",
-    "po2icu": "git://github.com/LLK/po2icu.git#develop",
+    "po2icu": "0.0.2",
     "postcss-loader": "0.8.2",
     "react-addons-test-utils": "0.14.7",
     "react-modal": "0.6.1",


### PR DESCRIPTION
Use the newly published to npm version of po2icu, which uses i18next-conv 2.2.5 which uses iconv-lite rather than iconv.  This avoids the node-gyp rebuild step.  Because of that, we can remove the gcc add-on step.

Also cache the pip requirements so they aren't installed each time.