### PR TITLE
Fix GH-642: Use empty default object for validation factory

### DIFF
--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -29,8 +29,9 @@ module.exports.validationHOCFactory = function (defaultValidationErrors) {
         var ValidatedComponent = React.createClass({
             render: function () {
                 var validationErrors = defaults(
-                    this.props.validationErrors,
-                    defaultValidationErrors
+                    {},
+                    defaultValidationErrors,
+                    this.props.validationErrors
                 );
                 return (
                     <Component {...this.props} validationErrors={validationErrors} />


### PR DESCRIPTION
Looks as if the having one of these objects as the default causes overwriting in some way, as opposed to augmentation. Have the source object be an empty one, so that it gets the attributes of both defaults and props. Fixes #642.

### Test Cases ###
* Register for a teacher account. On the "phone number" step, if your number is not real, it should show an error message