### PR TITLE
Set common y-origin for validation bubbles

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -25,8 +25,9 @@
         $arrow-border-width: 1rem;
         display: block;
         position: absolute;
+        top: 0;
         left: 0;
-        transform: translate(20rem, -4rem);
+        transform: translate(16rem, 0);
         margin-left: $arrow-border-width;
         border: 1px solid $active-gray;
         border-radius: 5px;
@@ -58,15 +59,7 @@
         }
     }
 
-    .checkbox-row,
-    .textarea-row {
-        .validation-message {
-            transform: translate(20rem, 0);  
-        }
-    }
-
     .form {
-        position: relative;
         padding: 3rem 4rem;
 
         .card-button {
@@ -80,6 +73,10 @@
                 .input {
                     border: 1px solid $ui-orange;
                 }
+            }
+
+            .col-sm-9 {
+                position: relative;
             }
         }
     }

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -80,7 +80,7 @@
     &.organization-step {
         .checkbox-group {
             .validation-message {
-                transform: translate(20rem, -16rem);
+                transform: translate(16rem, -16rem);
             }
         }
 
@@ -92,14 +92,6 @@
 
         .other-input {
             margin-top: -5.75rem;
-        }
-    }
-
-    &.address-step {
-        .select {
-            .validation-message {
-                transform: translate(20rem, .5rem);
-            }
         }
     }
 


### PR DESCRIPTION
I believe this will keep the misalignment from happening across browsers. Sets the top left corner to the top left corner of the input block.

Tested in Chrome 52 and confirmed this fixes the issue there, but Sauce was having network issues so I wasn't able to check this in other browsers yet. I think the absence of the `top` declaration was the source of the pain for this though.

Resolves #770 
