### PR TITLE
Fix gh-894: Community Guidelines Image

### DIFF
--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -1,4 +1,5 @@
 @import "../../colors";
+@import "../../frameless";
 
 .guidelines {
     .guidelines-footer {
@@ -10,5 +11,11 @@
         dt {
             margin-top: 1.5rem;
         }
+    }
+}
+
+@media only screen and (max-width: $tablet - 1){
+    .guidelines-footer {
+        display: none;
     }
 }


### PR DESCRIPTION
Update to hide page's footer image when the screen is too small.

Before:
![screenshot 1](https://cloud.githubusercontent.com/assets/12952370/18151892/7dc47af8-6fc0-11e6-9d89-22065c9ae6c2.png)

After:
![screenshot 2](https://cloud.githubusercontent.com/assets/12952370/18151897/87c795da-6fc0-11e6-9beb-c5c9b174f8f0.png)
