### PR TITLE
Fix GH-537: Logged-in user dropdown gap

### DIFF
--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -18,7 +18,7 @@
             height: 50px;
 
             &:hover {
-                transition: .15s ease all; 
+                transition: .15s ease all;
                 background-size: 100%;
             }
         }
@@ -49,7 +49,7 @@
                 height: 14px;
 
                 &[type=text] {
-                    transition: .15s ease background-color; 
+                    transition: .15s ease background-color;
                     padding: 0;
                     padding-right: 10px;
                     padding-left: 40px;
@@ -76,14 +76,14 @@
 
             .btn-search {
                 position: absolute;
-                
+
                 box-shadow: none;
                 background-color: transparent;
                 background-image: url("/images/nav-search-glass.png");
                 background-repeat: no-repeat;
-                background-position: center center;     
+                background-position: center center;
                 background-size: 14px 14px;
-                
+
                 width: 40px;
                 height: 40px;
 
@@ -186,9 +186,11 @@
         }
 
         .dropdown {
+            top: 50px;
             padding: 0;
             padding-top: 5px;
             width: 100%;
+            box-sizing: border-box;
         }
     }
 }


### PR DESCRIPTION
This PR fixes #537 by setting the dropdown's position to be directly underneath the navigation bar. It also sets the dropdown's `box-sizing` attribute to `border-box` so that the dropdown aligns with the button in the navbar as per Carl's sketch in the issue. 

Before:
<img width="178" alt="screenshot 2016-06-28 13 56 48" src="https://cloud.githubusercontent.com/assets/3019167/16426750/5db0207e-3d38-11e6-9f5d-8f72ce18bf26.png">

After:
<img width="179" alt="screenshot 2016-06-28 13 59 03" src="https://cloud.githubusercontent.com/assets/3019167/16426786/7f743416-3d38-11e6-9857-34fe454c6990.png">


I did notice that in the sketch on the issue, the dropdown remained darkened while the menu was open, but I figured a fix for that should go in another PR if that behavior is wanted.