### PR TITLE
Use eval for webpack devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ routes.forEach(function (route) {
 // Config
 module.exports = {
     entry: entry,
-    devtool: 'source-map',
+    devtool: 'eval',
     output: {
         path: path.resolve(__dirname, 'build'),
         filename: 'js/[name].bundle.js'


### PR DESCRIPTION
The source-map devtool adds a lot of time to startup, and eval works just as well for debugging.