### PR TITLE
Fix GH-395 and GH-396: Add initial state to splash header and navbar

### DIFF
--- a/src/components/adminpanel/adminpanel.jsx
+++ b/src/components/adminpanel/adminpanel.jsx
@@ -19,8 +19,8 @@ var AdminPanel = React.createClass({
     render: function () {
         // make sure user is present before checking if they're an admin. Don't show anything if user not an admin.
         var showAdmin = false;
-        if (this.props.session.results.user) {
-            showAdmin = this.props.session.results.permissions.admin;
+        if (this.props.session.session.user) {
+            showAdmin = this.props.session.session.permissions.admin;
         }
 
         if (!showAdmin) return false;

--- a/src/components/adminpanel/adminpanel.jsx
+++ b/src/components/adminpanel/adminpanel.jsx
@@ -19,8 +19,8 @@ var AdminPanel = React.createClass({
     render: function () {
         // make sure user is present before checking if they're an admin. Don't show anything if user not an admin.
         var showAdmin = false;
-        if (this.props.session.user) {
-            showAdmin = this.props.session.permissions.admin;
+        if (this.props.session.results.user) {
+            showAdmin = this.props.session.results.permissions.admin;
         }
 
         if (!showAdmin) return false;

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -225,7 +225,7 @@ var Navigation = React.createClass({
                             <Input type="hidden" name="sort_by" value="datetime_shared" />
                         </form>
                     </li>
-                    {this.props.session.status == sessionActions.Status.FETCHED ? (
+                    {this.props.session.status === sessionActions.Status.FETCHED ? (
                         this.props.session.results.user ? [
                             <li className="link right messages" key="messages">
                                 <a

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -44,19 +44,19 @@ var Navigation = React.createClass({
         };
     },
     componentDidMount: function () {
-        if (this.props.session.results.user) {
+        if (this.props.session.session.user) {
             this.getMessageCount();
             var intervalId = setInterval(this.getMessageCount, 120000); // check for new messages every 2 mins.
             this.setState({'messageCountIntervalId': intervalId});
         }
     },
     componentDidUpdate: function (prevProps) {
-        if (prevProps.session.results.user != this.props.session.results.user) {
+        if (prevProps.session.session.user != this.props.session.session.user) {
             this.setState({
                 'loginOpen': false,
                 'accountNavOpen': false
             });
-            if (this.props.session.results.user) {
+            if (this.props.session.session.user) {
                 this.getMessageCount();
                 var intervalId = setInterval(this.getMessageCount, 120000);
                 this.setState({'messageCountIntervalId': intervalId});
@@ -81,13 +81,13 @@ var Navigation = React.createClass({
         }
     },
     getProfileUrl: function () {
-        if (!this.props.session.results.user) return;
-        return '/users/' + this.props.session.results.user.username + '/';
+        if (!this.props.session.session.user) return;
+        return '/users/' + this.props.session.session.user.username + '/';
     },
     getMessageCount: function () {
         this.api({
             method: 'get',
-            uri: '/users/' + this.props.session.results.user.username + '/messages/count'
+            uri: '/users/' + this.props.session.session.user.username + '/messages/count'
         }, function (err, body) {
             if (err) return this.setState({'unreadMessageCount': 0});
             if (body) {
@@ -175,14 +175,14 @@ var Navigation = React.createClass({
     },
     render: function () {
         var classes = classNames({
-            'logged-in': this.props.session.results.user
+            'logged-in': this.props.session.session.user
         });
         var messageClasses = classNames({
             'message-count': true,
             'show': this.state.unreadMessageCount > 0
         });
         var formatMessage = this.props.intl.formatMessage;
-        var createLink = this.props.session.results.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
+        var createLink = this.props.session.session.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
         return (
             <NavigationBox className={classes}>
                 <ul>
@@ -226,7 +226,7 @@ var Navigation = React.createClass({
                         </form>
                     </li>
                     {this.props.session.status === sessionActions.Status.FETCHED ? (
-                        this.props.session.results.user ? [
+                        this.props.session.session.user ? [
                             <li className="link right messages" key="messages">
                                 <a
                                     href="/messages/"
@@ -246,8 +246,8 @@ var Navigation = React.createClass({
                             </li>,
                             <li className="link right account-nav" key="account-nav">
                                 <a className="user-info" href="#" onClick={this.handleAccountNavClick}>
-                                    <Avatar src={this.props.session.results.user.thumbnailUrl} alt="" />
-                                    {this.props.session.results.user.username}
+                                    <Avatar src={this.props.session.session.user.thumbnailUrl} alt="" />
+                                    {this.props.session.session.user.username}
                                 </a>
                                 <Dropdown
                                         as="ul"
@@ -263,16 +263,16 @@ var Navigation = React.createClass({
                                             <FormattedMessage id="general.myStuff" />
                                         </a>
                                     </li>
-                                    {this.props.session.results.permissions.educator ? [
+                                    {this.props.session.session.permissions.educator ? [
                                         <li>
                                             <a href="/educators/classes/">
                                                 <FormattedMessage id="general.myClasses" />
                                             </a>
                                         </li>
                                     ] : []}
-                                    {this.props.session.results.permissions.student ? [
+                                    {this.props.session.session.permissions.student ? [
                                         <li>
-                                            <a href={'/classes/' + this.props.session.results.user.classroomId + '/'}>
+                                            <a href={'/classes/' + this.props.session.session.user.classroomId + '/'}>
                                                 <FormattedMessage id="general.myClass" />
                                             </a>
                                         </li>

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -44,19 +44,19 @@ var Navigation = React.createClass({
         };
     },
     componentDidMount: function () {
-        if (this.props.session.user) {
+        if (this.props.session.results.user) {
             this.getMessageCount();
             var intervalId = setInterval(this.getMessageCount, 120000); // check for new messages every 2 mins.
             this.setState({'messageCountIntervalId': intervalId});
         }
     },
     componentDidUpdate: function (prevProps) {
-        if (prevProps.session.user != this.props.session.user) {
+        if (prevProps.session.results.user != this.props.session.results.user) {
             this.setState({
                 'loginOpen': false,
                 'accountNavOpen': false
             });
-            if (this.props.session.user) {
+            if (this.props.session.results.user) {
                 this.getMessageCount();
                 var intervalId = setInterval(this.getMessageCount, 120000);
                 this.setState({'messageCountIntervalId': intervalId});
@@ -81,13 +81,13 @@ var Navigation = React.createClass({
         }
     },
     getProfileUrl: function () {
-        if (!this.props.session.user) return;
-        return '/users/' + this.props.session.user.username + '/';
+        if (!this.props.session.results.user) return;
+        return '/users/' + this.props.session.results.user.username + '/';
     },
     getMessageCount: function () {
         this.api({
             method: 'get',
-            uri: '/users/' + this.props.session.user.username + '/messages/count'
+            uri: '/users/' + this.props.session.results.user.username + '/messages/count'
         }, function (err, body) {
             if (err) return this.setState({'unreadMessageCount': 0});
             if (body) {
@@ -175,14 +175,14 @@ var Navigation = React.createClass({
     },
     render: function () {
         var classes = classNames({
-            'logged-in': this.props.session.user
+            'logged-in': this.props.session.results.user
         });
         var messageClasses = classNames({
             'message-count': true,
             'show': this.state.unreadMessageCount > 0
         });
         var formatMessage = this.props.intl.formatMessage;
-        var createLink = this.props.session.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
+        var createLink = this.props.session.results.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
         return (
             <NavigationBox className={classes}>
                 <ul>
@@ -225,8 +225,8 @@ var Navigation = React.createClass({
                             <Input type="hidden" name="sort_by" value="datetime_shared" />
                         </form>
                     </li>
-                    {this.props.session.loaded ? (
-                        this.props.session.user ? [
+                    {this.props.session.status == sessionActions.Status.FETCHED ? (
+                        this.props.session.results.user ? [
                             <li className="link right messages" key="messages">
                                 <a
                                     href="/messages/"
@@ -246,8 +246,8 @@ var Navigation = React.createClass({
                             </li>,
                             <li className="link right account-nav" key="account-nav">
                                 <a className="user-info" href="#" onClick={this.handleAccountNavClick}>
-                                    <Avatar src={this.props.session.user.thumbnailUrl} alt="" />
-                                    {this.props.session.user.username}
+                                    <Avatar src={this.props.session.results.user.thumbnailUrl} alt="" />
+                                    {this.props.session.results.user.username}
                                 </a>
                                 <Dropdown
                                         as="ul"
@@ -263,16 +263,16 @@ var Navigation = React.createClass({
                                             <FormattedMessage id="general.myStuff" />
                                         </a>
                                     </li>
-                                    {this.props.session.permissions.educator ? [
+                                    {this.props.session.results.permissions.educator ? [
                                         <li>
                                             <a href="/educators/classes/">
                                                 <FormattedMessage id="general.myClasses" />
                                             </a>
                                         </li>
                                     ] : []}
-                                    {this.props.session.permissions.student ? [
+                                    {this.props.session.results.permissions.student ? [
                                         <li>
-                                            <a href={'/classes/' + this.props.session.user.classroomId + '/'}>
+                                            <a href={'/classes/' + this.props.session.results.user.classroomId + '/'}>
                                                 <FormattedMessage id="general.myClass" />
                                             </a>
                                         </li>

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -225,99 +225,101 @@ var Navigation = React.createClass({
                             <Input type="hidden" name="sort_by" value="datetime_shared" />
                         </form>
                     </li>
-                    {this.props.session.user ? [
-                        <li className="link right messages" key="messages">
-                            <a
-                                href="/messages/"
-                                title={formatMessage({id: 'general.messages'})}>
+                    {this.props.session.loaded ? (
+                        this.props.session.user ? [
+                            <li className="link right messages" key="messages">
+                                <a
+                                    href="/messages/"
+                                    title={formatMessage({id: 'general.messages'})}>
 
-                                <span className={messageClasses}>{this.state.unreadMessageCount}</span>
-                                <FormattedMessage id="general.messages" />
-                            </a>
-                        </li>,
-                        <li className="link right mystuff" key="mystuff">
-                            <a
-                                href="/mystuff/"
-                                title={formatMessage({id: 'general.myStuff'})}>
+                                    <span className={messageClasses}>{this.state.unreadMessageCount}</span>
+                                    <FormattedMessage id="general.messages" />
+                                </a>
+                            </li>,
+                            <li className="link right mystuff" key="mystuff">
+                                <a
+                                    href="/mystuff/"
+                                    title={formatMessage({id: 'general.myStuff'})}>
 
-                                <FormattedMessage id="general.myStuff" />
-                            </a>
-                        </li>,
-                        <li className="link right account-nav" key="account-nav">
-                            <a className="user-info" href="#" onClick={this.handleAccountNavClick}>
-                                <Avatar src={this.props.session.user.thumbnailUrl} alt="" />
-                                {this.props.session.user.username}
-                            </a>
-                            <Dropdown
-                                    as="ul"
-                                    isOpen={this.state.accountNavOpen}
-                                    onRequestClose={this.closeAccountNav}>
-                                <li>
-                                    <a href={this.getProfileUrl()}>
-                                        <FormattedMessage id="general.profile" />
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="/mystuff/">
-                                        <FormattedMessage id="general.myStuff" />
-                                    </a>
-                                </li>
-                                {this.props.session.permissions.educator ? [
+                                    <FormattedMessage id="general.myStuff" />
+                                </a>
+                            </li>,
+                            <li className="link right account-nav" key="account-nav">
+                                <a className="user-info" href="#" onClick={this.handleAccountNavClick}>
+                                    <Avatar src={this.props.session.user.thumbnailUrl} alt="" />
+                                    {this.props.session.user.username}
+                                </a>
+                                <Dropdown
+                                        as="ul"
+                                        isOpen={this.state.accountNavOpen}
+                                        onRequestClose={this.closeAccountNav}>
                                     <li>
-                                        <a href="/educators/classes/">
-                                            <FormattedMessage id="general.myClasses" />
+                                        <a href={this.getProfileUrl()}>
+                                            <FormattedMessage id="general.profile" />
                                         </a>
                                     </li>
-                                ] : []}
-                                {this.props.session.permissions.student ? [
                                     <li>
-                                        <a href={'/classes/' + this.props.session.user.classroomId + '/'}>
-                                            <FormattedMessage id="general.myClass" />
+                                        <a href="/mystuff/">
+                                            <FormattedMessage id="general.myStuff" />
                                         </a>
                                     </li>
-                                ] : []}
-                                <li>
-                                    <a href="/accounts/settings/">
-                                        <FormattedMessage id="general.accountSettings" />
-                                    </a>
-                                </li>
-                                <li className="divider">
-                                    <a href="#" onClick={this.handleLogOut}>
-                                        <FormattedMessage id="navigation.signOut" />
-                                    </a>
-                                </li>
-                            </Dropdown>
-                        </li>
-                    ] : [
-                        <li className="link right join" key="join">
-                            <a href="#" onClick={this.handleJoinClick}>
-                                <FormattedMessage id="general.joinScratch" />
-                            </a>
-                        </li>,
-                        <Registration
-                                key="registration"
-                                isOpen={this.state.registrationOpen}
-                                onRequestClose={this.closeRegistration}
-                                onRegistrationDone={this.completeRegistration} />,
-                        <li className="link right login-item" key="login">
-                            <a
-                                href="#"
-                                onClick={this.handleLoginClick}
-                                className="ignore-react-onclickoutside"
-                                key="login-link">
-                                    <FormattedMessage id="general.signIn" />
-                           </a>
-                            <Dropdown
-                                    className="login-dropdown with-arrow"
-                                    isOpen={this.state.loginOpen}
-                                    onRequestClose={this.closeLogin}
-                                    key="login-dropdown">
-                                <Login
-                                    onLogIn={this.handleLogIn}
-                                    error={this.state.loginError} />
-                            </Dropdown>
-                        </li>
-                    ]}
+                                    {this.props.session.permissions.educator ? [
+                                        <li>
+                                            <a href="/educators/classes/">
+                                                <FormattedMessage id="general.myClasses" />
+                                            </a>
+                                        </li>
+                                    ] : []}
+                                    {this.props.session.permissions.student ? [
+                                        <li>
+                                            <a href={'/classes/' + this.props.session.user.classroomId + '/'}>
+                                                <FormattedMessage id="general.myClass" />
+                                            </a>
+                                        </li>
+                                    ] : []}
+                                    <li>
+                                        <a href="/accounts/settings/">
+                                            <FormattedMessage id="general.accountSettings" />
+                                        </a>
+                                    </li>
+                                    <li className="divider">
+                                        <a href="#" onClick={this.handleLogOut}>
+                                            <FormattedMessage id="navigation.signOut" />
+                                        </a>
+                                    </li>
+                                </Dropdown>
+                            </li>
+                        ] : [
+                            <li className="link right join" key="join">
+                                <a href="#" onClick={this.handleJoinClick}>
+                                    <FormattedMessage id="general.joinScratch" />
+                                </a>
+                            </li>,
+                            <Registration
+                                    key="registration"
+                                    isOpen={this.state.registrationOpen}
+                                    onRequestClose={this.closeRegistration}
+                                    onRegistrationDone={this.completeRegistration} />,
+                            <li className="link right login-item" key="login">
+                                <a
+                                    href="#"
+                                    onClick={this.handleLoginClick}
+                                    className="ignore-react-onclickoutside"
+                                    key="login-link">
+                                        <FormattedMessage id="general.signIn" />
+                               </a>
+                                <Dropdown
+                                        className="login-dropdown with-arrow"
+                                        isOpen={this.state.loginOpen}
+                                        onRequestClose={this.closeLogin}
+                                        key="login-dropdown">
+                                    <Login
+                                        onLogIn={this.handleLogIn}
+                                        error={this.state.loginError} />
+                                </Dropdown>
+                            </li>
+                        ]) : [
+                        ]}
                 </ul>
                 <Modal isOpen={this.state.canceledDeletionOpen}
                        onRequestClose={this.closeCanceledDeletion}

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -17,7 +17,7 @@ module.exports.Status = keyMirror({
 });
 
 module.exports.getInitialState = function (){
-    return {'status': module.exports.Status.NOT_FETCHED, 'results':{}};
+    return {status: module.exports.Status.NOT_FETCHED, results:{}};
 };
 
 module.exports.sessionReducer = function (state, action) {
@@ -27,9 +27,9 @@ module.exports.sessionReducer = function (state, action) {
     }
     switch (action.type) {
     case Types.SET_SESSION:
-        return defaultsDeep({'results': action.session}, state);
+        return defaultsDeep({results: action.session}, state);
     case Types.SET_STATUS:
-        return defaultsDeep({'status': action.status}, state);
+        return defaultsDeep({status: action.status}, state);
     case Types.SET_SESSION_ERROR:
         // TODO: do something with action.error
         return state;

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -32,6 +32,7 @@ module.exports.setSessionError = function (error) {
 };
 
 module.exports.setSession = function (session) {
+    session.loaded = true;
     return {
         type: Types.SET_SESSION,
         session: session

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -7,7 +7,7 @@ var tokenActions = require('./token.js');
 var Types = keyMirror({
     SET_SESSION: null,
     SET_SESSION_ERROR: null,
-    SET_STATUS: null,
+    SET_STATUS: null
 });
 
 module.exports.Status = keyMirror({
@@ -27,9 +27,9 @@ module.exports.sessionReducer = function (state, action) {
     }
     switch (action.type) {
     case Types.SET_SESSION:
-        return defaultsDeep({"results": action.session}, state);
+        return defaultsDeep({'results': action.session}, state);
     case Types.SET_STATUS:
-        return defaultsDeep({"status": action.status}, state)
+        return defaultsDeep({'status': action.status}, state);
     case Types.SET_SESSION_ERROR:
         // TODO: do something with action.error
         return state;
@@ -52,12 +52,12 @@ module.exports.setSession = function (results) {
     };
 };
 
-module.exports.setStatus = function(status){
+module.exports.setStatus = function (status){
     return {
         type: Types.SET_STATUS,
         status: status
     };
-}
+};
 
 module.exports.refreshSession = function () {
     return function (dispatch) {

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -17,7 +17,7 @@ module.exports.Status = keyMirror({
 });
 
 module.exports.getInitialState = function (){
-    return {status: module.exports.Status.NOT_FETCHED, results:{}};
+    return {status: module.exports.Status.NOT_FETCHED, session:{}};
 };
 
 module.exports.sessionReducer = function (state, action) {

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -27,7 +27,7 @@ module.exports.sessionReducer = function (state, action) {
     }
     switch (action.type) {
     case Types.SET_SESSION:
-        return defaultsDeep({results: action.session}, state);
+        return defaultsDeep({session: action.session}, state);
     case Types.SET_STATUS:
         return defaultsDeep({status: action.status}, state);
     case Types.SET_SESSION_ERROR:
@@ -45,10 +45,10 @@ module.exports.setSessionError = function (error) {
     };
 };
 
-module.exports.setSession = function (results) {
+module.exports.setSession = function (session) {
     return {
         type: Types.SET_SESSION,
-        session: results
+        session: session
     };
 };
 

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -373,7 +373,7 @@ var Splash = injectIntl(React.createClass({
                 ] : []}
                 <CNBanner />
                 <div key="inner" className="inner">
-                    {this.props.session.status == sessionActions.Status.FETCHED ? (
+                    {this.props.session.status === sessionActions.Status.FETCHED ? (
                         this.props.session.results.user ? [
                             <div key="header" className="splash-header">
                                 {this.shouldShowWelcome() ? [

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -373,7 +373,7 @@ var Splash = injectIntl(React.createClass({
                 ] : []}
                 <CNBanner />
                 <div key="inner" className="inner">
-                    {this.props.session.user ? (
+                    {this.props.session.loaded ? (
                         this.props.session.user ? [
                             <div key="header" className="splash-header">
                                 {this.shouldShowWelcome() ? [
@@ -387,7 +387,7 @@ var Splash = injectIntl(React.createClass({
                             </div>
                         ] : [
                             <Intro projectCount={this.state.projectCount} messages={messages} key="intro"/>
-                        ]) : ()
+                        ]) : []
                     }
 
                     {featured}

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -45,8 +45,8 @@ var Splash = injectIntl(React.createClass({
         };
     },
     componentDidUpdate: function (prevProps) {
-        if (this.props.session.user != prevProps.session.user) {
-            if (this.props.session.user) {
+        if (this.props.session.results.user != prevProps.session.results.user) {
+            if (this.props.session.results.user) {
                 this.getActivity();
                 this.getFeaturedCustom();
                 this.getNews();
@@ -65,7 +65,7 @@ var Splash = injectIntl(React.createClass({
     },
     componentDidMount: function () {
         this.getFeaturedGlobal();
-        if (this.props.session.user) {
+        if (this.props.session.results.user) {
             this.getActivity();
             this.getFeaturedCustom();
             this.getNews();
@@ -91,7 +91,7 @@ var Splash = injectIntl(React.createClass({
     },
     getActivity: function () {
         this.api({
-            uri: '/proxy/users/' + this.props.session.user.username + '/activity?limit=5'
+            uri: '/proxy/users/' + this.props.session.results.user.username + '/activity?limit=5'
         }, function (err, body) {
             if (!err) this.setState({activity: body});
         }.bind(this));
@@ -105,7 +105,7 @@ var Splash = injectIntl(React.createClass({
     },
     getFeaturedCustom: function () {
         this.api({
-            uri: '/proxy/users/' + this.props.session.user.id + '/featured'
+            uri: '/proxy/users/' + this.props.session.results.user.id + '/featured'
         }, function (err, body) {
             if (!err) this.setState({featuredCustom: body});
         }.bind(this));
@@ -172,16 +172,16 @@ var Splash = injectIntl(React.createClass({
         });
     },
     shouldShowWelcome: function () {
-        if (!this.props.session.user || !this.props.session.flags.show_welcome) return false;
+        if (!this.props.session.results.user || !this.props.session.results.flags.show_welcome) return false;
         return (
-            new Date(this.props.session.user.dateJoined) >
+            new Date(this.props.session.results.user.dateJoined) >
             new Date(new Date - 2*7*24*60*60*1000) // Two weeks ago
         );
     },
     shouldShowEmailConfirmation: function () {
         return (
-            this.props.session.user && this.props.session.flags.has_outstanding_email_confirmation &&
-            this.props.session.flags.confirm_email_banner);
+            this.props.session.results.user && this.props.session.results.flags.has_outstanding_email_confirmation &&
+            this.props.session.results.flags.confirm_email_banner);
     },
     renderHomepageRows: function () {
         var formatMessage = this.props.intl.formatMessage;
@@ -240,7 +240,7 @@ var Splash = injectIntl(React.createClass({
             );
         }
 
-        if (this.props.session.user &&
+        if (this.props.session.results.user &&
             this.state.featuredGlobal.community_newest_projects &&
             this.state.featuredGlobal.community_newest_projects.length > 0) {
 
@@ -373,8 +373,8 @@ var Splash = injectIntl(React.createClass({
                 ] : []}
                 <CNBanner />
                 <div key="inner" className="inner">
-                    {this.props.session.loaded ? (
-                        this.props.session.user ? [
+                    {this.props.session.status == sessionActions.Status.FETCHED ? (
+                        this.props.session.results.user ? [
                             <div key="header" className="splash-header">
                                 {this.shouldShowWelcome() ? [
                                     <Welcome key="welcome"

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -45,8 +45,8 @@ var Splash = injectIntl(React.createClass({
         };
     },
     componentDidUpdate: function (prevProps) {
-        if (this.props.session.results.user != prevProps.session.results.user) {
-            if (this.props.session.results.user) {
+        if (this.props.session.session.user != prevProps.session.session.user) {
+            if (this.props.session.session.user) {
                 this.getActivity();
                 this.getFeaturedCustom();
                 this.getNews();
@@ -65,7 +65,7 @@ var Splash = injectIntl(React.createClass({
     },
     componentDidMount: function () {
         this.getFeaturedGlobal();
-        if (this.props.session.results.user) {
+        if (this.props.session.session.user) {
             this.getActivity();
             this.getFeaturedCustom();
             this.getNews();
@@ -91,7 +91,7 @@ var Splash = injectIntl(React.createClass({
     },
     getActivity: function () {
         this.api({
-            uri: '/proxy/users/' + this.props.session.results.user.username + '/activity?limit=5'
+            uri: '/proxy/users/' + this.props.session.session.user.username + '/activity?limit=5'
         }, function (err, body) {
             if (!err) this.setState({activity: body});
         }.bind(this));
@@ -105,7 +105,7 @@ var Splash = injectIntl(React.createClass({
     },
     getFeaturedCustom: function () {
         this.api({
-            uri: '/proxy/users/' + this.props.session.results.user.id + '/featured'
+            uri: '/proxy/users/' + this.props.session.session.user.id + '/featured'
         }, function (err, body) {
             if (!err) this.setState({featuredCustom: body});
         }.bind(this));
@@ -172,16 +172,16 @@ var Splash = injectIntl(React.createClass({
         });
     },
     shouldShowWelcome: function () {
-        if (!this.props.session.results.user || !this.props.session.results.flags.show_welcome) return false;
+        if (!this.props.session.session.user || !this.props.session.session.flags.show_welcome) return false;
         return (
-            new Date(this.props.session.results.user.dateJoined) >
+            new Date(this.props.session.session.user.dateJoined) >
             new Date(new Date - 2*7*24*60*60*1000) // Two weeks ago
         );
     },
     shouldShowEmailConfirmation: function () {
         return (
-            this.props.session.results.user && this.props.session.results.flags.has_outstanding_email_confirmation &&
-            this.props.session.results.flags.confirm_email_banner);
+            this.props.session.session.user && this.props.session.session.flags.has_outstanding_email_confirmation &&
+            this.props.session.session.flags.confirm_email_banner);
     },
     renderHomepageRows: function () {
         var formatMessage = this.props.intl.formatMessage;
@@ -240,7 +240,7 @@ var Splash = injectIntl(React.createClass({
             );
         }
 
-        if (this.props.session.results.user &&
+        if (this.props.session.session.user &&
             this.state.featuredGlobal.community_newest_projects &&
             this.state.featuredGlobal.community_newest_projects.length > 0) {
 
@@ -374,7 +374,7 @@ var Splash = injectIntl(React.createClass({
                 <CNBanner />
                 <div key="inner" className="inner">
                     {this.props.session.status === sessionActions.Status.FETCHED ? (
-                        this.props.session.results.user ? [
+                        this.props.session.session.user ? [
                             <div key="header" className="splash-header">
                                 {this.shouldShowWelcome() ? [
                                     <Welcome key="welcome"

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -206,7 +206,7 @@ var Splash = injectIntl(React.createClass({
 
         if (this.state.featuredGlobal.curator_top_projects &&
             this.state.featuredGlobal.curator_top_projects.length > 4) {
-            
+
             rows.push(
                 <Box
                         key="curator_top_projects"
@@ -223,7 +223,7 @@ var Splash = injectIntl(React.createClass({
 
         if (this.state.featuredGlobal.scratch_design_studio &&
             this.state.featuredGlobal.scratch_design_studio.length > 4) {
-            
+
             rows.push(
                 <Box
                         key="scratch_design_studio"
@@ -243,7 +243,7 @@ var Splash = injectIntl(React.createClass({
         if (this.props.session.user &&
             this.state.featuredGlobal.community_newest_projects &&
             this.state.featuredGlobal.community_newest_projects.length > 0) {
-            
+
             rows.push(
                 <Box
                         title={
@@ -259,14 +259,14 @@ var Splash = injectIntl(React.createClass({
 
         if (this.state.featuredCustom.custom_projects_by_following &&
             this.state.featuredCustom.custom_projects_by_following.length > 0) {
-            
+
             rows.push(
                 <Box title={
                             formatMessage({
                                 id: 'splash.projectsByScratchersFollowing',
                                 defaultMessage: 'Projects by Scratchers I\'m Following'})}
                      key="custom_projects_by_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_by_following} />
                 </Box>
             );
@@ -280,7 +280,7 @@ var Splash = injectIntl(React.createClass({
                                 id: 'splash.projectsLovedByScratchersFollowing',
                                 defaultMessage: 'Projects Loved by Scratchers I\'m Following'})}
                      key="custom_projects_loved_by_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_loved_by_following} />
                 </Box>
             );
@@ -288,14 +288,14 @@ var Splash = injectIntl(React.createClass({
 
         if (this.state.featuredCustom.custom_projects_in_studios_following &&
             this.state.featuredCustom.custom_projects_in_studios_following.length > 0) {
-            
+
             rows.push(
                 <Box title={
                             formatMessage({
                                 id:'splash.projectsInStudiosFollowing',
                                 defaultMessage: 'Projects in Studios I\'m Following'})}
                      key="custom_projects_in_studios_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_in_studios_following} />
                 </Box>
             );
@@ -307,7 +307,7 @@ var Splash = injectIntl(React.createClass({
                             id: 'splash.communityRemixing',
                             defaultMessage: 'What the Community is Remixing' })}
                  key="community_most_remixed_projects">
-                
+
                 <Carousel items={this.state.featuredGlobal.community_most_remixed_projects} showRemixes={true} />
             </Box>,
             <Box title={
@@ -315,7 +315,7 @@ var Splash = injectIntl(React.createClass({
                             id: 'splash.communityLoving',
                             defaultMessage: 'What the Community is Loving' })}
                  key="community_most_loved_projects">
-                
+
                 <Carousel items={this.state.featuredGlobal.community_most_loved_projects} showLoves={true} />
             </Box>
         );
@@ -373,20 +373,22 @@ var Splash = injectIntl(React.createClass({
                 ] : []}
                 <CNBanner />
                 <div key="inner" className="inner">
-                    {this.props.session.user ? [
-                        <div key="header" className="splash-header">
-                            {this.shouldShowWelcome() ? [
-                                <Welcome key="welcome"
-                                         onDismiss={this.handleDismiss.bind(this, 'welcome')}
-                                         messages={messages} />
-                            ] : [
-                                <Activity key="activity" items={this.state.activity} />
-                            ]}
-                            <News items={this.state.news} messages={messages} />
-                        </div>
-                    ] : [
-                        <Intro projectCount={this.state.projectCount} messages={messages} key="intro"/>
-                    ]}
+                    {this.props.session.user ? (
+                        this.props.session.user ? [
+                            <div key="header" className="splash-header">
+                                {this.shouldShowWelcome() ? [
+                                    <Welcome key="welcome"
+                                             onDismiss={this.handleDismiss.bind(this, 'welcome')}
+                                             messages={messages} />
+                                ] : [
+                                    <Activity key="activity" items={this.state.activity} />
+                                ]}
+                                <News items={this.state.news} messages={messages} />
+                            </div>
+                        ] : [
+                            <Intro projectCount={this.state.projectCount} messages={messages} key="intro"/>
+                        ]) : ()
+                    }
 
                     {featured}
 


### PR DESCRIPTION
This PR adds a {'loaded':true} item to the session object when a session is successfully loaded. This allows the navbar and splash header to have different states for 1) logged in users, 2) logged out users, and 3) not fully loaded pages. 

Fixes #395 and #396.

For the design, I've replicated the scratchr2 navbar design (search field is farthest element on the right side), and omitted the welcome element or news elements from the splash page.

Labeled as needs-discussion in case the way I'm modifying the session object isn't Kosher.