### PR TITLE
Prefix privacyPolicy message string

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -116,7 +116,7 @@ var Footer = React.createClass({
                         </dd>
                         <dd>
                             <a href="/privacy_policy/">
-                                <FormattedMessage id='privacyPolicy' />
+                                <FormattedMessage id='general.privacyPolicy' />
                             </a>
                         </dd>
                         <dd>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -26,6 +26,7 @@
     "general.myClasses": "My Classes",
     "general.myStuff": "My Stuff",
     "general.offlineEditor": "Offline Editor",
+    "general.privacyPolicy": "Privacy Policy",
     "general.profile": "Profile",
     "general.scratchConference": "Scratch Conference",
     "general.scratchday": "Scratch Day",


### PR DESCRIPTION
So that it matches the rest, and is localized. Not sure, but I think this was fallout from de-localizing the Privacy Policy page.