### PR TITLE
Bugfix: shorten fastly condition

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -44,9 +44,13 @@ var getStaticPaths = function (pathToStatic) {
  * the express route and a static view file associated with the route
  */
 var getViewPaths = function (routes) {
-    return routes.map(function (route) {
-        return route.pattern;
-    });
+    return routes.reduce(function (paths, route) {
+        var path = route.routeAlias || route.pattern;
+        if (paths.indexOf(path) === -1) {
+            paths.push(path);
+        }
+        return paths;
+    }, []);
 };
 
 /*

--- a/src/routes.json
+++ b/src/routes.json
@@ -26,12 +26,14 @@
     {
         "name": "explore",
         "pattern": "^/explore/:projects/:all/?$",
+        "routeAlias": "^/explore",
         "view": "explore/explore",
         "title": "Explore"
     },
     {
         "name": "search",
         "pattern": "^/search/:projects?$/?$",
+        "routeAlias": "^/search",
         "view": "search/search",
         "title": "Search"
     },
@@ -74,6 +76,7 @@
     {
         "name": "conference-index",
         "pattern": "^/conference/?$",
+        "routeAlias": "^/conference",
         "view": "conference/index/index",
         "title": "Scratch Conference",
         "viewportWidth": "device-width"
@@ -81,6 +84,7 @@
     {
         "name": "conference-plan",
         "pattern": "^/conference/plan/?$",
+        "routeAlias": "^/conference",
         "view": "conference/plan/plan",
         "title": "Plan Your Visit",
         "viewportWidth": "device-width"
@@ -88,6 +92,7 @@
     {
         "name": "conference-expectations",
         "pattern": "^/conference/expect/?$",
+        "routeAlias": "^/conference",
         "view": "conference/expect/expect",
         "title": "What to Expect",
         "viewportWidth": "device-width"
@@ -95,6 +100,7 @@
     {
         "name": "conference-schedule",
         "pattern": "^/conference/schedule/?$",
+        "routeAlias": "^/conference",
         "view": "conference/schedule/schedule",
         "title": "Conference Schedule",
         "viewportWidth": "device-width"
@@ -102,6 +108,7 @@
     {
         "name": "conference-details",
         "pattern": "^/conference/:id/details/?$",
+        "routeAlias": "^/conference",
         "view": "conference/details/details",
         "title": "Event Details",
         "viewportWidth": "device-width"

--- a/src/routes.json
+++ b/src/routes.json
@@ -12,12 +12,6 @@
         "title": "About"
     },
     {
-        "name": "components",
-        "pattern": "^/components/?$",
-        "view": "components/components",
-        "title": "Components"
-    },
-    {
         "name": "developers",
         "pattern": "^/developers/?$",
         "view": "developers/developers",


### PR DESCRIPTION
* removes `/components` from routes.json, as it's a dev-only route now
* generalizes the matching pattern for the following using a new object key, `routeAlias`, to group together patterns into singular checks:
  1. match all `^/explore` to www
  2. match all `^/search` to www
  3. match all `^/conference` to www

This of course means all old search pages, explore pages and conference pages will now be inaccessible if they're not in www, including old conference pages for 2015 and 2014 ( @sleggss please let me know if this is an issue).

Currently, the output of this is now fewer than 400 characters:
`'req.url~"^/css/|^/favicon.ico|^/images/|^/js/|^/pdfs/|^/routes.json|^/svgs/|^/version.txt|^/?$|^/about/?$|^/developers/?$|^/hoc/?$|^/explore|^/search|^/info/credits/?$|^/info/faq/?$|^/info/cards/?$|^/info/communityblocks-interviews/?$|^/jobs/?$|^/wedo/?$|^/conference|^/info/donate/?|^/DMCA/?$|^/community_guidelines/?$|^/privacy_policy/?$|^/terms_of_use/?$|^/\\?|^/[^/]*.html$"'`