### PR TITLE
Fix GH-760: Add username `not equals` to password validation

### DIFF
--- a/src/components/footer/conference/footer.scss
+++ b/src/components/footer/conference/footer.scss
@@ -35,7 +35,7 @@
 
             .intel {
                 img {
-                    max-height: 50px
+                    max-height: 50px;
                 }
             }
         }

--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -23,6 +23,7 @@ module.exports.validations = {
         return phoneNumberUtil.isValidNumber(parsed);
     }
 };
+module.exports.validations.notEqualsUsername = module.exports.validations.notEquals;
 
 module.exports.validationHOCFactory = function (defaultValidationErrors) {
     return function (Component) {

--- a/src/components/login/login.scss
+++ b/src/components/login/login.scss
@@ -7,11 +7,11 @@
         padding-top: 5px;
         font-weight: bold;
     }
-    
+
     .right {
         float: right;
     }
-    
+
     .spinner {
         margin: 0 .8rem;
         width: 1rem;

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -226,6 +226,7 @@ module.exports = {
     ChoosePasswordStep: intl.injectIntl(React.createClass({
         getDefaultProps: function () {
             return {
+                studentUsername: null,
                 showPassword: false,
                 waiting: false
             };
@@ -257,7 +258,7 @@ module.exports = {
                                    validations={{
                                        minLength: 6,
                                        notEquals: 'password',
-                                       notEqualsField: 'user.username'
+                                       notEqualsUsername: this.props.studentUsername
                                    }}
                                    validationErrors={{
                                        minLength: formatMessage({
@@ -266,7 +267,7 @@ module.exports = {
                                        notEquals: formatMessage({
                                            id: 'registration.validationPasswordNotEquals'
                                        }),
-                                       notEqualsField: formatMessage({
+                                       notEqualsUsername: formatMessage({
                                            id: 'registration.validationPasswordNotUsername'
                                        })
                                    }}
@@ -879,7 +880,11 @@ module.exports = {
             };
         },
         onNextStep: function () {
-            this.props.onNextStep();
+            this.props.onNextStep({
+                user: {
+                    username: this.props.studentUsername
+                }
+            });
         },
         render: function () {
             var formatMessage = this.props.intl.formatMessage;

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -226,7 +226,7 @@ module.exports = {
     ChoosePasswordStep: intl.injectIntl(React.createClass({
         getDefaultProps: function () {
             return {
-                studentUsername: null,
+                username: null,
                 showPassword: false,
                 waiting: false
             };
@@ -258,7 +258,7 @@ module.exports = {
                                    validations={{
                                        minLength: 6,
                                        notEquals: 'password',
-                                       notEqualsUsername: this.props.studentUsername
+                                       notEqualsUsername: this.props.username
                                    }}
                                    validationErrors={{
                                        minLength: formatMessage({
@@ -880,11 +880,7 @@ module.exports = {
             };
         },
         onNextStep: function () {
-            this.props.onNextStep({
-                user: {
-                    username: this.props.studentUsername
-                }
-            });
+            this.props.onNextStep();
         },
         render: function () {
             var formatMessage = this.props.intl.formatMessage;

--- a/src/main.scss
+++ b/src/main.scss
@@ -164,7 +164,7 @@ dl {
     dt {
         font-weight: 700;
     }
-    
+
     dd {
         margin: 0;
     }

--- a/src/views/studentcompleteregistration/studentcompleteregistration.jsx
+++ b/src/views/studentcompleteregistration/studentcompleteregistration.jsx
@@ -133,10 +133,7 @@ var StudentCompleteRegistration = intl.injectIntl(React.createClass({
                                 <Steps.ChoosePasswordStep onNextStep={this.advanceStep}
                                                           showPassword={true}
                                                           waiting={this.state.waiting}
-                                                          studentUsername={
-                                                              this.state.formData.user &&
-                                                              this.state.formData.user.username
-                                                          } />
+                                                          username={this.props.studentUsername} />
                             :
                                 []
                             }

--- a/src/views/studentcompleteregistration/studentcompleteregistration.jsx
+++ b/src/views/studentcompleteregistration/studentcompleteregistration.jsx
@@ -132,7 +132,11 @@ var StudentCompleteRegistration = intl.injectIntl(React.createClass({
                             {this.props.must_reset_password ?
                                 <Steps.ChoosePasswordStep onNextStep={this.advanceStep}
                                                           showPassword={true}
-                                                          waiting={this.state.waiting} />
+                                                          waiting={this.state.waiting}
+                                                          studentUsername={
+                                                              this.state.formData.user &&
+                                                              this.state.formData.user.username
+                                                          } />
                             :
                                 []
                             }


### PR DESCRIPTION
for Student Complete Registration. This fixes #760.

### Test Cases ###
* Sign in as a student, and be redirected to the registration page. You should not be able to use your own username as a password
* Regression tests: 
  * Should not be able to use "password" as your password
  * Password should be longer than 6 characters