### PR TITLE
Fix gh-500: Footer press link

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -26,6 +26,7 @@
     "general.myClasses": "My Classes",
     "general.myStuff": "My Stuff",
     "general.offlineEditor": "Offline Editor",
+    "general.press": "Press",
     "general.privacyPolicy": "Privacy Policy",
     "general.profile": "Profile",
     "general.scratchConference": "Scratch Conference",


### PR DESCRIPTION
The string associated to the link was (previously) non-existent. This should fix #500 

@mewtaylor 