### PR TITLE
Fix GH-618: Override devault input style for login

### DIFF
--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -147,6 +147,21 @@
 
     .login-dropdown {
         width: 200px;
+
+        .button {
+            padding: .75em;
+        }
+    }
+
+    .dropdown {
+        .row {
+            margin-bottom: 1.25rem;
+
+            input {
+                margin: 0;
+                height: 2.25rem;
+            }
+        }
     }
 
     .account-nav {


### PR DESCRIPTION
so that it looks like it used to, and not to tall. Fixes #618.