### PR TITLE
Make the student registration views more consistent with each other

### DIFF
--- a/src/views/studentcompleteregistration/studentcompleteregistration.jsx
+++ b/src/views/studentcompleteregistration/studentcompleteregistration.jsx
@@ -90,30 +90,33 @@ var StudentCompleteRegistration = intl.injectIntl(React.createClass({
         var demographicsDescription = this.props.intl.formatMessage({
             id: 'registration.studentPersonalStepDescription'});
         var registrationErrors = this.state.registrationErrors;
-        var sessionFetched = this.props.session.status === sessionStatus.FETCHED;
-        if (sessionFetched &&
-            !(this.props.session.session.permissions.student &&
-              this.props.session.session.flags.must_complete_registration)) {
+        if (this.props.session.status === sessionStatus.FETCHED && !(
+                this.props.session.session.permissions &&
+                this.props.session.session.permissions.student &&
+                this.props.session.session.flags.must_complete_registration)
+        ) {
             registrationErrors = {
                 __all__: this.props.intl.formatMessage({id: 'registration.mustBeNewStudent'})
             };
         }
         return (
             <Deck className="student-registration">
-                {sessionFetched && this.state.classroom ?
-                    (registrationErrors ?
-                        <Steps.RegistrationError>
-                            <ul>
-                                {Object.keys(registrationErrors).map(function (field) {
-                                    var label = field + ': ';
-                                    if (field === '__all__') {
-                                        label = '';
-                                    }
-                                    return (<li>{label}{registrationErrors[field]}</li>);
-                                })}
-                            </ul>
-                        </Steps.RegistrationError>
-                    :
+                {registrationErrors ? (
+                    <Steps.RegistrationError>
+                        <ul>
+                            {Object.keys(registrationErrors).map(function (field) {
+                                var label = field + ': ';
+                                if (field === '__all__') {
+                                    label = '';
+                                }
+                                return (<li>{label}{registrationErrors[field]}</li>);
+                            })}
+                        </ul>
+                    </Steps.RegistrationError>
+                ) : (
+                    this.state.waiting || !this.state.classroom ? (
+                        <Spinner />
+                    ) : (
                         <Progression {... this.state}>
                             <Steps.ClassInviteStep classroom={this.state.classroom}
                                                    messages={this.props.messages}
@@ -134,9 +137,7 @@ var StudentCompleteRegistration = intl.injectIntl(React.createClass({
                                                     waiting={this.state.waiting} />
                         </Progression>
                     )
-                :
-                    <Spinner />
-                }
+                )}
             </Deck>
         );
     }

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -35,10 +35,12 @@ var StudentRegistration = intl.injectIntl(React.createClass({
         });
     },
     componentDidMount: function () {
+        this.setState({waiting: true});
         api({
             uri: '/classrooms/' + this.props.classroomId,
             params: {token: this.props.classroomToken}
         }, function (err, body, res) {
+            this.setState({waiting: false});
             if (err) {
                 return this.setState({
                     registrationError: this.props.intl.formatMessage({


### PR DESCRIPTION
While doing so, fix an issue where logged out users just saw a spinner when visiting `/classes/complete_registration` — now it shows an error.