### PR TITLE
[Master] Fix GH-828: check street number range for address

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -18,9 +18,7 @@ var urlParams = require('./url-params');
 module.exports = function (opts, callback) {
     defaultsDeep(opts, {
         host: process.env.API_HOST,
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest'
-        },
+        headers: {},
         responseType: 'json',
         useCsrf: false
     });
@@ -52,6 +50,8 @@ module.exports = function (opts, callback) {
                 opts.uri = parts[0] + '?' + qs;
 
             }
+        } else {
+            opts['X-Requested-With'] = 'XMLHttpRequest';
         }
         xhr(opts, function (err, res, body) {
             if (err) log.error(err);

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,4 +1,5 @@
 var defaults = require('lodash.defaults');
+var defaultsDeep = require('lodash.defaultsdeep');
 var xhr = require('xhr');
 
 var jar  = require('./jar');
@@ -15,15 +16,13 @@ var urlParams = require('./url-params');
  */
 
 module.exports = function (opts, callback) {
-    defaults(opts, {
+    defaultsDeep(opts, {
         host: process.env.API_HOST,
-        headers: {},
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+        },
         responseType: 'json',
         useCsrf: false
-    });
-
-    defaults(opts.headers, {
-        'X-Requested-With': 'XMLHttpRequest'
     });
 
     opts.uri = opts.host + opts.uri;
@@ -43,7 +42,9 @@ module.exports = function (opts, callback) {
             // For IE < 10, we must use XDR for cross-domain requests. XDR does not support
             // custom headers.
             defaults(opts, {useXDR: true});
-            delete opts.headers;
+            if (opts.useXDR) {
+                delete opts.headers;
+            }
             if (opts.authentication) {
                 var authenticationParams = ['x-token=' + opts.authentication];
                 var parts = opts.uri.split('?');

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,4 @@
 var defaults = require('lodash.defaults');
-var defaultsDeep = require('lodash.defaultsdeep');
 var xhr = require('xhr');
 
 var jar  = require('./jar');
@@ -16,7 +15,7 @@ var urlParams = require('./url-params');
  */
 
 module.exports = function (opts, callback) {
-    defaultsDeep(opts, {
+    defaults(opts, {
         host: process.env.API_HOST,
         headers: {},
         responseType: 'json',

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -22,6 +22,12 @@ module.exports = function (opts, callback) {
         useCsrf: false
     });
 
+    if (opts.host === '') {
+        defaults(opts.headers, {
+            'X-Requested-With': 'XMLHttpRequest'
+        });
+    }
+
     opts.uri = opts.host + opts.uri;
 
     if (opts.params) {
@@ -49,8 +55,6 @@ module.exports = function (opts, callback) {
                 opts.uri = parts[0] + '?' + qs;
 
             }
-        } else {
-            opts['X-Requested-With'] = 'XMLHttpRequest';
         }
         xhr(opts, function (err, res, body) {
             if (err) log.error(err);

--- a/src/lib/smarty-streets.js
+++ b/src/lib/smarty-streets.js
@@ -8,7 +8,11 @@ module.exports = function smartyStreetApi (params, callback) {
     api({
         host: 'https://api.smartystreets.com',
         uri: '/street-address',
-        params: params
+        headers: {
+            'X-Standardize-Only': true
+        },
+        params: params,
+        useXDR: false
     }, function (err, body, res) {
         if (err) return callback(err);
         if (res.statusCode !== 200) {

--- a/src/lib/smarty-streets.js
+++ b/src/lib/smarty-streets.js
@@ -3,16 +3,13 @@ var api = require('./api');
 
 module.exports = function smartyStreetApi (params, callback) {
     defaults(params, {
-        'auth-id': process.env.SMARTY_STREETS_API_KEY
+        'auth-id': process.env.SMARTY_STREETS_API_KEY,
+        'match': 'range'
     });
     api({
         host: 'https://api.smartystreets.com',
         uri: '/street-address',
-        headers: {
-            'X-Standardize-Only': true
-        },
-        params: params,
-        useXDR: false
+        params: params
     }, function (err, body, res) {
         if (err) return callback(err);
         if (res.statusCode !== 200) {


### PR DESCRIPTION
This makes use of a custom header used by Smarty Streets (https://smartystreets.com/docs/us-street-api#x-standardize-only) which uses street number ranges, rather than exact addresses, to return results. This can help if, for some reason, we have someone sign up whose post office listing has not been updated, for instance. 

Fixes #828.