### PR TITLE
Fix gh-822: Missing Email Address

### DIFF
--- a/src/views/terms/terms.jsx
+++ b/src/views/terms/terms.jsx
@@ -85,7 +85,7 @@ var Terms = React.createClass({
                              (for example, in the event of a loss, theft, or unauthorized disclosure
                              of your password), promptly change your password. If you cannot access
                              your account to change your password, notify us at{' '}
-                             <a href="mailto:help@scratch.mit.edu"></a>.
+                             <a href="mailto:help@scratch.mit.edu">help@scratch.mit.edu</a>.
                         </p>
                     </section>
                     <section id="rules-of-usage">


### PR DESCRIPTION
Fixes #822 
Turns out the link tag was there, it just didn't have any text.

@thisandagain @mewtaylor @rschamp @technoboy10 