### PR TITLE
Fix gh-484: "interfacesto" -> "interfaces to"

### DIFF
--- a/src/views/developers/developers.jsx
+++ b/src/views/developers/developers.jsx
@@ -166,7 +166,7 @@ var Developers = React.createClass({
                                         We believe that the learning process is inherently iterative. Tinkerers{' '}
                                         start by exploring and experimenting, then revising and refining their{' '}
                                         goals and creations. To support this style of interaction, we design{' '}
-                                        our interfacesto encourage quick experimentation and rapid cycles of iteration.
+                                        our interfaces to encourage quick experimentation and rapid cycles of iteration.
                                     </dd>
                                 </dl>
                             </div>


### PR DESCRIPTION
Changes "we design our interfacesto" to "we design our interfaces to" in the Design for Tinkerability section.

Resolves #484.