### PR TITLE
Fix GH-674: Waiting room cards should be centered in IE

### DIFF
--- a/src/views/teacherregistration/teacherregistration.scss
+++ b/src/views/teacherregistration/teacherregistration.scss
@@ -149,7 +149,7 @@ body {
         }
 
         .card {
-            margin: 1rem 0;
+            margin: 1rem auto;
             padding: 1.5rem;
             width: initial;
 


### PR DESCRIPTION
This PR fixes #674 by setting the horizontal margin of the waiting room card elements to auto instead of 0. 