### PR TITLE
Filter before mapping to avoid returning undefined

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -29,13 +29,13 @@ var extraAppRoutes = [
  */
 var getStaticPaths = function (pathToStatic) {
     var staticPaths = glob.sync(path.resolve(__dirname, pathToStatic));
-    return staticPaths.map(function (pathName) {
+    return staticPaths.filter(function (pathName) {
         // Exclude view html, resolve everything else in the build
-        if (path.extname(pathName) !== '.html') {
-            // Reduce absolute path to relative paths like '/js'
-            var base = path.dirname(path.resolve(__dirname, pathToStatic));
-            return '^' + pathName.replace(base, '') + (path.extname(pathName) ? '' : '/');
-        }
+        return path.extname(pathName) !== '.html';
+    }).map(function (pathName) {
+        // Reduce absolute path to relative paths like '/js'
+        var base = path.dirname(path.resolve(__dirname, pathToStatic));
+        return '^' + pathName.replace(base, '') + (path.extname(pathName) ? '' : '/');
     });
 };
 


### PR DESCRIPTION
If the map function doesn't return anything, the added item is undefined. Avoid this by filtering the array before mapping.

I actually tested this :|