### PR TITLE
Fix gh-505: Incorrect time header background

### DIFF
--- a/src/views/conference/schedule/schedule.scss
+++ b/src/views/conference/schedule/schedule.scss
@@ -57,7 +57,7 @@
             }
 
             span {
-                background-color: $ui-white;
+                background-color: $background-color;
                 padding: 0 10px;
             }
         }


### PR DESCRIPTION
Changes the background color on the schedule page to $background-color instead of $ui-white, fixes #505.

**Test Cases**
Ensure that the background color of the time headers is consistent with the rest of the page. 