### PR TITLE
Fix Spacing Issues on Privacy Policy

### DIFF
--- a/src/views/privacypolicy/privacypolicy.jsx
+++ b/src/views/privacypolicy/privacypolicy.jsx
@@ -18,7 +18,7 @@ var Privacypolicy = React.createClass({
                          to explain what information we collect, how we use it,
                          and what we're doing to keep it safe. If you have any
                          questions regarding this privacy policy, you can
-                         <a href="/contact-us">contact us</a>.
+                         <a href="/contact-us"> contact us</a>.
                     </p>
                     <p><i>
                         Please do not share personal contact information, such as
@@ -49,7 +49,7 @@ var Privacypolicy = React.createClass({
                          Scratch Team is responsible for moderation, we have access to all
                          content stored on the Scratch website, including unshared projects.
                          If you prefer to work on projects in complete privacy, you can use
-                         either the <a href="/scratch2download">Scratch 2 offline editor</a>
+                         either the <a href="/scratch2download">Scratch 2 offline editor </a>
                          or <a href="/scratch_1.4">Scratch 1.4</a>.
                     </p>
                     <p>
@@ -104,7 +104,7 @@ var Privacypolicy = React.createClass({
                         <li>
                             Parents and guardians who register their under-13 year olds for
                              Scratch may also receive additional updates from the
-                             <a href="http://www.codetolearn.org/">Scratch Foundation</a>,
+                             <a href="http://www.codetolearn.org/"> Scratch Foundation</a>,
                              a non-profit that supports Scratch educational initiatives.
                              The Scratch Foundation will never sell or share your email
                              address without your permission. You can unsubscribe from these
@@ -123,7 +123,7 @@ var Privacypolicy = React.createClass({
                              how people learn with Scratch. The results of this research are
                              shared with educators and researchers through conferences,
                              journals, and other publications. You can find out more on our
-                             <a href="/info/research">Research page</a>.
+                             <a href="/info/research"> Research page</a>.
                         </li>
                         <li>
                             We may disclose some of the information we collect to third-party
@@ -152,7 +152,7 @@ var Privacypolicy = React.createClass({
                         You can update your password, email address, and country through
                          the <a href="/account/password_change">Account Settings</a> page.
                          You can also reset your password through the
-                          <a href="/account/password_reset">Account Reset</a>
+                          <a href="/account/password_reset">Account Reset </a>
                          page. You cannot change your username, but you can make a new
                          account and manually copy your projects to the new account.
                     </p>

--- a/src/views/privacypolicy/privacypolicy.jsx
+++ b/src/views/privacypolicy/privacypolicy.jsx
@@ -17,8 +17,8 @@ var Privacypolicy = React.createClass({
                          especially kids and parents. We wrote this privacy policy
                          to explain what information we collect, how we use it,
                          and what we're doing to keep it safe. If you have any
-                         questions regarding this privacy policy, you can
-                         <a href="/contact-us"> contact us</a>.
+                         questions regarding this privacy policy, you can{' '}
+                         <a href="/contact-us">contact us</a>.
                     </p>
                     <p><i>
                         Please do not share personal contact information, such as
@@ -49,7 +49,7 @@ var Privacypolicy = React.createClass({
                          Scratch Team is responsible for moderation, we have access to all
                          content stored on the Scratch website, including unshared projects.
                          If you prefer to work on projects in complete privacy, you can use
-                         either the <a href="/scratch2download">Scratch 2 offline editor </a>
+                         either the <a href="/scratch2download">Scratch 2 offline editor</a>{' '}
                          or <a href="/scratch_1.4">Scratch 1.4</a>.
                     </p>
                     <p>
@@ -103,8 +103,8 @@ var Privacypolicy = React.createClass({
                         </li>
                         <li>
                             Parents and guardians who register their under-13 year olds for
-                             Scratch may also receive additional updates from the
-                             <a href="http://www.codetolearn.org/"> Scratch Foundation</a>,
+                             Scratch may also receive additional updates from the{' '}
+                             <a href="http://www.codetolearn.org/">Scratch Foundation</a>,
                              a non-profit that supports Scratch educational initiatives.
                              The Scratch Foundation will never sell or share your email
                              address without your permission. You can unsubscribe from these
@@ -122,8 +122,8 @@ var Privacypolicy = React.createClass({
                              in research studies intended to improve our understanding of
                              how people learn with Scratch. The results of this research are
                              shared with educators and researchers through conferences,
-                             journals, and other publications. You can find out more on our
-                             <a href="/info/research"> Research page</a>.
+                             journals, and other publications. You can find out more on our{' '}
+                             <a href="/info/research">Research page</a>.
                         </li>
                         <li>
                             We may disclose some of the information we collect to third-party
@@ -152,7 +152,7 @@ var Privacypolicy = React.createClass({
                         You can update your password, email address, and country through
                          the <a href="/account/password_change">Account Settings</a> page.
                          You can also reset your password through the
-                          <a href="/account/password_reset">Account Reset </a>
+                          <a href="/account/password_reset">Account Reset</a>{' '}
                          page. You cannot change your username, but you can make a new
                          account and manually copy your projects to the new account.
                     </p>


### PR DESCRIPTION
![screenshot](https://cloud.githubusercontent.com/assets/12952370/15324625/3719bebe-1c15-11e6-8bf4-4661f5f61f0e.png)

I noticed on the new [privacy policy page](https://staging.scratch.mit.edu/privacy_policy/) there were some spacing issues beside links. (Some links didn't have a space between a word before or after)

Also, I noticed that bolding doesn't seem to work on the staging site. The `h3`s aren't bolded (very well if at all), and neither are anything that I put in `<b>` tags. Is this just an issue on the staging site or will changes need to be made for the page?