### PR TITLE
Fix GH-633, GH-634, and GH-635: Embedded player fixes

### DIFF
--- a/src/views/teachers/landing/landing.jsx
+++ b/src/views/teachers/landing/landing.jsx
@@ -25,8 +25,10 @@ var Landing = injectIntl(React.createClass({
                             <p className="intro">
                                 <FormattedMessage id="teacherlanding.intro" />
                             </p>
-                            <iframe src="https://www.youtube.com/embed/uPSuG063jhA"
-                                frameborder="0" allowfullscreen></iframe>
+                            <div className="ted-talk">
+                                <iframe src="https://www.youtube.com/embed/uPSuG063jhA?border=0&wmode=transparent"
+                                    frameBorder="0" allowFullScreen></iframe>
+                            </div>
                         </FlexRow>
                     </div>
                     <div className="band">

--- a/src/views/teachers/landing/landing.scss
+++ b/src/views/teachers/landing/landing.scss
@@ -48,12 +48,23 @@ $story-width: $cols3;
                         color: $ui-white;
                     }
                 }
+            }
+
+            .ted-talk {
+                position: relative;
+                z-index: 10;
+                margin-bottom: $gutter;
+                border: 2px solid $ui-border;
+                border-radius: 10px;
+                width: $cols4;
+                height: $cols4 * .5625;
+                overflow: hidden;
 
                 iframe {
-                    margin-bottom: $gutter;
-                    border: 2px solid $ui-border;
-                    border-radius: 10px;
+                    z-index: 9;
+                    border: 0;
                     width: $cols4;
+                    height: $cols4 * .5625;
                 }
             }
 

--- a/src/views/teachers/landing/landing.scss
+++ b/src/views/teachers/landing/landing.scss
@@ -63,8 +63,8 @@ $story-width: $cols3;
                 iframe {
                     z-index: 9;
                     border: 0;
-                    width: $cols4;
-                    height: $cols4 * .5625;
+                    width: inherit;
+                    height: inherit;
                 }
             }
 


### PR DESCRIPTION
This PR fixes #633, #634, and #635 by adding a container div for the YouTube iframe to force it to maintain a border radius, as well as setting the height correctly and changing the "allowfullscreen" prop to "allowFullScreen".