### PR TITLE
Fix GH-872: Check for username before sending

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -91,6 +91,13 @@ module.exports = {
         },
         validateUsername: function (username, callback) {
             callback = callback || function () {};
+            if (username.length < 1) {
+                this.refs.form.refs.formsy.updateInputsWithError({
+                    'user.username': formatMessage({id: 'teacherRegistration.validationRequired'})
+                });
+                return callback(false);
+            }
+
             api({
                 host: '',
                 uri: '/accounts/check_username/' + username + '/'

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -91,7 +91,7 @@ module.exports = {
         },
         validateUsername: function (username, callback) {
             callback = callback || function () {};
-            if (username.length < 1) {
+            if (!username) {
                 this.refs.form.refs.formsy.updateInputsWithError({
                     'user.username': formatMessage({id: 'teacherRegistration.validationRequired'})
                 });


### PR DESCRIPTION
the `//` for an empty username that gets sent to the backend causes a 500 error. This is an edge case in formsy, as it has not detected a change value yet, so handle it in the username validation method. Fixes #872