### PR TITLE
Fix gh-507: Consistently change URI

### DIFF
--- a/src/views/conference/schedule/schedule.jsx
+++ b/src/views/conference/schedule/schedule.jsx
@@ -22,6 +22,7 @@ var ConferenceSchedule = React.createClass({
         this.handleScheduleChange(day);
     },
     handleScheduleChange: function (day) {
+        window.history.replaceState(history.state, '', "#" + day);
         this.props.dispatch(scheduleActions.startGetSchedule(day));
     },
     renderChunkItems: function (timeSlot) {

--- a/src/views/conference/schedule/schedule.jsx
+++ b/src/views/conference/schedule/schedule.jsx
@@ -22,7 +22,7 @@ var ConferenceSchedule = React.createClass({
         this.handleScheduleChange(day);
     },
     handleScheduleChange: function (day) {
-        window.history.replaceState(history.state, '', "#" + day);
+        window.history.replaceState(history.state, '', '#' + day);
         this.props.dispatch(scheduleActions.startGetSchedule(day));
     },
     renderChunkItems: function (timeSlot) {


### PR DESCRIPTION
Fixes #507 by adding a location hash after clicking on a different schedule day (conforms with the behavior of the 'back to full schedule' links on detail pages). 

I used window.history.replaceState to change the hash, so that moving back and forward in history drops the user into the place in the schedule where they left off, but that behavior is certainly up for discussion.

**Test Cases**
Clicking on days in the schedule should change the location hash in the address bar, and moving back and forward in browser history should load the schedule for the most recently accessed day.