### PR TITLE
Fix GH-781: Jobs page image is too wide

### DIFF
--- a/src/views/jobs/jobs.scss
+++ b/src/views/jobs/jobs.scss
@@ -4,6 +4,7 @@
     .top {
         img {
             margin-bottom: 10px;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
This PR fixes #781 by setting the width of the `img` element to 100% (like the rest of the paragraph elements on the page). 

This page will probably need some more work when #217 is merged, but that's outside the scope of this PR.