### PR TITLE
Fix GH-623: Add link to splash page around registration icon

### DIFF
--- a/src/components/deck/deck.jsx
+++ b/src/components/deck/deck.jsx
@@ -9,7 +9,9 @@ var Deck = React.createClass({
         return (
             <div className={classNames(['deck', this.props.className])}>
                 <div className="inner">
-                    <img src="/images/logo_sm.png" />
+                    <a href="/" aria-label="Scratch">
+                        <img src="/images/logo_sm.png" />
+                    </a>
                     {this.props.children}
                 </div>
             </div>


### PR DESCRIPTION
Fixes #623 

### Test Cases ###
* Try to navigate to the homepage from the registration page for teachers. It should lead you to the homepage.