### PR TITLE
Don't error on null children

### DIFF
--- a/src/components/forms/form.jsx
+++ b/src/components/forms/form.jsx
@@ -32,6 +32,7 @@ var Form = React.createClass({
         return (
             <Formsy.Form {... this.props} className={classes} ref="formsy" onChange={this.onChange}>
                 {React.Children.map(this.props.children, function (child) {
+                    if (!child) return child;
                     if (child.props.name === 'all') {
                         return React.cloneElement(child, {value: this.state.allValues});
                     } else {


### PR DESCRIPTION
Was throwing a `TypeError` when child was null/undefined.

/cc @mewtaylor 