### PR TITLE
[Bugfix] Add permissions dispatch for `WillReceiveProps`

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -259,14 +259,14 @@ var Navigation = React.createClass({
                                             <FormattedMessage id="general.myStuff" />
                                         </a>
                                     </li>
-                                    {this.props.session.session.permissions.educator ? [
+                                    {this.props.permissions.educator ? [
                                         <li>
                                             <a href="/educators/classes/">
                                                 <FormattedMessage id="general.myClasses" />
                                             </a>
                                         </li>
                                     ] : []}
-                                    {this.props.session.session.permissions.student ? [
+                                    {this.props.permissions.student ? [
                                         <li>
                                             <a href={'/classes/' + this.props.session.session.user.classroomId + '/'}>
                                                 <FormattedMessage id="general.myClass" />
@@ -335,7 +335,8 @@ var Navigation = React.createClass({
 
 var mapStateToProps = function (state) {
     return {
-        session: state.session
+        session: state.session,
+        permissions: state.permissions
     };
 };
 

--- a/src/lib/render.jsx
+++ b/src/lib/render.jsx
@@ -6,6 +6,7 @@ var ReactDOM = require('react-dom');
 var StoreProvider = require('react-redux').Provider;
 
 var IntlProvider = require('./intl.jsx').IntlProvider;
+var permissionsActions = require('../redux/permissions.js');
 var sessionActions = require('../redux/session.js');
 var reducer = require('../redux/reducer.js');
 
@@ -42,7 +43,8 @@ var render = function (jsx, element) {
         element
     );
 
-    // Get initial session
+    // Get initial session & permissions
+    store.dispatch(permissionsActions.getPermissions());
     store.dispatch(sessionActions.refreshSession());
 };
 

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -2,6 +2,7 @@ var keyMirror = require('keymirror');
 var defaults = require('lodash.defaults');
 
 var api = require('../lib/api');
+var permissionsActions = require('./permissions.js');
 var tokenActions = require('./token.js');
 
 var Types = keyMirror({
@@ -75,6 +76,9 @@ module.exports.refreshSession = function () {
                     dispatch(tokenActions.getToken());
                     dispatch(module.exports.setSession(body));
                     dispatch(module.exports.setStatus(module.exports.Status.FETCHED));
+
+                    // get the permissions from the updated session
+                    dispatch(permissionsActions.getPermissions());
                     return;
                 }
             }

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -4,7 +4,6 @@ var omit = require('lodash.omit');
 var React = require('react');
 
 var api = require('../../lib/api');
-var permissionsActions = require('../../redux/permissions.js');
 var render = require('../../lib/render.jsx');
 var sessionActions = require('../../redux/session.js');
 var shuffle = require('../../lib/shuffle.js').shuffle;
@@ -61,15 +60,6 @@ var Splash = injectIntl(React.createClass({
                 window.removeEventListener('message', this.onMessage);
             }
         }
-    },
-    componentWillReceiveProps: function () {
-        // Determine whether to show the teacher banner or not
-        this.props.dispatch(permissionsActions.getPermissions());
-    },
-    componentWillMount: function () {
-        // Determine whether to show the teacher banner or not
-        // Needed still for initial render
-        this.props.dispatch(permissionsActions.getPermissions());
     },
     componentDidMount: function () {
         this.getFeaturedGlobal();

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -62,8 +62,13 @@ var Splash = injectIntl(React.createClass({
             }
         }
     },
+    componentWillReceiveProps: function () {
+        // Determine whether to show the teacher banner or not
+        this.props.dispatch(permissionsActions.getPermissions());
+    },
     componentWillMount: function () {
         // Determine whether to show the teacher banner or not
+        // Needed still for initial render
         this.props.dispatch(permissionsActions.getPermissions());
     },
     componentDidMount: function () {


### PR DESCRIPTION
We still need `componentWillMount` to handle the initial render for a logged in teacher first visting the page. Fixes issue in which a teacher would not see the banner immediately after dynamic login.