### PR TITLE
Use babel-loader for jsx transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
   "devDependencies": {
     "async": "1.5.2",
     "autoprefixer": "6.3.6",
+    "babel-core": "6.10.4",
+    "babel-loader": "6.2.4",
+    "babel-preset-es2015": "6.9.0",
+    "babel-preset-react": "6.11.1",
     "classnames": "2.1.3",
     "cookie": "0.2.2",
     "copy-webpack-plugin": "0.2.0",
@@ -51,7 +55,6 @@
     "iso-3166-2": "0.4.0",
     "json-loader": "0.5.2",
     "json2po-stream": "1.0.3",
-    "jsx-loader": "0.13.2",
     "keymirror": "0.1.1",
     "lodash.clone": "3.0.3",
     "lodash.defaultsdeep": "3.10.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,10 @@ module.exports = {
         loaders: [
             {
                 test: /\.jsx$/,
-                loader: 'jsx-loader',
+                loader: 'babel',
+                query: {
+                    presets: ['es2015','react']
+                },
                 include: path.resolve(__dirname, 'src')
             },
             {


### PR DESCRIPTION
This is to remove the deprecation warning about React.__spread. It will give us other nice things too, though.