### PR TITLE
Fix GH-806: Teacher Account Video Embded

### DIFF
--- a/src/views/teachers/faq/faq.jsx
+++ b/src/views/teachers/faq/faq.jsx
@@ -20,6 +20,8 @@ var TeacherFaq = injectIntl(React.createClass({
                         <dl>
                             <dt><FormattedMessage id='teacherfaq.teacherWhatTitle' /></dt>
                             <dd><FormattedHTMLMessage id='teacherfaq.teacherWhatBody' /></dd>
+                            <iframe width="565" height="318" src="https://www.youtube.com/embed/7Hl9GxA1zwQ"
+                            frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen>...</iframe>
                             <dt><FormattedMessage id='teacherfaq.teacherQuestionsTitle' /></dt>
                             <dd><FormattedHTMLMessage id='teacherfaq.teacherQuestionsBody' /></dd>
                             <dt><FormattedMessage id='teacherfaq.teacherConvertTitle' /></dt>

--- a/src/views/teachers/faq/faq.jsx
+++ b/src/views/teachers/faq/faq.jsx
@@ -21,7 +21,7 @@ var TeacherFaq = injectIntl(React.createClass({
                             <dt><FormattedMessage id='teacherfaq.teacherWhatTitle' /></dt>
                             <dd><FormattedHTMLMessage id='teacherfaq.teacherWhatBody' /></dd>
                             <iframe width="565" height="318" src="https://www.youtube.com/embed/7Hl9GxA1zwQ"
-                            frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen>...</iframe>
+                            frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
                             <dt><FormattedMessage id='teacherfaq.teacherQuestionsTitle' /></dt>
                             <dd><FormattedHTMLMessage id='teacherfaq.teacherQuestionsBody' /></dd>
                             <dt><FormattedMessage id='teacherfaq.teacherConvertTitle' /></dt>

--- a/src/views/teachers/faq/l10n.json
+++ b/src/views/teachers/faq/l10n.json
@@ -1,7 +1,7 @@
 {
     "teacherfaq.title": "Scratch Teacher Account FAQ",
     "teacherfaq.teacherWhatTitle": "What are teacher accounts?",
-    "teacherfaq.teacherWhatBody": "A Scratch Teacher Account provides teachers and other educators with additional features to manage student participation on Scratch, including the ability to create student accounts, organize student projects into studios, and monitor student comments. Learn more about Teacher Accounts in <a href=\"https://www.youtube.com/watch?v=7Hl9GxA1zwQ\">this video</a>.",
+    "teacherfaq.teacherWhatBody": "A Scratch Teacher Account provides teachers and other educators with additional features to manage student participation on Scratch, including the ability to create student accounts, organize student projects into studios, and monitor student comments. Learn more about Teacher Accounts in the video below:",
     "teacherfaq.teacherQuestionsTitle": "What if I have any questions or comments on Teacher Accounts?",
     "teacherfaq.teacherQuestionsBody": "If you have any questions or feedback on Teacher Accounts please send us a message through <a href=\"/contact-us\">Contact Us</a>.",
     "teacherfaq.teacherConvertTitle": "Can I convert my Scratch account into a Teacher Account?",


### PR DESCRIPTION
This PR fixes #806 by embedding the youtube video using `iframe` and amending the text to what was suggested by @kaschm :)

This is what the page looks like for me after the PR on my local host:
<img width="1280" alt="screen shot 2016-08-09 at 10 21 11 am" src="https://cloud.githubusercontent.com/assets/16446551/17519703/0ab67de2-5e1b-11e6-8e17-03cdf4d7b96f.png">

Hope this helps!
@thisandagain @mewtaylor @rschamp @technoboy10