### PR TITLE
Fix GH-574: Add explore redirects

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -31,6 +31,24 @@
         "title": "Explore"
     },
     {
+        "name": "explore-redirect",
+        "pattern": "^/explore/?$",
+        "routeAlias": "^/explore",
+        "redirect": "/explore/projects/all"
+    },
+    {
+        "name": "explore-projects-redirect",
+        "pattern": "^/explore/projects/?$",
+        "routeAlias": "^/explore",
+        "redirect": "/explore/projects/all"
+    },
+    {
+        "name": "explore-studios-redirect",
+        "pattern": "^/explore/studios/?$",
+        "routeAlias": "^/explore",
+        "redirect": "/explore/studios/all"
+    },
+    {
         "name": "search",
         "pattern": "^/search/:projects?$/?$",
         "routeAlias": "^/search",


### PR DESCRIPTION
for `/explore`, `/explore/projects` and `/explore/studios` to `/explore/<projects|studios>/all`.This fixes #574.

### Test Cases ###
* Go to `/explore`. It should redirect to `/explore/projects/all`.
* Go to `/explore/projects`. It should redirect to `/explore/projects/all`.
* Go to `/explore/studios`. It should redirect to `/explore/studios/all`.