### PR TITLE
Fix pdf localization check

### DIFF
--- a/src/views/cards/cards.jsx
+++ b/src/views/cards/cards.jsx
@@ -11,6 +11,12 @@ require('./cards.scss');
 
 var Cards = injectIntl(React.createClass({
     type: 'Cards',
+    pdfLocaleMismatch: function (locale, pdf, englishPdf) {
+        if (pdf === englishPdf && locale.indexOf('en') !== 0) {
+            return true;
+        }
+        return false;
+    },
     render: function () {
         var locale = this.props.intl.locale || 'en';
         var formatMessage = this.props.intl.formatMessage;
@@ -51,8 +57,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.starterLink'] === englishLinks['cards.starterLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.starterLink'],
+                                            englishLinks['cards.starterLink']
+                                        )
                                     ) ? [
                                         <span> <FormattedMessage id='cards.english' /></span>
                                     ] : []}
@@ -67,8 +76,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.nameLink'] === englishLinks['cards.nameLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.nameLink'],
+                                            englishLinks['cards.nameLink']
+                                        )
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -83,8 +95,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.pongLink'] === englishLinks['cards.pongLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.pongLink'],
+                                            englishLinks['cards.pongLink']
+                                        )
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -101,8 +116,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.storyLink'] === englishLinks['cards.storyLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.storyLink'],
+                                            englishLinks['cards.storyLink']
+                                        )
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -117,8 +135,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.danceLink'] === englishLinks['cards.danceLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.danceLink'],
+                                            englishLinks['cards.danceLink']
+                                        )
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -133,8 +154,11 @@ var Cards = injectIntl(React.createClass({
                                     <img src="/svgs/pdf-icon-ui-blue.svg" alt="" className='pdf-icon' />
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
-                                        formattedLinks['cards.hideLink'] === englishLinks['cards.hideLink'] &&
-                                        locale.indexOf('en') === -1
+                                        this.pdfLocaleMismatch(
+                                            locale,
+                                            formattedLinks['cards.hideLink'],
+                                            englishLinks['cards.hideLink']
+                                        )
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}

--- a/src/views/cards/cards.jsx
+++ b/src/views/cards/cards.jsx
@@ -12,7 +12,7 @@ require('./cards.scss');
 var Cards = injectIntl(React.createClass({
     type: 'Cards',
     render: function () {
-        var locale = window._locale || 'en';
+        var locale = this.props.intl.locale || 'en';
         var formatMessage = this.props.intl.formatMessage;
         var englishLinks = {
             'cards.starterLink': '//scratch.mit.edu/scratchr2/static/pdfs/help/Scratch2Cards.pdf',
@@ -52,7 +52,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.starterLink'] === englishLinks['cards.starterLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> <FormattedMessage id='cards.english' /></span>
                                     ] : []}
@@ -68,7 +68,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.nameLink'] === englishLinks['cards.nameLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -84,7 +84,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.pongLink'] === englishLinks['cards.pongLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -102,7 +102,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.storyLink'] === englishLinks['cards.storyLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -118,7 +118,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.danceLink'] === englishLinks['cards.danceLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}
@@ -134,7 +134,7 @@ var Cards = injectIntl(React.createClass({
                                     <FormattedMessage id='cards.viewCard' />
                                     {(
                                         formattedLinks['cards.hideLink'] === englishLinks['cards.hideLink'] &&
-                                        locale !== 'en'
+                                        locale.indexOf('en') === -1
                                     ) ? [
                                         <span> (<FormattedMessage id='cards.english' />)</span>
                                     ] : []}


### PR DESCRIPTION
It was adding the `(English)` suffix no matter what before, when it should do so only if the cards are only available in english, and the language is not english. This fixes it by getting the locale from props, and also by making the conditional check a bit more safe by using `indexOf` instead of a complete equal check.

### Test Cases ###
* Visit `/info/cards` in English. No links should have the `(English)` suffix anymore
* Visit `/info/cards` in Spanish. The first link should not have the suffix, but the others should.