### PR TITLE
Fix GH-572: HOC page formatting

### DIFF
--- a/src/views/hoc/hoc.scss
+++ b/src/views/hoc/hoc.scss
@@ -9,7 +9,7 @@ $base-bg: $ui-white;
 
 .hoc {
     .title-banner {
-        &.wbb-bg {    
+        &.wbb-bg {
             background-image: url("/images/hoc2015/hide-bg.jpg");
         }
 
@@ -41,9 +41,9 @@ $base-bg: $ui-white;
         .card {
             margin: 10px;
             border-radius: 7px;
-            background-color: $active-gray;                
+            background-color: $active-gray;
             padding: 2px;
-            
+
             width: 30%;
             min-width: 200px;
             max-width: 230px;
@@ -53,7 +53,7 @@ $base-bg: $ui-white;
                 background-color: $base-bg;
                 width: 100%;
                 height: 100%;
-                
+
 
                 button,
                 img {
@@ -128,7 +128,7 @@ $base-bg: $ui-white;
     .resource,
     .studio {
         display: flex;
-        margin: 10px 0; 
+        margin: 10px 0;
         min-width: 200px;
 
         text-align: left;
@@ -164,7 +164,7 @@ $base-bg: $ui-white;
         }
     }
 
-    .resource { 
+    .resource {
         width: 33%;
 
         a {
@@ -175,8 +175,8 @@ $base-bg: $ui-white;
 
         .resource-info {
             h5 {
-                margin: .85rem 0;
-                line-height: 0;
+                margin: 0;
+                line-height: inherit;
             }
         }
     }
@@ -199,7 +199,7 @@ $base-bg: $ui-white;
         @media only screen and (min-width: $mobile) and (max-width: $tablet - 1) {
             display: inline-block;
         }
-        
+
         //8 columns
         @media only screen and (min-width: $tablet) and (max-width: $desktop - 1) {
             h5 {


### PR DESCRIPTION
This PR fixes #572 using @Choco31415's suggestion.

Tested on Chrome 51, Firefox 46.0.1, and Safari 9.1.1.

**Testing Steps**
Making the width of the window small enough to cause the center box to resize should *not* cause the headers in "Activity Cards and Guides" section to collapse on themselves. 

I did have some issues in Safari with the headers extending past the box, but this behavior is the same on the existing Scratch website.