### PR TITLE
Use `routes.json` to get localization paths

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -66,7 +66,8 @@ try {
 
 // get global locale strings first.
 var globalTemplateFile = path.resolve(__dirname, '../src/l10n.json');
-var ids = JSON.parse(fs.readFileSync(globalTemplateFile, 'utf8'));
+var ids = require(globalTemplateFile);
+// var ids = JSON.parse(fs.readFileSync(globalTemplateFile, 'utf8'));
 
 // message key with english string values (i.e. default values)
 var viewLocales = {
@@ -76,7 +77,6 @@ var viewLocales = {
 };
 var idsWithICU = localeCompare.idToICUMap('general', ids);
 var icuWithIds = localeCompare.icuToIdMap('general', ids);
-// localeCompare.getIdsForView('general', globalTemplateFile, viewLocales, idsWithICU, icuWithIds);
 
 var views = [];
 var localizedAssetUrls = {};
@@ -92,15 +92,17 @@ for (var v in routes) {
         var subdir = routes[v].view.split('/');
         subdir.pop();
         var l10n = path.resolve(__dirname, '../src/views/' + subdir.join('/') + '/l10n.json');
-        fs.accessSync(l10n, fs.F_OK);
-        ids = JSON.parse(fs.readFileSync(l10n, 'utf8'));
+        ids = require(l10n);
         viewLocales[routes[v].name] = {
             en: ids
         };
         idsWithICU = merge(idsWithICU, localeCompare.idToICUMap(routes[v].name, ids));
         icuWithIds = merge(icuWithIds, localeCompare.icuToIdMap(routes[v].name, ids));
     } catch (err) {
-        // check that routes' view path is not malformed, error if it is
+        if (err.code !== 'MODULE_NOT_FOUND') {
+            throw err;
+        }
+
         try {
             fs.accessSync(path.resolve(__dirname, '../src/views/' + routes[v].view + '.jsx'));
         } catch (err) {
@@ -111,11 +113,12 @@ for (var v in routes) {
 
     // get asset url translations
     try {
-        var l10nStatic = path.resolve(__dirname, '../src/views/' + routes[v].view + '/l10n-static.json');
-        fs.accessSync(l10nStatic, fs.F_OK);
+        subdir = routes[v].view.split('/');
+        subdir.pop();
+        var l10nStatic = path.resolve(__dirname, '../src/views/' + subdir.join('/') + '/l10n-static.json');
         localizedAssetUrls[routes[v].name] = {};
 
-        var assetUrls = JSON.parse(fs.readFileSync(l10nStatic, 'utf8'));
+        var assetUrls = require(l10nStatic);
         for (var lang in localizedUrls) {
             localizedAssetUrls[routes[v].name][lang] = {};
             for (var key in assetUrls) {
@@ -127,7 +130,16 @@ for (var v in routes) {
             }
         }
     } catch (err) {
-        // :)
+        if (err.code !== 'MODULE_NOT_FOUND') {
+            throw err;
+        }
+
+        try {
+            fs.accessSync(path.resolve(__dirname, '../src/views/' + routes[v].view + '.jsx'));
+        } catch (err) {
+            // the config for the view is not set up correctly, so throw the error.
+            throw err;
+        }
     }
 }
 

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -149,20 +149,20 @@ var md5WithIds = localeCompare.getMD5Map(icuWithIds);
 
 // Get ui localization strings first
 var isoCodes = Object.keys(languages);
-for (var i in isoCodes) {
-    var translations = localeCompare.getTranslationsForLanguage(isoCodes[i], idsWithICU, md5WithIds);
-    for (key in translations) {
-        viewLocales[key] = merge(viewLocales[key], translations[key]);
+for (var isoCode in isoCodes) {
+    var translations = localeCompare.getTranslationsForLanguage(isoCodes[isoCode], idsWithICU, md5WithIds);
+    for (var messageId in translations) {
+        viewLocales[messageId] = merge(viewLocales[messageId], translations[messageId]);
     }
 }
 
-for (i in views) {
+for (var view in views) {
     var viewTranslations = viewLocales['general'];
-    if (views[i] in viewLocales) {
-        viewTranslations = merge(viewLocales[views[i]], viewTranslations);
+    if (views[view] in viewLocales) {
+        viewTranslations = merge(viewLocales[views[view]], viewTranslations);
     }
-    if (views[i] in localizedAssetUrls) {
-        viewTranslations = merge(viewTranslations, localizedAssetUrls[[views[i]]]);
+    if (views[view] in localizedAssetUrls) {
+        viewTranslations = merge(viewTranslations, localizedAssetUrls[[views[view]]]);
     }
-    localeCompare.writeTranslationsToJS(outputDir, views[i], viewTranslations);
+    localeCompare.writeTranslationsToJS(outputDir, views[view], viewTranslations);
 }

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -36,13 +36,13 @@
     '''
 */
 var fs = require('fs');
-var glob = require('glob');
 var merge = require('lodash.merge');
 var path = require('path');
 
 var languages = require('../languages.json');
 var localeCompare = require('./lib/locale-compare');
 var localizedUrls = require('./lib/localized-urls');
+var routes = require('../src/routes.json');
 
 // -----------------------------------------------------------------------------
 // Main script
@@ -64,56 +64,72 @@ try {
     fs.mkdirSync(outputDir);
 }
 
-// message key with english string values (i.e. default values)
-var viewLocales = {};
-// FormattedMessage id with english string as value. Use for default values in translations
-// Sample structure: { 'general-general.blah': 'blah', 'about-about.blah': 'blahblah' }
-var idsWithICU = {};
-// reverse (i.e. english string with message key as the value) object for searching po files.
-// Sample structure: { 'blah': 'general-general.blah', 'blahblah': 'about-about.blah' }
-var icuWithIds = {};
-
 // get global locale strings first.
 var globalTemplateFile = path.resolve(__dirname, '../src/l10n.json');
-localeCompare.getIdsForView('general', globalTemplateFile, viewLocales, idsWithICU, icuWithIds);
+var ids = JSON.parse(fs.readFileSync(globalTemplateFile, 'utf8'));
 
+// message key with english string values (i.e. default values)
+var viewLocales = {
+    general: {
+        en: ids
+    }
+};
+var idsWithICU = localeCompare.idToICUMap('general', ids);
+var icuWithIds = localeCompare.icuToIdMap('general', ids);
+// localeCompare.getIdsForView('general', globalTemplateFile, viewLocales, idsWithICU, icuWithIds);
+
+var views = [];
+var localizedAssetUrls = {};
 
 // start with all views, and remove localized ones as they are iterated over
-var views = glob.sync(path.resolve(__dirname, '../src/views/*'));
-for (var i = 0; i < views.length; i++) {
-    views[i] = views[i].split('/').pop();
-}
-
-// get view-specific locale strings.
-var files = glob.sync(path.resolve(__dirname, '../src/views/**/l10n.json'));
-files.forEach(function (file) {
-    var dirPath = file.split('/');
-    dirPath.pop();
-    var view = dirPath.pop();
-    localeCompare.getIdsForView(view, file, viewLocales, idsWithICU, icuWithIds);
-});
-
-// get asset url translations
-var localizedAssetUrls = {};
-files = glob.sync(path.resolve(__dirname, '../src/views/**/l10n-static.json'));
-files.forEach(function (file) {
-    var dirPath = file.split('/');
-    dirPath.pop();
-    var view = dirPath.pop();
-    localizedAssetUrls[view] = {};
-
-    var assetUrls = JSON.parse(fs.readFileSync(file, 'utf8'));
-    for (var lang in localizedUrls) {
-        localizedAssetUrls[view][lang] = {};
-        for (var key in assetUrls) {
-            if (localizedUrls[lang].hasOwnProperty(key)) {
-                localizedAssetUrls[view][lang][key] = localizedUrls[lang][key];
-            } else {
-                localizedAssetUrls[view][lang][key] = assetUrls[key];
-            }
+for (var v in routes) {
+    if (typeof routes[v].redirect !== 'undefined') {
+        continue;
+    }
+    
+    views.push(routes[v].name);
+    try {
+        var subdir = routes[v].view.split('/');
+        subdir.pop();
+        var l10n = path.resolve(__dirname, '../src/views/' + subdir.join('/') + '/l10n.json');
+        fs.accessSync(l10n, fs.F_OK);
+        ids = JSON.parse(fs.readFileSync(l10n, 'utf8'));
+        viewLocales[routes[v].name] = {
+            en: ids
+        };
+        idsWithICU = merge(idsWithICU, localeCompare.idToICUMap(routes[v].name, ids));
+        icuWithIds = merge(icuWithIds, localeCompare.icuToIdMap(routes[v].name, ids));
+    } catch (err) {
+        // check that routes' view path is not malformed, error if it is
+        try {
+            fs.accessSync(path.resolve(__dirname, '../src/views/' + routes[v].view + '.jsx'));
+        } catch (err) {
+            // the config for the view is not set up correctly, so throw the error.
+            throw err;
         }
     }
-});
+
+    // get asset url translations
+    try {
+        var l10nStatic = path.resolve(__dirname, '../src/views/' + routes[v].view + '/l10n-static.json');
+        fs.accessSync(l10nStatic, fs.F_OK);
+        localizedAssetUrls[routes[v].name] = {};
+
+        var assetUrls = JSON.parse(fs.readFileSync(l10nStatic, 'utf8'));
+        for (var lang in localizedUrls) {
+            localizedAssetUrls[routes[v].name][lang] = {};
+            for (var key in assetUrls) {
+                if (localizedUrls[lang].hasOwnProperty(key)) {
+                    localizedAssetUrls[routes[v].name][lang][key] = localizedUrls[lang][key];
+                } else {
+                    localizedAssetUrls[routes[v].name][lang][key] = assetUrls[key];
+                }
+            }
+        }
+    } catch (err) {
+        // :)
+    }
+}
 
 // md5 of english strings with message key as the value for searching po files.
 // Sample structure: { 'sdfas43534sdfasdf': 'general-general.blah', 'lkjfasdf4t342asdfa': 'about-about.blah' }
@@ -121,9 +137,9 @@ var md5WithIds = localeCompare.getMD5Map(icuWithIds);
 
 // Get ui localization strings first
 var isoCodes = Object.keys(languages);
-for (i in isoCodes) {
+for (var i in isoCodes) {
     var translations = localeCompare.getTranslationsForLanguage(isoCodes[i], idsWithICU, md5WithIds);
-    for (var key in translations) {
+    for (key in translations) {
         viewLocales[key] = merge(viewLocales[key], translations[key]);
     }
 }

--- a/bin/lib/locale-compare.js
+++ b/bin/lib/locale-compare.js
@@ -125,15 +125,24 @@ Helpers.writeTranslationsToJS = function (outputDir, viewName, translationObject
     fs.writeFileSync(outputDir + '/' + viewName + '.intl.js', fileString);
 };
 
-Helpers.getIdsForView = function (viewName, viewFile, localeObject, idsWithICU, icuWithIds) {
-    var ids = JSON.parse(fs.readFileSync(viewFile, 'utf8'));
-    localeObject[viewName] = {
-        en: ids
-    };
+// Returns a FormattedMessage id with english string as value. Use for default values in translations
+// Sample structure: { 'general-general.blah': 'blah', 'about-about.blah': 'blahblah' }
+Helpers.idToICUMap = function (viewName, ids) {
+    var idsToICU = {};
     for (var id in ids) {
-        idsWithICU[viewName + '-' + id] = ids[id];
-        icuWithIds[ids[id]] = viewName + '-' + id; // add viewName to identifier for later
+        idsToICU[viewName + '-' + id] = ids[id];
     }
+    return idsToICU;
+};
+
+// Reuturns reverse (i.e. english string with message key as the value) object for searching po files.
+// Sample structure: { 'blah': 'general-general.blah', 'blahblah': 'about-about.blah' }
+Helpers.icuToIdMap = function (viewName, ids) {
+    var icuToIds = {};
+    for (var id in ids) {
+        icuToIds[ids[id]] = viewName + '-' + id;
+    }
+    return icuToIds;
 };
 
 module.exports = Helpers;

--- a/test/localization/spot_check_about_has_strings.js
+++ b/test/localization/spot_check_about_has_strings.js
@@ -12,16 +12,13 @@ var localeCompare = require('../../bin/lib/locale-compare');
 tap.test('spotCheckAboutStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
-    var viewLocales = {};
-    var idsWithICU = {};
-    var icuWithIds = {};
-    localeCompare.getIdsForView(
-        'about',
-        path.resolve(__dirname, '../../src/views/about/l10n.json'),
-        viewLocales,
-        idsWithICU,
-        icuWithIds
-    );
+    
+    var ids = path.resolve(__dirname, '../../views/about/l10n.json');
+    var viewLocales = {
+        about: {en: ids}
+    };
+    var idsWithICU = localeCompare.idToICUMap('about', ids);
+    var icuWithIds = localeCompare.icuToIdMap('about', ids);
     var md5WithIds = localeCompare.getMD5Map(icuWithIds);
     var keysToCheck = Object.keys(merge(viewLocales['about']['en'])).sort();
     for (var i in isoCodes) {

--- a/test/localization/spot_check_about_has_strings.js
+++ b/test/localization/spot_check_about_has_strings.js
@@ -13,7 +13,7 @@ tap.test('spotCheckAboutStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
     
-    var ids = path.resolve(__dirname, '../../views/about/l10n.json');
+    var ids = require(path.resolve(__dirname, '../../src/views/about/l10n.json'));
     var viewLocales = {
         about: {en: ids}
     };

--- a/test/localization/spot_check_cards_has_strings.js
+++ b/test/localization/spot_check_cards_has_strings.js
@@ -9,19 +9,16 @@ var tap = require('tap');
 var languages = require('../../languages.json');
 var localeCompare = require('../../bin/lib/locale-compare');
 
-tap.test('spotCheckAboutStrings', function (t) {
+tap.test('spotCheckCardStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
-    var viewLocales = {};
-    var idsWithICU = {};
-    var icuWithIds = {};
-    localeCompare.getIdsForView(
-        'cards',
-        path.resolve(__dirname, '../../src/views/cards/l10n.json'),
-        viewLocales,
-        idsWithICU,
-        icuWithIds
-    );
+    
+    var ids = path.resolve(__dirname, '../../views/cards/l10n.json');
+    var viewLocales = {
+        cards: {en: ids}
+    };
+    var idsWithICU = localeCompare.idToICUMap('cards', ids);
+    var icuWithIds = localeCompare.icuToIdMap('cards', ids);
     var md5WithIds = localeCompare.getMD5Map(icuWithIds);
     var keysToCheck = Object.keys(merge(viewLocales['cards']['en'])).sort();
     for (var i in isoCodes) {

--- a/test/localization/spot_check_cards_has_strings.js
+++ b/test/localization/spot_check_cards_has_strings.js
@@ -13,7 +13,7 @@ tap.test('spotCheckCardStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
     
-    var ids = path.resolve(__dirname, '../../views/cards/l10n.json');
+    var ids = require(path.resolve(__dirname, '../../src/views/cards/l10n.json'));
     var viewLocales = {
         cards: {en: ids}
     };

--- a/test/localization/spot_check_general_has_strings.js
+++ b/test/localization/spot_check_general_has_strings.js
@@ -13,7 +13,7 @@ tap.test('spotCheckGeneralStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
     
-    var ids = path.resolve(__dirname, '../../src/l10n.json');
+    var ids = require(path.resolve(__dirname, '../../src/l10n.json'));
     var viewLocales = {
         general: {en: ids}
     };

--- a/test/localization/spot_check_general_has_strings.js
+++ b/test/localization/spot_check_general_has_strings.js
@@ -9,19 +9,16 @@ var tap = require('tap');
 var languages = require('../../languages.json');
 var localeCompare = require('../../bin/lib/locale-compare');
 
-tap.test('spotCheckAboutStrings', function (t) {
+tap.test('spotCheckGeneralStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
-    var viewLocales = {};
-    var idsWithICU = {};
-    var icuWithIds = {};
-    localeCompare.getIdsForView(
-        'general',
-        path.resolve(__dirname, '../../src/l10n.json'),
-        viewLocales,
-        idsWithICU,
-        icuWithIds
-    );
+    
+    var ids = path.resolve(__dirname, '../../src/l10n.json');
+    var viewLocales = {
+        general: {en: ids}
+    };
+    var idsWithICU = localeCompare.idToICUMap('general', ids);
+    var icuWithIds = localeCompare.icuToIdMap('general', ids);
     var md5WithIds = localeCompare.getMD5Map(icuWithIds);
     var keysToCheck = Object.keys(merge(viewLocales['general']['en'])).sort();
     for (var i in isoCodes) {

--- a/test/localization/spot_check_nav.js
+++ b/test/localization/spot_check_nav.js
@@ -16,10 +16,6 @@ var path = require('path');
 var tap = require('tap');
 
 var localeCompare = require('../../bin/lib/locale-compare');
-var viewLocales = {};
-var idsWithICU = {};
-var icuWithIds = {};
-
 var languagesToCheck = [
     'he', 'zh-cn', 'ja', 'pt-br', 'pl', 'nb'
 ];
@@ -29,14 +25,12 @@ var idsToCheck = [
 ];
 
 
-// Test nav for real languages.
-localeCompare.getIdsForView(
-    'general',
-    path.resolve(__dirname, '../../src/l10n.json'),
-    viewLocales,
-    idsWithICU,
-    icuWithIds
-);
+var ids = path.resolve(__dirname, '../../src/l10n.json');
+var viewLocales = {
+    general: {en: ids}
+};
+var idsWithICU = localeCompare.idToICUMap('general', ids);
+var icuWithIds = localeCompare.icuToIdMap('general', ids);
 var md5WithIds = localeCompare.getMD5Map(icuWithIds);
 
 tap.test('spotCheckNavBar', function (t) {

--- a/test/localization/spot_check_nav.js
+++ b/test/localization/spot_check_nav.js
@@ -25,7 +25,7 @@ var idsToCheck = [
 ];
 
 
-var ids = path.resolve(__dirname, '../../src/l10n.json');
+var ids = require(path.resolve(__dirname, '../../src/l10n.json'));
 var viewLocales = {
     general: {en: ids}
 };
@@ -51,20 +51,19 @@ tap.test('spotCheckNavBar', function (t) {
 // Test splash items for fake language.
 var fakeLanguageIdsToCheck = ['news.scratchNews', 'splash.featuredProjects', 'splash.featuredStudios'];
 
-localeCompare.getIdsForView(
-    'splash',
-    path.resolve(__dirname, '../../src/views/splash/l10n.json'),
-    viewLocales,
-    idsWithICU,
-    icuWithIds
-);
+ids = require(path.resolve(__dirname, '../../src/views/splash/l10n.json'));
+viewLocales = {
+    splash: {en: ids}
+};
+idsWithICU = localeCompare.idToICUMap('splash', ids);
+icuWithIds = localeCompare.icuToIdMap('splash', ids);
 md5WithIds = localeCompare.getMD5Map(icuWithIds);
 
 tap.test('spotCheckNavBarFakeLanguage', function (t) {
     var translations = localeCompare.getTranslationsForLanguage('yum', idsWithICU, md5WithIds);
     for (var i in fakeLanguageIdsToCheck) {
         t.notEqual(
-            translations['general']['yum'][fakeLanguageIdsToCheck[i]],
+            translations['splash']['yum'][fakeLanguageIdsToCheck[i]],
             viewLocales['splash']['en'][fakeLanguageIdsToCheck[i]],
             'check localization of ' + fakeLanguageIdsToCheck[i] + ' for yum'
         );

--- a/test/localization/spot_check_splash_has_strings.js
+++ b/test/localization/spot_check_splash_has_strings.js
@@ -9,19 +9,16 @@ var tap = require('tap');
 var languages = require('../../languages.json');
 var localeCompare = require('../../bin/lib/locale-compare');
 
-tap.test('spotCheckAboutStrings', function (t) {
+tap.test('spotCheckSplashStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
-    var viewLocales = {};
-    var idsWithICU = {};
-    var icuWithIds = {};
-    localeCompare.getIdsForView(
-        'splash',
-        path.resolve(__dirname, '../../src/views/splash/l10n.json'),
-        viewLocales,
-        idsWithICU,
-        icuWithIds
-    );
+    
+    var ids = path.resolve(__dirname, '../../views/splash/l10n.json');
+    var viewLocales = {
+        splash: {en: ids}
+    };
+    var idsWithICU = localeCompare.idToICUMap('splash', ids);
+    var icuWithIds = localeCompare.icuToIdMap('splash', ids);
     var md5WithIds = localeCompare.getMD5Map(icuWithIds);
     var keysToCheck = Object.keys(merge(viewLocales['splash']['en'])).sort();
     for (var i in isoCodes) {

--- a/test/localization/spot_check_splash_has_strings.js
+++ b/test/localization/spot_check_splash_has_strings.js
@@ -13,7 +13,7 @@ tap.test('spotCheckSplashStrings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
     
-    var ids = path.resolve(__dirname, '../../views/splash/l10n.json');
+    var ids = require(path.resolve(__dirname, '../../src/views/splash/l10n.json'));
     var viewLocales = {
         splash: {en: ids}
     };

--- a/test/localization/spot_check_wedo2_has_strings.js
+++ b/test/localization/spot_check_wedo2_has_strings.js
@@ -9,19 +9,16 @@ var tap = require('tap');
 var languages = require('../../languages.json');
 var localeCompare = require('../../bin/lib/locale-compare');
 
-tap.test('spotCheckAboutStrings', function (t) {
+tap.test('spotCheckWedo2Strings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
-    var viewLocales = {};
-    var idsWithICU = {};
-    var icuWithIds = {};
-    localeCompare.getIdsForView(
-        'wedo2',
-        path.resolve(__dirname, '../../src/views/wedo2/l10n.json'),
-        viewLocales,
-        idsWithICU,
-        icuWithIds
-    );
+    
+    var ids = path.resolve(__dirname, '../../views/wedo2/l10n.json');
+    var viewLocales = {
+        wedo2: {en: ids}
+    };
+    var idsWithICU = localeCompare.idToICUMap('wedo2', ids);
+    var icuWithIds = localeCompare.icuToIdMap('wedo2', ids);
     var md5WithIds = localeCompare.getMD5Map(icuWithIds);
     var keysToCheck = Object.keys(merge(viewLocales['wedo2']['en'])).sort();
     for (var i in isoCodes) {

--- a/test/localization/spot_check_wedo2_has_strings.js
+++ b/test/localization/spot_check_wedo2_has_strings.js
@@ -13,7 +13,7 @@ tap.test('spotCheckWedo2Strings', function (t) {
     var isoCodes = Object.keys(languages);
     isoCodes.splice(isoCodes.indexOf('en'), 1);
     
-    var ids = path.resolve(__dirname, '../../views/wedo2/l10n.json');
+    var ids = require(path.resolve(__dirname, '../../src/views/wedo2/l10n.json'));
     var viewLocales = {
         wedo2: {en: ids}
     };


### PR DESCRIPTION
Before we were using glob, which was about to start failing on subdirectories in views (which we started using in `conference`). Instead of searching for `l10n.json`, it seemed more appropriate to instead look for localization by using the configured pages that need to be localized.

### Test Cases ###
* run `make translations && npm start`. Check the website in pt_BR – it should be localised.