### PR TITLE
Fix GH-825: Only require zip code for US addresses

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -745,7 +745,7 @@ module.exports = {
                                            id: 'registration.validationMaxLength'
                                        })
                                    }}
-                                   required />
+                                   required={(this.state.countryChoice === 'us')} />
                             <GeneralError name="all" />
                             <NextStepButton waiting={this.props.waiting || this.state.waiting}
                                             text={<intl.FormattedMessage id="registration.nextStep" />} />


### PR DESCRIPTION
Since we only check for the US, only require for that country. Other countries have zip codes, but it seems better to do it this way than codify which countries do/do not have zip codes (in case local practices are not the same as international information). Fixes #825