### PR TITLE
Add missing locale strings for localization

### DIFF
--- a/src/components/thumbnail/thumbnail.jsx
+++ b/src/components/thumbnail/thumbnail.jsx
@@ -1,5 +1,6 @@
-var React = require('react');
 var classNames = require('classnames');
+var FormattedMessage = require('react-intl').FormattedMessage;
+var React = require('react');
 
 require('./thumbnail.scss');
 
@@ -32,7 +33,10 @@ var Thumbnail = React.createClass({
         if (this.props.creator) {
             extra.push(
                 <div key="creator" className="thumbnail-creator">
-                    by <a href={'/users/' + this.props.creator + '/'}>{this.props.creator}</a>
+                    <FormattedMessage id={'thumbnail.by'} />{' '}
+                    <a href={'/users/' + this.props.creator + '/'}>
+                        {this.props.creator}
+                    </a>
                 </div>
             );
         }

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -57,6 +57,7 @@
     "general.privacyPolicy": "Privacy Policy",
     "general.projects": "Projects",
     "general.profile": "Profile",
+    "general.resourcesTitle": "Educator Resources",
     "general.scratchConference": "Scratch Conference",
     "general.scratchday": "Scratch Day",
     "general.scratchEd": "ScratchEd",

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -154,5 +154,7 @@
     "registration.waitForApprovalDescription": "You can log into your Scratch Account now, but the features specific to Teachers are not yet available. Your information is being reviewed. Please be patient, the approval process can take up to 24 hours. You will receive an email indicating your account has been upgraded once your account has been approved.",
     "registration.welcomeStepDescription": "You have successfully set up a Scratch account! You are now a member of the class:",
     "registration.welcomeStepPrompt": "To get started, click on the button below.",
-    "registration.welcomeStepTitle": "Hurray! Welcome to Scratch!"
+    "registration.welcomeStepTitle": "Hurray! Welcome to Scratch!",
+
+    "thumbnail.by": "by"
 }

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -111,10 +111,12 @@ var Explore = injectIntl(React.createClass({
         );
     },
     render: function () {
+        var formatMessage = this.props.intl.formatMessage;
+
         return (
             <div>
                 <div className='outer'>
-                    <Box title={'Explore'}>
+                    <Box title={formatMessage({id: 'general.explore'})}>
                         <SubNavigation className='categories'>
                             {this.getBubble('all')}
                             {this.getBubble('animations')}

--- a/src/views/splash/l10n.json
+++ b/src/views/splash/l10n.json
@@ -26,7 +26,6 @@
     "teacherbanner.greeting": "Hi",
     "teacherbanner.subgreeting": "Teacher Account",
     "teacherbanner.classesButton": "My Classes",
-    "teacherbanner.resourcesButton": "Educator Resources",
     "teacherbanner.faqButton": "Teacher Account FAQ",
 
     "welcome.welcomeToScratch": "Welcome to Scratch!",

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -324,7 +324,7 @@ var Splash = injectIntl(React.createClass({
             'teacherbanner.greeting': formatMessage({id: 'teacherbanner.greeting'}),
             'teacherbanner.subgreeting': formatMessage({id: 'teacherbanner.subgreeting'}),
             'teacherbanner.classesButton': formatMessage({id: 'teacherbanner.classesButton'}),
-            'teacherbanner.resourcesButton': formatMessage({id: 'teacherbanner.resourcesButton'}),
+            'teacherbanner.resourcesButton': formatMessage({id: 'general.resourcesTitle'}),
             'teacherbanner.faqButton': formatMessage({id: 'teacherbanner.faqButton'})
         };
         if (this.state.projectCount === this.getInitialState().projectCount) {

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -189,16 +189,12 @@ var Splash = injectIntl(React.createClass({
 
         var rows = [
             <Box
-                    title={formatMessage({
-                        id: 'splash.featuredProjects',
-                        defaultMessage: 'Featured Projects'})}
+                    title={formatMessage({id: 'splash.featuredProjects'})}
                     key="community_featured_projects">
                 <Carousel items={this.state.featuredGlobal.community_featured_projects} />
             </Box>,
             <Box
-                    title={formatMessage({
-                        id: 'splash.featuredStudios',
-                        defaultMessage: 'Featured Studios'})}
+                    title={formatMessage({id: 'splash.featuredStudios'})}
                     key="community_featured_studios">
                 <Carousel items={this.state.featuredGlobal.community_featured_studios}
                           settings={{slidesToShow: 4, slidesToScroll: 4, lazyLoad: false}} />
@@ -216,8 +212,8 @@ var Splash = injectIntl(React.createClass({
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
                         moreTitle={formatMessage({id: 'general.learnMore', defaultMessage: 'Learn More'})}
                         moreHref="/studios/386359/">
-                    <Carousel
-                        items={this.state.featuredGlobal.curator_top_projects} />
+                    
+                    <Carousel items={this.state.featuredGlobal.curator_top_projects} />
                 </Box>
             );
         }
@@ -229,14 +225,12 @@ var Splash = injectIntl(React.createClass({
                 <Box
                         key="scratch_design_studio"
                         title={
-                            formatMessage({
-                                id: 'splash.scratchDesignStudioTitle',
-                                defaultMessage: 'Scratch Design Studio' })
+                            formatMessage({id: 'splash.scratchDesignStudioTitle'})
                             + ' - ' + this.state.featuredGlobal.scratch_design_studio[0].gallery_title}
                         moreTitle={formatMessage({id: 'splash.visitTheStudio', defaultMessage: 'Visit the studio'})}
                         moreHref={'/studios/' + this.state.featuredGlobal.scratch_design_studio[0].gallery_id + '/'}>
-                    <Carousel
-                        items={this.state.featuredGlobal.scratch_design_studio} />
+                    
+                    <Carousel items={this.state.featuredGlobal.scratch_design_studio} />
                 </Box>
             );
         }
@@ -246,14 +240,9 @@ var Splash = injectIntl(React.createClass({
             this.state.featuredGlobal.community_newest_projects.length > 0) {
 
             rows.push(
-                <Box
-                        title={
-                            formatMessage({
-                                id: 'splash.recentlySharedProjects',
-                                defaultMessage: 'Recently Shared Projects' })}
-                        key="community_newest_projects">
-                    <Carousel
-                        items={this.state.featuredGlobal.community_newest_projects} />
+                <Box title={formatMessage({id: 'splash.recentlySharedProjects'})}
+                     key="community_newest_projects">
+                    <Carousel items={this.state.featuredGlobal.community_newest_projects} />
                 </Box>
             );
         }
@@ -262,12 +251,9 @@ var Splash = injectIntl(React.createClass({
             this.state.featuredCustom.custom_projects_by_following.length > 0) {
 
             rows.push(
-                <Box title={
-                            formatMessage({
-                                id: 'splash.projectsByScratchersFollowing',
-                                defaultMessage: 'Projects by Scratchers I\'m Following'})}
+                <Box title={formatMessage({id: 'splash.projectsByScratchersFollowing'})}
                      key="custom_projects_by_following">
-
+                    
                     <Carousel items={this.state.featuredCustom.custom_projects_by_following} />
                 </Box>
             );
@@ -276,12 +262,9 @@ var Splash = injectIntl(React.createClass({
             this.state.featuredCustom.custom_projects_loved_by_following.length > 0) {
 
             rows.push(
-                <Box title={
-                            formatMessage({
-                                id: 'splash.projectsLovedByScratchersFollowing',
-                                defaultMessage: 'Projects Loved by Scratchers I\'m Following'})}
+                <Box title={formatMessage({id: 'splash.projectsLovedByScratchersFollowing'})}
                      key="custom_projects_loved_by_following">
-
+                    
                     <Carousel items={this.state.featuredCustom.custom_projects_loved_by_following} />
                 </Box>
             );
@@ -291,31 +274,22 @@ var Splash = injectIntl(React.createClass({
             this.state.featuredCustom.custom_projects_in_studios_following.length > 0) {
 
             rows.push(
-                <Box title={
-                            formatMessage({
-                                id:'splash.projectsInStudiosFollowing',
-                                defaultMessage: 'Projects in Studios I\'m Following'})}
+                <Box title={formatMessage({id:'splash.projectsInStudiosFollowing'})}
                      key="custom_projects_in_studios_following">
-
+                    
                     <Carousel items={this.state.featuredCustom.custom_projects_in_studios_following} />
                 </Box>
             );
         }
 
         rows.push(
-            <Box title={
-                        formatMessage({
-                            id: 'splash.communityRemixing',
-                            defaultMessage: 'What the Community is Remixing' })}
+            <Box title={formatMessage({id: 'splash.communityRemixing'})}
                  key="community_most_remixed_projects">
 
                 <Carousel items={shuffle(this.state.featuredGlobal.community_most_remixed_projects)}
                           showRemixes={true} />
             </Box>,
-            <Box title={
-                        formatMessage({
-                            id: 'splash.communityLoving',
-                            defaultMessage: 'What the Community is Loving' })}
+            <Box title={formatMessage({id: 'splash.communityLoving'})}
                  key="community_most_loved_projects">
 
                 <Carousel items={shuffle(this.state.featuredGlobal.community_most_loved_projects)}

--- a/src/views/teachers/landing/l10n.json
+++ b/src/views/teachers/landing/l10n.json
@@ -8,7 +8,6 @@
     "teacherlanding.generalUsageSettings": "<b>Settings:</b> schools, museums, libraries, community centers",
     "teacherlanding.generalUsageGradeLevels": "<b>Grade Levels:</b> elementary, middle, and high school (and some colleges too!)",
     "teacherlanding.generalUsageSubjectAreas": "<b>Subject Areas:</b> language arts, science, social studies, math, computer science, foreign languages, and the arts",
-    "teacherlanding.resourcesTitle": "Educator Resources",
     "teacherlanding.scratchEdTitle": "A Community for Educators",
     "teacherlanding.scratchEdDescription": "<a href=\"http://scratched.gse.harvard.edu/\">ScratchEd</a> is an online community where Scratch educators <a href=\"http://scratched.gse.harvard.edu/stories\">share stories</a>, exchange resources, ask questions, and find people. ScratchEd is developed and supported by the Harvard Graduate School of Education.",
     "teacherlanding.meetupTitle": "In-Person Gatherings",

--- a/src/views/teachers/landing/landing.jsx
+++ b/src/views/teachers/landing/landing.jsx
@@ -64,7 +64,7 @@ var Landing = injectIntl(React.createClass({
                     </section>
                     <section id="resources">
                         <span className="nav-spacer"></span>
-                        <h2><FormattedMessage id="teacherlanding.resourcesTitle" /></h2>
+                        <h2><FormattedMessage id="general.resourcesTitle" /></h2>
                         <FlexRow className="educator-community">
                             <div>
                                 <h3><FormattedMessage id="teacherlanding.scratchEdTitle" /></h3>


### PR DESCRIPTION
This is part of https://github.com/LLK/scratchr2/pull/3955, adding strings that have been ported over:
* "by" in thumbnails
* "Explore" header on the Explore page

It also does a bit of cleanup on the splash page to format the intl handling as we do on other pages  (i.e. remove `defaultMessage` from being inline, just use the `id`)

[UPDATE] Also fixes #840.