### PR TITLE
Fix GH-701, GH-700: IE11 select form background, indent issues

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -23,6 +23,12 @@
             display: none;
         }
 
+        &::-ms-value {
+            background-color: inherit;
+            padding-left: 1rem;
+            color: inherit;
+        }
+
         &:focus {
             transition: all .5s ease;
             outline: none;


### PR DESCRIPTION
Fixes #701 by adding an ::-ms-value pseudoclass to the select element to set the background color and color attributes to the original values. 

It also fixes #700 by setting left padding to 1rem, as text-indent does not appear to work on select elements in IE.