### PR TITLE
Fix GH-607: Language chooser should not be 100% width

### DIFF
--- a/src/components/languagechooser/languagechooser.jsx
+++ b/src/components/languagechooser/languagechooser.jsx
@@ -6,6 +6,8 @@ var languages = require('../../../languages.json');
 var Form = require('../forms/form.jsx');
 var Select = require('../forms/select.jsx');
 
+require('./languagechooser.scss');
+
 /**
  * Footer dropdown menu that allows one to change their language.
  */

--- a/src/components/languagechooser/languagechooser.scss
+++ b/src/components/languagechooser/languagechooser.scss
@@ -1,8 +1,10 @@
 @import "../../frameless";
 
 .language-chooser {
-    select {
-        width: 13.75rem;
-        /* 3 columns */
+    .select {
+        select {
+            width: 13.75rem;
+            /* 3 columns */
+        }
     }
 }

--- a/src/components/languagechooser/languagechooser.scss
+++ b/src/components/languagechooser/languagechooser.scss
@@ -1,0 +1,8 @@
+@import "../../frameless";
+
+.language-chooser {
+    select {
+        width: 13.75rem;
+        /* 3 columns */
+    }
+}


### PR DESCRIPTION
This PR fixes #607 by adding a stylesheet for the languagechooser component that sets the `select` element's width to 13.75 rem (3 columns).