### PR TITLE
Fix GH-554: Localize FAQ title

### DIFF
--- a/src/views/faq/faq.jsx
+++ b/src/views/faq/faq.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var injectIntl = require('react-intl').injectIntl;
 var FormattedHTMLMessage = require('react-intl').FormattedHTMLMessage;
 var FormattedMessage = require('react-intl').FormattedMessage;
 var render = require('../../lib/render.jsx');
@@ -6,11 +7,12 @@ var render = require('../../lib/render.jsx');
 var Page = require('../../components/page/www/page.jsx');
 var InformationPage = require('../../components/informationpage/informationpage.jsx');
 
-var Faq = React.createClass({
+var Faq = injectIntl(React.createClass({
     type: 'Faq',
     render: function () {
+        var formatMessage = this.props.intl.formatMessage;
         return (
-            <InformationPage title={'Frequently Asked Questions (FAQ)'}>
+            <InformationPage title={formatMessage({id: 'faq.title'})}>
                 <div className="inner info-inner">
                     <section id="about-scratch">
                         <span className="nav-spacer"></span>
@@ -190,6 +192,6 @@ var Faq = React.createClass({
             </InformationPage>
         );
     }
-});
+}));
 
 render(<Page><Faq /></Page>, document.getElementById('app'));

--- a/src/views/faq/l10n.json
+++ b/src/views/faq/l10n.json
@@ -1,4 +1,5 @@
 {
+    "faq.title":"Frequently Asked Questions (FAQ)",
     "faq.intro":"On this page, you’ll find answers to frequently asked questions about Scratch.",
     "faq.aboutTitle":"General Questions",
     "faq.privacyTitle":"Privacy Policy",


### PR DESCRIPTION
This PR localizes the FAQ title to replicate the current behavior on the Scratch site, resolving #554.

**Test cases**
- [ ] In the English locale, the FAQ page title should display "Frequently Asked Questions (FAQ)".
- [ ] Switching to other languages should change the title to the correct string for that language.