### PR TITLE
Fix GH-643: use empty string if no cookie value found

### DIFF
--- a/src/redux/permissions.js
+++ b/src/redux/permissions.js
@@ -24,6 +24,8 @@ module.exports.getPermissions = function () {
     return function (dispatch) {
         jar.getUnsignedValue('scratchsessionsid', 'permissions', function (err, value) {
             if (err) return dispatch(module.exports.setPermissionsError(err));
+
+            value = value || {};
             return dispatch(module.exports.setPermissions(value));
         });
     };

--- a/src/redux/token.js
+++ b/src/redux/token.js
@@ -27,6 +27,8 @@ module.exports.getToken = function () {
     return function (dispatch) {
         jar.getUnsignedValue('scratchsessionsid', 'token', function (err, value) {
             if (err) return dispatch(module.exports.setTokenError(err));
+
+            value = value || '';
             return dispatch(module.exports.setToken(value));
         });
     };


### PR DESCRIPTION
redux doesn't like getting null values for actions, so give empty ones

/cc @rschamp