### PR TITLE
Fix GH-605: Make languagechooser keep locale state

### DIFF
--- a/src/components/languagechooser/languagechooser.jsx
+++ b/src/components/languagechooser/languagechooser.jsx
@@ -33,7 +33,7 @@ var LanguageChooser = React.createClass({
             <Form className={classes}>
                 <Select name="language"
                         options={languageOptions}
-                        defaultValue={this.props.locale}
+                        value={this.props.locale}
                         onChange={this.onSetLanguage}
                         required />
             </Form>


### PR DESCRIPTION
This PR fixes #605 by using the `value` prop rather than `defaultValue`. This makes the dropdown behave as expected (dropdown should default to the current locale).