### PR TITLE
Darken Account Nav Link when Menu Open

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -241,7 +241,8 @@ var Navigation = React.createClass({
                                 </a>
                             </li>,
                             <li className="link right account-nav" key="account-nav">
-                                <a className="user-info" href="#" onClick={this.handleAccountNavClick}>
+                                <a className={this.state.accountNavOpen ? 'user-info open' : 'user-info'}
+                                    href="#" onClick={this.handleAccountNavClick}>
                                     <Avatar src={this.props.session.session.user.thumbnailUrl} alt="" />
                                     {this.props.session.session.user.username}
                                 </a>

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -178,6 +178,10 @@ var Navigation = React.createClass({
             'message-count': true,
             'show': this.state.unreadMessageCount > 0
         });
+        var dropdownClasses = classNames({
+            'user-info': true,
+            'open': this.state.accountNavOpen
+        });
         var formatMessage = this.props.intl.formatMessage;
         var createLink = this.props.session.session.user ? '/projects/editor/' : '/projects/editor/?tip_bar=home';
         return (
@@ -241,7 +245,7 @@ var Navigation = React.createClass({
                                 </a>
                             </li>,
                             <li className="link right account-nav" key="account-nav">
-                                <a className={this.state.accountNavOpen ? 'user-info open' : 'user-info'}
+                                <a className={dropdownClasses}
                                     href="#" onClick={this.handleAccountNavClick}>
                                     <Avatar src={this.props.session.session.user.thumbnailUrl} alt="" />
                                     {this.props.session.session.user.username}

--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -18,7 +18,7 @@
             height: 50px;
 
             &:hover {
-                transition: .15s ease all; 
+                transition: .15s ease all;
                 background-size: 100%;
             }
         }
@@ -49,7 +49,7 @@
                 height: 14px;
 
                 &[type=text] {
-                    transition: .15s ease background-color; 
+                    transition: .15s ease background-color;
                     padding: 0;
                     padding-right: 10px;
                     padding-left: 40px;
@@ -76,14 +76,14 @@
 
             .btn-search {
                 position: absolute;
-                
+
                 box-shadow: none;
                 background-color: transparent;
                 background-image: url("/images/nav-search-glass.png");
                 background-repeat: no-repeat;
-                background-position: center center;     
+                background-position: center center;
                 background-size: 14px 14px;
-                
+
                 width: 40px;
                 height: 40px;
 
@@ -168,6 +168,10 @@
                 width: 24px;
                 height: 24px;
                 vertical-align: middle;
+            }
+
+            &.open {
+                background-color: $active-gray;
             }
 
             &:after {


### PR DESCRIPTION
This PR adds an `open` class to the account nav link whenever the profile menu is open and darkens the link, as per Carl's sketch in #537.