### PR TITLE
Fix GH-749: Fix formatting for a few form elements

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -21,25 +21,6 @@
         }
     }
 
-    .form {
-        position: relative;
-        padding: 3rem 4rem;
-
-        .card-button {
-            margin: 0 0 -3rem -4rem;
-        }
-
-        .form-group {        
-            margin-bottom: 1.2rem;
-
-            &.has-error {
-                .input {
-                    border: 1px solid $ui-orange;
-                }
-            }
-        }
-    }
-
     .validation-message {
         $arrow-border-width: 1rem;
         display: block;
@@ -77,6 +58,32 @@
         }
     }
 
+    .form {
+        position: relative;
+        padding: 3rem 4rem;
+
+        .card-button {
+            margin: 0 0 -3rem -4rem;
+        }
+
+        .form-group {        
+            margin-bottom: 1.2rem;
+
+            &.has-error {
+                .input {
+                    border: 1px solid $ui-orange;
+                }
+            }
+
+            .checkbox-row,
+            .phone-input,
+            .textarea-group {
+                .validation-message {
+                    transform: translate(20rem, 0);  
+                }
+            }
+        }
+    }
 }
 
 @media only screen and (max-width: $mobile - 1) {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -58,6 +58,13 @@
         }
     }
 
+    .checkbox-row,
+    .textarea-row {
+        .validation-message {
+            transform: translate(20rem, 0);  
+        }
+    }
+
     .form {
         position: relative;
         padding: 3rem 4rem;
@@ -66,20 +73,12 @@
             margin: 0 0 -3rem -4rem;
         }
 
-        .form-group {        
+        .row {        
             margin-bottom: 1.2rem;
 
             &.has-error {
                 .input {
                     border: 1px solid $ui-orange;
-                }
-            }
-
-            .checkbox-row,
-            .phone-input,
-            .textarea-group {
-                .validation-message {
-                    transform: translate(20rem, 0);  
                 }
             }
         }

--- a/src/components/forms/checkbox.jsx
+++ b/src/components/forms/checkbox.jsx
@@ -15,7 +15,7 @@ var Checkbox = React.createClass({
             this.props.className
         );
         return (
-            <FRCCheckbox elementWrapperClassName={classes} {... this.props} />
+            <FRCCheckbox rowClassName={classes} {... this.props} />
         );
     }
 });

--- a/src/components/forms/checkbox.jsx
+++ b/src/components/forms/checkbox.jsx
@@ -15,9 +15,7 @@ var Checkbox = React.createClass({
             this.props.className
         );
         return (
-            <div className={classes}>
-                <FRCCheckbox {... this.props} />
-            </div>
+            <FRCCheckbox elementWrapperClassName={classes} {... this.props} />
         );
     }
 });

