### PR TITLE
Fix GH-617: switch ordering in defaults

### DIFF
--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -29,8 +29,8 @@ module.exports.validationHOCFactory = function (defaultValidationErrors) {
         var ValidatedComponent = React.createClass({
             render: function () {
                 var validationErrors = defaults(
-                    defaultValidationErrors,
-                    this.props.validationErrors
+                    this.props.validationErrors,
+                    defaultValidationErrors
                 );
                 return (
                     <Component {...this.props} validationErrors={validationErrors} />


### PR DESCRIPTION
This was assigning `props` to defaults, rather than the other way around. Fixes #617.

### Test Cases ###
* in `/eduators/register`, type a password that is too short. The error message should not refer to the "username" in any way (as it does currently according to #617. 