### PR TITLE
Fix GH-628: Add box shadow for focus state on checkboxes

### DIFF
--- a/src/components/forms/checkbox.scss
+++ b/src/components/forms/checkbox.scss
@@ -20,12 +20,12 @@
 
                 &:checked,
                 &:focus {
+                    transition: all .5s ease;
                     outline: none;
+                    box-shadow: 0 0 0 .25rem $active-gray;
                 }
 
                 &:checked {
-                    transition: all .5s ease;
-                    box-shadow: 0 0 0 .25rem $active-gray;
                     background-color: $ui-blue;
                     text-align: center;
                     text-indent: .125rem;


### PR DESCRIPTION
Fixes #628 by applying the same outline for focus as is currently applied to checked boxes.

/cc @carljbowman 