--- a/src/components/forms/input.jsx
+++ b/src/components/forms/input.jsx
@@ -29,14 +29,13 @@ var Input = React.createClass({
     },
     render: function () {
         var classes = classNames(
-            'input',
             this.state.status,
             this.props.className
         );
-        return (this.props.type === 'submit' || this.props.noformsy ?
-            <input {... this.props} className={classes} /> :
+        return (
             <FRCInput {... this.props}
-                      className={classes}
+                      className="input"
+                      rowClassName={classes}
                       onValid={this.onValid}
                       onInvalid={this.onInvalid} />
         );

--- a/src/components/forms/input.jsx
+++ b/src/components/forms/input.jsx
@@ -30,7 +30,8 @@ var Input = React.createClass({
     render: function () {
         var classes = classNames(
             this.state.status,
-            this.props.className
+            this.props.className,
+            {'no-label': (typeof this.props.label === 'undefined')}
         );
         return (
             <FRCInput {... this.props}

--- a/src/components/forms/input.scss
+++ b/src/components/forms/input.scss
@@ -12,7 +12,7 @@ $pass-bg: lighten($ui-aqua, 35%);
 
 .input {
     transition: all .5s ease;
-    margin: .75rem 0;
+    margin-bottom: .75rem;
     border: 1px solid $active-gray;
     border-radius: 5px;
     background-color: $base-bg;

--- a/src/components/forms/phone-input.jsx
+++ b/src/components/forms/phone-input.jsx
@@ -53,9 +53,9 @@ var PhoneInput = React.createClass({
                                      label={null}
                                      disabled={this.isFormDisabled() || this.props.disabled}
                     />
+                    {this.renderHelp()}
                     {this.renderErrorMessage()}
                 </div>
-                {this.renderHelp()}
             </Row>
         );
     }

--- a/src/components/forms/phone-input.jsx
+++ b/src/components/forms/phone-input.jsx
@@ -42,7 +42,7 @@ var PhoneInput = React.createClass({
         return (
             <Row {... this.getRowProperties()}
                  htmlFor={this.getId()}
-                 className={classNames('phone-input', this.props.className)}
+                 elementWrapperClassName={classNames('phone-input', this.props.className)}
             >
                 <div className="input-group">
                     <ReactPhoneInput className="form-control"

--- a/src/components/forms/phone-input.jsx
+++ b/src/components/forms/phone-input.jsx
@@ -42,7 +42,7 @@ var PhoneInput = React.createClass({
         return (
             <Row {... this.getRowProperties()}
                  htmlFor={this.getId()}
-                 elementWrapperClassName={classNames('phone-input', this.props.className)}
+                 rowClassName={classNames('phone-input', this.props.className)}
             >
                 <div className="input-group">
                     <ReactPhoneInput className="form-control"
@@ -53,9 +53,9 @@ var PhoneInput = React.createClass({
                                      label={null}
                                      disabled={this.isFormDisabled() || this.props.disabled}
                     />
+                    {this.renderErrorMessage()}
                 </div>
                 {this.renderHelp()}
-                {this.renderErrorMessage()}
             </Row>
         );
     }

--- a/src/components/forms/phone-input.scss
+++ b/src/components/forms/phone-input.scss
@@ -1,11 +1,11 @@
 @import "../../colors";
 
 .input-group {
-    margin: .75rem 0;
     width: 100%;
 }
 
 .react-tel-input {
+    margin-bottom: .75rem;
     width: 100%;
 
     input {

--- a/src/components/forms/row.scss
+++ b/src/components/forms/row.scss
@@ -13,4 +13,10 @@
         display: inline-block;
         margin-bottom: .75rem;
     }
+
+    &.no-label {
+        label {
+            display: none;
+        }
+    }
 }

--- a/src/components/forms/row.scss
+++ b/src/components/forms/row.scss
@@ -4,8 +4,13 @@
  * the formsy-react-components
  */
 
-.form-group {
+.row {
     .required-symbol {
         display: none;
+    }
+
+    label {
+        display: inline-block;
+        margin-bottom: .75rem;
     }
 }

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -8,7 +8,7 @@
 
     select {
         transition: all .5s ease;
-        margin: .75rem 0;
+        margin-bottom: .75rem;
         border: 1px solid $active-gray;
         border-radius: 5px;
         background: $ui-light-gray url("../../../static/svgs/forms/carot.svg") no-repeat right center;

--- a/src/components/forms/textarea.jsx
+++ b/src/components/forms/textarea.jsx
@@ -11,13 +11,13 @@ var TextArea = React.createClass({
     type: 'TextArea',
     render: function () {
         var classes = classNames(
-            'textarea',
+            'textarea-row',
             this.props.className
         );
         return (
             <FRCTextarea {... this.props}
-                         className={classes}
-                         rowClassName="textarea-row" />
+                         className="textarea"
+                         rowClassName={classes} />
         );
     }
 });

--- a/src/components/forms/textarea.jsx
+++ b/src/components/forms/textarea.jsx
@@ -17,7 +17,7 @@ var TextArea = React.createClass({
         return (
             <FRCTextarea {... this.props}
                          className={classes}
-                         elementWrapperClassName="textarea-group" />
+                         rowClassName="textarea-row" />
         );
     }
 });

--- a/src/components/forms/textarea.jsx
+++ b/src/components/forms/textarea.jsx
@@ -15,7 +15,9 @@ var TextArea = React.createClass({
             this.props.className
         );
         return (
-            <FRCTextarea {... this.props} className={classes} />
+            <FRCTextarea {... this.props}
+                         className={classes}
+                         elementWrapperClassName="textarea-group" />
         );
     }
 });

--- a/src/components/forms/textarea.scss
+++ b/src/components/forms/textarea.scss
@@ -2,7 +2,7 @@
 
 .textarea {
     transition: all 1s ease;
-    margin: .75rem 0;
+    margin-bottom: .75rem;
     border: 1px solid $active-gray;
     border-radius: 5px;
     background-color: $ui-light-gray;

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -223,7 +223,6 @@ var Navigation = React.createClass({
                         <Form onSubmit={this.onSearchSubmit}>
                             <Button type="submit" className="btn-search" />
                             <Input type="text"
-                                   className="no-label"
                                    aria-label={formatMessage({id: 'general.search'})}
                                    placeholder={formatMessage({id: 'general.search'})}
                                    name="q" />

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -172,7 +172,7 @@ var Navigation = React.createClass({
         this.closeRegistration();
     },
     onSearchSubmit: function (formData) {
-        window.location.href = '/search/projects?q=' + formData.q; 
+        window.location.href = '/search/projects?q=' + formData.q;
     },
     render: function () {
         var classes = classNames({

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -11,6 +11,7 @@ var api = require('../../../lib/api');
 var Avatar = require('../../avatar/avatar.jsx');
 var Button = require('../../forms/button.jsx');
 var Dropdown = require('../../dropdown/dropdown.jsx');
+var Form = require('../../forms/form.jsx');
 var Input = require('../../forms/input.jsx');
 var log = require('../../../lib/log.js');
 var Login = require('../../login/login.jsx');
@@ -170,6 +171,9 @@ var Navigation = React.createClass({
         this.props.dispatch(sessionActions.refreshSession());
         this.closeRegistration();
     },
+    onSearchSubmit: function (formData) {
+        window.location.href = '/search/projects?q=' + formData.q; 
+    },
     render: function () {
         var classes = classNames({
             'logged-in': this.props.session.session.user
@@ -216,14 +220,14 @@ var Navigation = React.createClass({
                     </li>
 
                     <li className="search">
-                        <form action="/search/projects" method="get">
+                        <Form onSubmit={this.onSearchSubmit}>
                             <Button type="submit" className="btn-search" />
                             <Input type="text"
+                                   className="no-label"
                                    aria-label={formatMessage({id: 'general.search'})}
                                    placeholder={formatMessage({id: 'general.search'})}
-                                   name="q"
-                                   noformsy />
-                        </form>
+                                   name="q" />
+                        </Form>
                     </li>
                     {this.props.session.status === sessionActions.Status.FETCHED ? (
                         this.props.session.session.user ? [

--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -47,12 +47,18 @@
                 width: 100%;
             }
 
-            form {
+            .form {
                 margin: 0;
             }
 
-            input,
-            button {
+            .row {
+                .help-block {
+                    display: none;
+                }
+            }
+
+            .input,
+            .button {
                 display: inline-block;
                 margin-top: 5px;
                 outline: none;

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -315,6 +315,7 @@ module.exports = {
                             <div className="gender-input">
                                 <Input name="user.genderOther"
                                        type="text"
+                                       className="no-label"
                                        disabled={this.state.otherDisabled}
                                        required={!this.state.otherDisabled}
                                        help={null} />
@@ -499,6 +500,7 @@ module.exports = {
                             </div>
                             <div className="other-input">
                                 <Input type="text"
+                                       className="no-label"
                                        name="organization.other"
                                        disabled={this.state.otherDisabled}
                                        required="isFalse"

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -315,7 +315,6 @@ module.exports = {
                             <div className="gender-input">
                                 <Input name="user.genderOther"
                                        type="text"
-                                       className="no-label"
                                        disabled={this.state.otherDisabled}
                                        required={!this.state.otherDisabled}
                                        help={null} />
@@ -500,7 +499,6 @@ module.exports = {
                             </div>
                             <div className="other-input">
                                 <Input type="text"
-                                       className="no-label"
                                        name="organization.other"
                                        disabled={this.state.otherDisabled}
                                        required="isFalse"

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -79,13 +79,9 @@
     }
 
     &.organization-step {
-        .validation-message {
-            transform: translate(16rem, -4rem);
-        }
-
         .checkbox-group {
             .validation-message {
-                transform: translate(16rem, -16rem);
+                transform: translate(20rem, -16rem);
             }
         }
 
@@ -103,7 +99,7 @@
     &.address-step {
         .select {
             .validation-message {
-                transform: translate(0, .5rem);
+                transform: translate(20rem, .5rem);
             }
         }
     }

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -66,16 +66,6 @@
                 margin-bottom: 1.25rem;
             }
         }
-
-        .validation-message {
-            margin-top: .5rem;
-        }
-
-        .checkbox-row {
-            .validation-message {
-                margin-top: 0;
-            }
-        }
     }
 
     &.organization-step {
@@ -115,12 +105,6 @@
                     }
                 }
             }
-
-
-        }
-
-        .validation-message {
-            margin-top: .75rem;
         }
 
         p {


### PR DESCRIPTION
and make use of the FRC `elementWrapperClassName`, since they way we did it before – custom `className` strings on the element – was not working. Fixes #749 .

### Elements to test ###
* Phone number input
* "Why use scratch" textarea
* Checkbox group