### PR TITLE
Fix GH-419: Some localization cleanup

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -14,201 +14,145 @@ var Footer = React.createClass({
                 <div className="lists">
                     <dl>
                         <dt>
-                            <FormattedMessage
-                                id='general.about'
-                                defaultMessage={'About'} />
+                            <FormattedMessage id='general.about' />
                         </dt>
                         <dd>
                             <a href="/about/">
-                                <FormattedMessage
-                                    id='footer.about'
-                                    defaultMessage={'About Scratch'} />
+                                <FormattedMessage id='general.aboutScratch' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/parents/">
-                                <FormattedMessage
-                                    id='general.forParents'
-                                    defaultMessage={'For Parents'} />
+                                <FormattedMessage id='general.forParents' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/educators/">
-                                <FormattedMessage
-                                    id='general.forEducators'
-                                    defaultMessage={'For Educators'} />
+                                <FormattedMessage id='general.forEducators' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/info/credits/">
-                                <FormattedMessage
-                                    id='general.credits'
-                                    defaultMessage={'Credits'} />
+                                <FormattedMessage id='general.credits' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/jobs/">
-                                <FormattedMessage
-                                    id='general.jobs'
-                                    defaultMessage={'Jobs'} />
+                                <FormattedMessage id='general.jobs' />
                             </a>
                         </dd>
                         <dd>
                             <a href="http://wiki.scratch.mit.edu/wiki/Scratch_Press">
-                                <FormattedMessage
-                                    id='general.press'
-                                    defaultMessage={'Press'} />
+                                <FormattedMessage id='general.press' />
                             </a>
                         </dd>
                     </dl>
 
                     <dl>
                         <dt>
-                            <FormattedMessage
-                                id='general.community'
-                                defaultMessage={'Community'} />
+                            <FormattedMessage id='general.community' />
                         </dt>
                         <dd>
                             <a href="/community_guidelines/">
-                                <FormattedMessage
-                                    id='general.guidelines'
-                                    defaultMessage={'Community Guidelines'} />
+                                <FormattedMessage id='general.guidelines' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/discuss/">
-                                <FormattedMessage
-                                    id='footer.discuss'
-                                    defaultMessage={'Discussion Forums'} />
+                                <FormattedMessage id='footer.discuss' />
                             </a>
                         </dd>
                         <dd>
                             <a href="https://wiki.scratch.mit.edu/">
-                                <FormattedMessage
-                                    id='general.wiki'
-                                    defaultMessage={'Scratch Wiki'} />
+                                <FormattedMessage id='general.wiki' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/statistics/">
-                                <FormattedMessage
-                                    id='general.statistics'
-                                    defaultMessage={'Statistics'} />
+                                <FormattedMessage id='general.statistics' />
                             </a>
                         </dd>
                     </dl>
 
                     <dl>
                         <dt>
-                            <FormattedMessage
-                                id='general.support'
-                                defaultMessage={'Support'} />
+                            <FormattedMessage id='general.support' />
                         </dt>
                         <dd>
                             <a href="/help/">
-                                <FormattedMessage
-                                    id='footer.help'
-                                    defaultMessage={'Help Page'} />
+                                <FormattedMessage id='footer.help' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/info/faq/">
-                                <FormattedMessage
-                                    id='general.faq'
-                                    defaultMessage={'FAQ'} />
+                                <FormattedMessage id='general.faq' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/scratch2download/">
-                                <FormattedMessage
-                                    id='general.offlineEditor'
-                                    defaultMessage={'Offline Editor'} />
+                                <FormattedMessage id='general.offlineEditor' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/contact-us/">
-                                <FormattedMessage
-                                    id='general.contactUs'
-                                    defaultMessage={'Contact Us'} />
+                                <FormattedMessage id='general.contactUs' />
                             </a>
                         </dd>
                         <dd>
                             <a href="https://secure.donationpay.org/scratchfoundation/">
-                                <FormattedMessage
-                                    id='general.donate'
-                                    defaultMessage={'Donate'} />
+                                <FormattedMessage id='general.donate'/>
                             </a>
                         </dd>
                     </dl>
 
                     <dl>
                         <dt>
-                            <FormattedMessage
-                                id='general.legal'
-                                defaultMessage={'Legal'} />
+                            <FormattedMessage id='general.legal'/>
                         </dt>
                         <dd>
                             <a href="/terms_of_use/">
-                                <FormattedMessage
-                                    id='general.termsOfUse'
-                                    defaultMessage={'Terms of Use'} />
+                                <FormattedMessage id='general.termsOfUse' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/privacy_policy/">
-                                <FormattedMessage
-                                    id='privacyPolicy'
-                                    defaultMessage={'Privacy Policy'} />
+                                <FormattedMessage id='privacyPolicy' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/DMCA/">
-                                <FormattedMessage
-                                    id='general.dmca'
-                                    defaultMessage={'DMCA'} />
+                                <FormattedMessage id='general.dmca' />
                             </a>
                         </dd>
                     </dl>
 
                     <dl>
                         <dt>
-                            <FormattedMessage
-                                id='footer.scratchFamily'
-                                defaultMessage={'Scratch Family'} />
+                            <FormattedMessage id='footer.scratchFamily' />
                         </dt>
                         <dd>
                             <a href="http://scratched.gse.harvard.edu/">
-                                <FormattedMessage
-                                    id='general.scratchEd'
-                                    defaultMessage={'ScratchEd'} />
+                                <FormattedMessage id='general.scratchEd' />
                             </a>
                         </dd>
                         <dd>
                             <a href="http://www.scratchjr.org/">
-                                <FormattedMessage
-                                    id='general.scratchJr'
-                                    defaultMessage={'ScratchJr'} />
+                                <FormattedMessage id='general.scratchJr' />
                             </a>
                         </dd>
                         <dd>
                             <a href="http://day.scratch.mit.edu/">
-                                <FormattedMessage
-                                    id='general.scratchday'
-                                    defaultMessage={'Scratch Day'} />
+                                <FormattedMessage id='general.scratchday' />
                             </a>
                         </dd>
                         <dd>
                             <a href="/conference/">
-                                <FormattedMessage
-                                    id='general.scratchConference'
-                                    defaultMessage={'Scratch Conference'} />
+                                <FormattedMessage id='general.scratchConference' />
                             </a>
                         </dd>
                         <dd>
                             <a href="http://www.scratchfoundation.org/">
-                                <FormattedMessage
-                                    id='general.scratchFoundation'
-                                    defaultMessage={'Scratch Foundation'} />
+                                <FormattedMessage id='general.scratchFoundation' />
                             </a>
                         </dd>
                     </dl>
@@ -218,11 +162,7 @@ var Footer = React.createClass({
 
                 <div className="copyright">
                     <p>
-                        <FormattedMessage
-                            id='general.copyright'
-                            defaultMessage={
-                                'Scratch is a project of the Lifelong Kindergarten Group at the MIT Media Lab'
-                            } />
+                        <FormattedMessage id='general.copyright' />
                     </p>
                 </div>
             </FooterBox>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -49,7 +49,6 @@
     "general.whatsHappening": "What's Happening?",
     "general.wiki": "Scratch Wiki",
 
-    "footer.about": "About Scratch",    
     "footer.discuss": "Discussion Forums",
     "footer.help": "Help Page",
     "footer.scratchFamily": "Scratch Family",

--- a/src/template.html
+++ b/src/template.html
@@ -75,5 +75,21 @@
             });
             ga('send', 'pageview');
         </script>
+
+        <!-- translate title element -->
+        <script>
+            var loc = window._locale || 'en';
+            if (typeof window._messages !== 'undefined' && loc !== 'en') {
+                if (typeof window._messages[loc] === 'undefined') {
+                    loc = loc.split('-')[0];
+                }
+                if (typeof window._messages[loc] !== 'undefined') {
+                    var localizedTitle = window._messages[loc]['general.' + '{{title}}'.toLowerCase()] || '';
+                    if (localizedTitle.length > 0) {
+                        document.title = 'Scratch - ' + localizedTitle;
+                    }
+                }
+            }
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Fixes #419 by doing the following:
* Makes `About Scratch` localizable by removing a duplicate react-intl key
* Localizes title tags after javascript is loaded onto the template page

The solution for the title tags is only half complete – it does not solve the issue of making title tags localizable for crawlers. However, that requires further thinking in the long term as we think about new localization systems, and how it's handled client-side.

### Test Cases ###
* Load the about page in another language. "About Scratch" should be translated
* Load the about page in another language. The title should be translated.