### PR TITLE
fix chinese translation

### DIFF
--- a/static/js/lib/react-intl-with-locales.js
+++ b/static/js/lib/react-intl-with-locales.js
@@ -2879,7 +2879,10 @@ var IntlProvider = (function (_Component) {
             config[name] = _this2.props[name];
             return config;
         }, {});
-
+        if(config.locale === 'zh-cn'||config.locale ==='zh-tw')
+        {
+           config.locale = 'zh';
+        }
         if (!_localeDataRegistry.hasLocaleData(config.locale)) {
             var _config = config;
             var locale = _config.locale;


### PR DESCRIPTION
language selection box have zh-cn and zh-tw ,but in react-intl/lib/locale-data/ don't have zh-cn.js and zh-tw.js ,so change 'zh-cn' and 'zh-tw' to 'zh'