### PR TITLE
Disable default style for select elements in IE

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -19,6 +19,10 @@
         font-size: .875rem;
         appearance: none;
 
+        &::-ms-expand {
+            display: none;
+        }
+
         &:focus {
             transition: all .5s ease;
             outline: none;


### PR DESCRIPTION
Fixes #669. /cc @mewtaylor