### PR TITLE
Fix GH-649: Dropdown hidden by TED Talk

### DIFF
--- a/src/views/teachers/landing/landing.scss
+++ b/src/views/teachers/landing/landing.scss
@@ -52,7 +52,6 @@ $story-width: $cols3;
 
             .ted-talk {
                 position: relative;
-                z-index: 10;
                 margin-bottom: $gutter;
                 border: 2px solid $ui-border;
                 border-radius: 10px;
@@ -61,7 +60,6 @@ $story-width: $cols3;
                 overflow: hidden;
 
                 iframe {
-                    z-index: 9;
                     border: 0;
                     width: inherit;
                     height: inherit;


### PR DESCRIPTION
Fixes #649 by removing the z-index attributes from the video containers, as it doesn't appear that they were needed after all.