### PR TITLE
Fix gh-506: Center conference links

### DIFF
--- a/src/views/conference/index/index.scss
+++ b/src/views/conference/index/index.scss
@@ -80,6 +80,7 @@
     }
 }
 
+
 @media only screen and (max-width: $tablet - 1) {
   .index{
     .flex-row {


### PR DESCRIPTION
Fixes #506 by setting the align-items property of flex-row to center when the width of the page is small enough. 

**Test Cases**
Ensure that the links on the conference page are centered on mobile devices and small browser widths, and that this change does not apply to larger browser widths.