### PR TITLE
Fix GH-757: Redirect to `/educators/classes` if a confirmed teacher

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -763,14 +763,8 @@ module.exports = {
             return {
                 email: null,
                 invited: false,
-                confirmed: false,
-                educator: true
+                confirmed: false
             };
-        },
-        componentWillReceiveProps: function (nextProps) {
-            if (nextProps.educator && nextProps.confirmed) {
-                window.location.href = '/educators/classes/';
-            }
         },
         render: function () {
             return (

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -762,8 +762,15 @@ module.exports = {
         getDefaultProps: function () {
             return {
                 email: null,
-                invited: false
+                invited: false,
+                confirmed: false,
+                educator: true
             };
+        },
+        componentWillReceiveProps: function (nextProps) {
+            if (nextProps.educator && nextProps.confirmed) {
+                window.location.href = '/educators/classes/';
+            }
         },
         render: function () {
             return (

--- a/src/views/teacherwaitingroom/teacherwaitingroom.jsx
+++ b/src/views/teacherwaitingroom/teacherwaitingroom.jsx
@@ -10,6 +10,11 @@ require('./teacherwaitingroom.scss');
 
 var TeacherWaitingRoom = React.createClass({
     displayName: 'TeacherWaitingRoom',
+    componentWillReceiveProps: function (nextProps) {
+        if (nextProps.session.permissions.educator && nextProps.session.permissions.social) {
+            window.location.href = '/educators/classes/';
+        }
+    },
     render: function () {
         var permissions = this.props.session.permissions || {};
         var user = this.props.session.user || {};


### PR DESCRIPTION
Fixes #757. Note: Because we are getting this info from the session, the redirect may not happen until the page is rendered first in cases where the connection is slow, or the db is slow.

### Test Cases ###
* With a confirmed teacher account, try to go directly to the `waiting` page. It should redirect you to "My Classes"