### PR TITLE
Fix GH-625: fix educator faq link

### DIFF
--- a/src/components/teacher-banner/teacher-banner.jsx
+++ b/src/components/teacher-banner/teacher-banner.jsx
@@ -58,7 +58,7 @@ var TeacherBanner = React.createClass({
                                         {this.props.messages['teacherbanner.resourcesButton']}
                                     </Button>
                                 </a>,
-                                <a href="/info/educators/faq">
+                                <a href="/educators/faq">
                                     <Button>
                                         {this.props.messages['teacherbanner.faqButton']}
                                     </Button>


### PR DESCRIPTION
`info` is not in there anymore. Fixes #625.

See #625 for test case.