### PR TITLE
For GH-835: eliminate max height of validation messsage

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -35,7 +35,6 @@
         padding: 1rem;
         max-width: 18.75rem;
         min-height: 1rem;
-        max-height: 3rem;
         overflow: visible;
         color: $type-white;
 


### PR DESCRIPTION
now that it’s not centered but rather top/down, we don’t need this anymore. This was breaking with the new max character copy.