### PR TITLE
Fix gh-555: Squished News Icons

### DIFF
--- a/src/views/splash/splash.scss
+++ b/src/views/splash/splash.scss
@@ -24,7 +24,10 @@
 
         .news {
             width: 40%;
-            flex-shrink: 0;
+            
+            img {
+                flex-shrink: 0;
+            }
         }
     }
 

--- a/src/views/splash/splash.scss
+++ b/src/views/splash/splash.scss
@@ -24,6 +24,7 @@
 
         .news {
             width: 40%;
+            flex-shrink: 0;
         }
     }
 


### PR DESCRIPTION
Should fix #555 
@Choco31415 came up with the fix and tested it in Safari, I have tested it locally on Chrome 51.