### PR TITLE
Navbar issues; :hover

### DIFF
--- a/src/components/navigation/container/navigation.scss
+++ b/src/components/navigation/container/navigation.scss
@@ -84,6 +84,7 @@
 
             &:hover {
                 background-color: $active-gray;
+                height: 34px;
             }
         }
     }

--- a/src/components/navigation/container/navigation.scss
+++ b/src/components/navigation/container/navigation.scss
@@ -73,7 +73,7 @@
     .link {
         > a {
             display: block;
-            padding: 13px 15px 3px 15px;
+            padding: 13px 15px 4px 15px;
             height: 33px;
             
             text-decoration: none;
@@ -84,7 +84,6 @@
 
             &:hover {
                 background-color: $active-gray;
-                height: 34px;
             }
         }
     }


### PR DESCRIPTION
On the Scratch Website, when hovering over any of the links on the navbar, the dark blue caused by the `:hover` code does not extend to the bottom of the navbar, causing there to be a faint line of the normal blue at the bottom. See here:
<img width="179" alt="screen shot 2016-06-21 at 5 01 13 pm" src="https://cloud.githubusercontent.com/assets/16446551/16272873/6f59e1fe-386d-11e6-8827-aa4aa5bdb0dd.png">

However, adding a height of 34px to the dark blue `:hover` code (`height: 34px;`) fixes this, ensuring that the dark blue color extends to the very bottom of the navbar. See here:
<img width="181" alt="screen shot 2016-06-21 at 5 02 11 pm" src="https://cloud.githubusercontent.com/assets/16446551/16272938/a24680fe-386d-11e6-9c28-88d97b3bffdd.png">


This is my first PR on github, so if I did anything wrong I am so sorry :)
