### PR TITLE
Upload svgs with MIME type image/svg+xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ webpack:
 	$(WEBPACK) --bail
 
 sync-s3:
-	$(S3CMD) sync -P --delete-removed --exclude '.DS_Store' ./build/ s3://$(S3_BUCKET_NAME)/
+	$(S3CMD) sync -P --delete-removed --exclude '.DS_Store' --exclude '*.svg' ./build/ s3://$(S3_BUCKET_NAME)/
+	$(S3CMD) sync -P --delete-removed --exclude '*' --include '*.svg' --default-mime-type 'image/svg+xml' ./build/ s3://$(S3_BUCKET_NAME)/
 
 sync-fastly:
 	$(NODE) ./bin/configure-fastly.js


### PR DESCRIPTION
Unfortunately there's no way to map extensions to MIME type. The s3cmd tool guesses wrong and uploads svgs with text/html.  Upload everything but svgs first, then upload only svgs using the correct MIME type.

Fixes an issue where svg `<img>` tags were appearing as not found.

FYI @mewtaylor 