### PR TITLE
Move "select country" to general strings

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -29,7 +29,7 @@ require('./steps.scss');
 var DEFAULT_COUNTRY = 'us';
 var getCountryOptions = function (defaultCountry) {
     var options = countryData.countryOptions.concat({
-        label: <intl.FormattedMessage id="teacherRegistration.selectCountry" />,
+        label: <intl.FormattedMessage id="registration.selectCountry" />,
         disabled: true,
         selected: true
     });

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -128,6 +128,7 @@
     "registration.notYou": "Not you? Log in as another user",
     "registration.personalStepTitle": "Personal Information",
     "registration.personalStepDescription": "Your individual responses will not be displayed publicly, and will be kept confidential and secure",
+    "registration.selectCountry": "select country",
     "registration.studentPersonalStepDescription": "This information will not appear on the Scratch website.",
     "registration.showPassword": "Show password",
     "registration.usernameStepDescription": "Fill in the following forms to request an account. The approval process may take up to 24 hours.",

--- a/src/views/teacherregistration/l10n.json
+++ b/src/views/teacherregistration/l10n.json
@@ -25,7 +25,6 @@
     "teacherRegistration.orgChoiceCamp": "Camp",
     "teacherRegistration.orgChoiceOther": " ",
     "teacherRegistration.notRequired": "Not Required",
-    "teacherRegistration.selectCountry": "select country",
     "teacherRegistration.addressValidationError": "This doesn't look like a real address",
     "teacherRegistration.addressLine1": "Address Line 1",
     "teacherRegistration.addressLine2": "Address Line 2 (Optional)",


### PR DESCRIPTION
It's reused in the other registration views so doesn't belong in teacherregistration/l10n.json

Fixes #783 

/cc @mewtaylor 