### PR TITLE
Allow an optional / in teacher registration URL

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -105,7 +105,7 @@
     },
     {
         "name": "teacherregistration",
-        "pattern": "^/educators/register$",
+        "pattern": "^/educators/register/?$",
         "routeAlias": "/educators(?:/(faq|register|waiting))?/?$",
         "view": "teacherregistration/teacherregistration",
         "title": "Teacher Registration",


### PR DESCRIPTION
Resolves LLK/scratchr2#3895

## Test case
* Go to /educators/registration — you should see the teacher registration page
* Go to /educators/registration/ — you should see the teacher registration page (not a 403)