### PR TITLE
Fix GH-548: Sign out should take effect before reload

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -1,5 +1,5 @@
 var keyMirror = require('keymirror');
-var defaultsDeep = require('lodash.defaultsdeep');
+var defaults = require('lodash.defaults');
 
 var api = require('../mixins/api.jsx').api;
 var tokenActions = require('./token.js');
@@ -27,9 +27,9 @@ module.exports.sessionReducer = function (state, action) {
     }
     switch (action.type) {
     case Types.SET_SESSION:
-        return defaultsDeep({session: action.session}, state);
+        return defaults({session: action.session}, state);
     case Types.SET_STATUS:
-        return defaultsDeep({status: action.status}, state);
+        return defaults({status: action.status}, state);
     case Types.SET_SESSION_ERROR:
         // TODO: do something with action.error
         return state;
@@ -74,7 +74,7 @@ module.exports.refreshSession = function () {
                 } else {
                     dispatch(tokenActions.getToken());
                     dispatch(module.exports.setSession(body));
-                    dispatch(module.exports.setStatus(module.exports.Status.FETCHED));
+                    dispatch(module.exports.setStatus(module.exports.Status.FETCHED)); //not firing?
                     return;
                 }
             }

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -74,7 +74,7 @@ module.exports.refreshSession = function () {
                 } else {
                     dispatch(tokenActions.getToken());
                     dispatch(module.exports.setSession(body));
-                    dispatch(module.exports.setStatus(module.exports.Status.FETCHED)); //not firing?
+                    dispatch(module.exports.setStatus(module.exports.Status.FETCHED));
                     return;
                 }
             }


### PR DESCRIPTION
This PR resolves #548 by using lodash.defaults instead of lodash.defaultsDeep.

The reason for this is that using defaultsDeep doesn't replace a non-empty object with an empty object, which is necessary for the logged-in -> logged-out state change.