### PR TITLE
Fix JSON response parsing in IE

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -54,6 +54,16 @@ module.exports = function (opts, callback) {
         }
         xhr(opts, function (err, res, body) {
             if (err) log.error(err);
+            if (opts.responseType === 'json' && typeof body === 'string') {
+                // IE doesn't parse responses as JSON without the json attribute,
+                // even with responseType: 'json'.
+                // See https://github.com/Raynos/xhr/issues/123
+                try {
+                    body = JSON.parse(body);
+                } catch (e) {
+                    // Not parseable anyway, don't worry about it
+                }
+            }
             // Legacy API responses come as lists, and indicate to redirect the client like
             // [{success: true, redirect: "/location/to/redirect"}]
             try {


### PR DESCRIPTION
Fixes #654

IE does not honor responseType: 'json', and will not parse responses as JSON unless json data is present in the request. For some reason this issue can also be solved by including a `json` attribute on the xhr request, but if that's present, url encoded form data is overwritten with the contents of the json.  So just try to parse the response ourselves if it looks like it wasn't parsed.

See https://github.com/Raynos/xhr/issues/123