### PR TITLE
[Master] Hotfix GH-835: Add maxLength validations when needed

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -35,7 +35,6 @@
         padding: 1rem;
         max-width: 18.75rem;
         min-height: 1rem;
-        max-height: 3rem;
         overflow: visible;
         color: $type-white;
 

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -27,12 +27,14 @@ var Tooltip = require('../../components/tooltip/tooltip.jsx');
 require('./steps.scss');
 
 var DEFAULT_COUNTRY = 'us';
-var getCountryOptions = function (defaultCountry, intl) {
-    if (typeof intl === 'undefined') {
-        intl = defaultCountry;
-        defaultCountry = undefined;
-    }
 
+/**
+ * Return a list of options to give to frc select
+ * @param  {Object} intl           react-intl, used to localize strings
+ * @param  {String} defaultCountry optional string of default country to put at top of list
+ * @return {Object}                ordered set of county options formatted for frc select
+ */
+var getCountryOptions = function (intl, defaultCountry) {
     var options = countryData.countryOptions.concat({
         label: intl.formatMessage({id: 'registration.selectCountry'}),
         disabled: true,
@@ -352,7 +354,7 @@ module.exports = {
                             </div>
                             <Select label={formatMessage({id: 'general.country'})}
                                     name="user.country"
-                                    options={getCountryOptions(DEFAULT_COUNTRY, this.props.intl)}
+                                    options={getCountryOptions(this.props.intl, DEFAULT_COUNTRY)}
                                     required />
                             <Checkbox className="demographics-checkbox-is-robot"
                                       label="I'm a robot!"

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -27,9 +27,14 @@ var Tooltip = require('../../components/tooltip/tooltip.jsx');
 require('./steps.scss');
 
 var DEFAULT_COUNTRY = 'us';
-var getCountryOptions = function (defaultCountry) {
+var getCountryOptions = function (defaultCountry, intl) {
+    if (typeof intl === 'undefined') {
+        intl = defaultCountry;
+        defaultCountry = undefined;
+    }
+
     var options = countryData.countryOptions.concat({
-        label: <intl.FormattedMessage id="registration.selectCountry" />,
+        label: intl.formatMessage({id: 'registration.selectCountry'}),
         disabled: true,
         selected: true
     });
@@ -347,7 +352,7 @@ module.exports = {
                             </div>
                             <Select label={formatMessage({id: 'general.country'})}
                                     name="user.country"
-                                    options={getCountryOptions(DEFAULT_COUNTRY)}
+                                    options={getCountryOptions(DEFAULT_COUNTRY, this.props.intl)}
                                     required />
                             <Checkbox className="demographics-checkbox-is-robot"
                                       label="I'm a robot!"
@@ -660,7 +665,7 @@ module.exports = {
                         <Form onValidSubmit={this.onValidSubmit}>
                             <Select label={formatMessage({id: 'general.country'})}
                                     name="address.country"
-                                    options={getCountryOptions()}
+                                    options={getCountryOptions(this.props.intl)}
                                     value={this.props.defaultCountry}
                                     onChange={this.onChangeCountry}
                                     required />

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -333,6 +333,14 @@ module.exports = {
                             <div className="gender-input">
                                 <Input name="user.genderOther"
                                        type="text"
+                                       validations={{
+                                           maxLength: 25
+                                       }}
+                                       validationErrors={{
+                                           maxLength: formatMessage({
+                                               id: 'registration.validationMaxLength'
+                                           })
+                                       }}
                                        disabled={this.state.otherDisabled}
                                        required={!this.state.otherDisabled}
                                        help={null} />
@@ -376,10 +384,26 @@ module.exports = {
                             <Input label={formatMessage({id: 'teacherRegistration.firstName'})}
                                    type="text"
                                    name="user.name.first"
+                                   validations={{
+                                       maxLength: 50
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <Input label={formatMessage({id: 'teacherRegistration.lastName'})}
                                    type="text"
                                    name="user.name.last"
+                                   validations={{
+                                       maxLength: 50
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <NextStepButton waiting={this.props.waiting}
                                             text={<intl.FormattedMessage id="registration.nextStep" />} />
@@ -498,10 +522,26 @@ module.exports = {
                             <Input label={formatMessage({id: 'teacherRegistration.organization'})}
                                    type="text"
                                    name="organization.name"
+                                   validations={{
+                                       maxLength: 50
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <Input label={formatMessage({id: 'teacherRegistration.orgTitle'})}
                                    type="text"
                                    name="organization.title"
+                                   validations={{
+                                       maxLength: 50
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <div className="organization-type">
                                 <b><intl.FormattedMessage id="teacherRegistration.orgType" /></b>
@@ -517,6 +557,14 @@ module.exports = {
                             <div className="other-input">
                                 <Input type="text"
                                        name="organization.other"
+                                       validations={{
+                                           maxLength: 50
+                                       }}
+                                       validationErrors={{
+                                           maxLength: formatMessage({
+                                               id: 'registration.validationMaxLength'
+                                           })
+                                       }}
                                        disabled={this.state.otherDisabled}
                                        required="isFalse"
                                        placeholder={formatMessage({id: 'general.other'})} />
@@ -528,6 +576,14 @@ module.exports = {
                                 </p>
                                 <Input type="url"
                                        name="organization.url"
+                                       validations={{
+                                           maxLength: 200
+                                       }}
+                                       validationErrors={{
+                                           maxLength: formatMessage({
+                                               id: 'registration.validationMaxLength'
+                                           })
+                                       }}
                                        required="isFalse"
                                        placeholder={'http://'} />
                             </div>
@@ -611,14 +667,38 @@ module.exports = {
                             <Input label={formatMessage({id: 'teacherRegistration.addressLine1'})}
                                    type="text"
                                    name="address.line1"
+                                   validations={{
+                                       maxLength: 100
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <Input label={formatMessage({id: 'teacherRegistration.addressLine2'})}
                                    type="text"
                                    name="address.line2"
+                                   validations={{
+                                       maxLength: 100
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required="isFalse" />
                             <Input label={formatMessage({id: 'teacherRegistration.city'})}
                                    type="text"
                                    name="address.city"
+                                   validations={{
+                                       maxLength: 50
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             {stateOptions.length > 2 ?
                                 <Select label={formatMessage({id: 'teacherRegistration.stateProvince'})}
@@ -630,6 +710,14 @@ module.exports = {
                             <Input label={formatMessage({id: 'teacherRegistration.zipCode'})}
                                    type="text"
                                    name="address.zip"
+                                   validations={{
+                                       maxLength: 10
+                                   }}
+                                   validationErrors={{
+                                       maxLength: formatMessage({
+                                           id: 'registration.validationMaxLength'
+                                       })
+                                   }}
                                    required />
                             <GeneralError name="all" />
                             <NextStepButton waiting={this.props.waiting || this.state.waiting}

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -139,7 +139,7 @@
     "registration.studentUsernameFieldHelpText": "For safety, don't use your real name!",
     "registration.usernameStepTitle": "Request a Teacher Account",
     "registration.usernameStepTitleScratcher": "Create a Scratch Account",
-    "registration.validationMaxLength": "Sorry, that is too many characters for us.",
+    "registration.validationMaxLength": "Sorry, you have exceeded the maximum character limit.",
     "registration.validationPasswordLength": "Passwords must be at least six characters",
     "registration.validationPasswordNotEquals": "Your password may not be \"password\"",
     "registration.validationPasswordNotUsername": "Your password may not be your username",

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -139,6 +139,7 @@
     "registration.studentUsernameFieldHelpText": "For safety, don't use your real name!",
     "registration.usernameStepTitle": "Request a Teacher Account",
     "registration.usernameStepTitleScratcher": "Create a Scratch Account",
+    "registration.validationMaxLength": "Sorry, that is too many characters for us.",
     "registration.validationPasswordLength": "Passwords must be at least six characters",
     "registration.validationPasswordNotEquals": "Your password may not be \"password\"",
     "registration.validationPasswordNotUsername": "Your password may not be your username",


### PR DESCRIPTION
This fixes #835 by adding maxlength validations for: first name, last name, organization name, organization role, organization url, gender input, address line 1, address line 2, zip code, city.

This also changes `getCountryOptions` to take in a required argument of `intl`, which is meant to be the currently injected `react-intl` object, so that it can localize the `select country` string on its own. This eliminates hundreds of console warnings, since the previously used `<FormattedMessage />` component would wrap each option in a `span`, which threw a warning for react. 

### Test Cases ###
* These fields should say they're too long after *more than 50* characters are typed:
  * first name, last name, organization name, organization role, city
* These fields should say they're too long after *more than 100* characters are typed: 
  * address line 1, address line 2
* `gender` should say it's too long after 25 characters
* `zip` should say it's too long after 10 characters
* `organization url` should say it's too long after 200 characters
