### PR TITLE
Revalidate address step after invalid submissions

### DIFF
--- a/src/components/forms/form.jsx
+++ b/src/components/forms/form.jsx
@@ -1,5 +1,6 @@
 var classNames = require('classnames');
 var Formsy = require('formsy-react');
+var omit = require('lodash.omit');
 var React = require('react');
 var GeneralError = require('./general-error.jsx');
 var validations = require('./validations.jsx').validations;
@@ -11,8 +12,18 @@ for (var validation in validations) {
 var Form = React.createClass({
     getDefaultProps: function () {
         return {
-            noValidate: true
+            noValidate: true,
+            onChange: function () {}
         };
+    },
+    getInitialState: function () {
+        return {
+            allValues: {}
+        };
+    },
+    onChange: function (currentValues, isChanged) {
+        this.setState({allValues: omit(currentValues, 'all')});
+        this.props.onChange(currentValues, isChanged);
     },
     render: function () {
         var classes = classNames(
@@ -20,8 +31,8 @@ var Form = React.createClass({
             this.props.className
         );
         return (
-            <Formsy.Form {... this.props} className={classes}>
-                <GeneralError name="all" />
+            <Formsy.Form {... this.props} className={classes} ref="formsy" onChange={this.onChange}>
+                <GeneralError name="all" value={this.state.allValues} />
                 {this.props.children}
             </Formsy.Form>
         );


### PR DESCRIPTION
I don't like that the state is being set to a calculation of existing props. When I did that calculation in `render`, it didn't update when fields were changed.

Fixes #645