### PR TITLE
Bugfix: Add webkit prefixes for safari 8

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ module.exports = {
         noParse: /node_modules\/google-libphonenumber\/dist/
     },
     postcss: function () {
-        return [autoprefixer({browsers: ['last 3 versions']})];
+        return [autoprefixer({browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']})];
     },
     node: {
         fs: 'empty'


### PR DESCRIPTION
`caniuse` updated their api recently, and it appears that support for safari 8 is no longer in the last 3 versions (and it appears that safari 8 is not listed as supported there in general). explicitly add the version back in to make sure the proper `-webkit` prefixes are included for that browser.