### PR TITLE
Use hashed bundle filenames to break cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ESLINT=./node_modules/.bin/eslint
 NODE=node
 SASSLINT=./node_modules/.bin/sass-lint -v
-S3CMD=s3cmd
+S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:public,max-age=86400
 TAP=./node_modules/.bin/tap
 WATCH=./node_modules/.bin/watch
 WEBPACK=./node_modules/.bin/webpack
@@ -31,9 +31,9 @@ webpack:
 	$(WEBPACK) --bail
 
 sync-s3:
-	$(S3CMD) sync -P --delete-removed --exclude '.DS_Store' --exclude '*.svg' --exclude '*.js' ./build/ s3://$(S3_BUCKET_NAME)/
-	$(S3CMD) sync -P --delete-removed --exclude '*' --include '*.svg' --mime-type 'image/svg+xml' ./build/ s3://$(S3_BUCKET_NAME)/
-	$(S3CMD) sync -P --delete-removed --exclude '*' --include '*.js' --mime-type 'application/javascript' ./build/ s3://$(S3_BUCKET_NAME)/	
+	$(S3CMD) --exclude '.DS_Store' --exclude '*.svg' --exclude '*.js' ./build/ s3://$(S3_BUCKET_NAME)/
+	$(S3CMD) --exclude '*' --include '*.svg' --mime-type 'image/svg+xml' ./build/ s3://$(S3_BUCKET_NAME)/
+	$(S3CMD) --exclude '*' --include '*.js' --mime-type 'application/javascript' ./build/ s3://$(S3_BUCKET_NAME)/
 
 sync-fastly:
 	$(NODE) ./bin/configure-fastly.js


### PR DESCRIPTION
This is a possible fix for #787. I am still not sure why the error occurs, nor why it's fixed by a refresh. However, I was able to reproduce the issue when deploying locally, and after using this, I wasn't able to anymore.  I did confirm that there was some sort of mismatch going on because the error is raised when a file in the view bundle was attempting to require the render function in the common bundle. This PR ensures that the view bundle and common bundle are always in sync.  That is, a new view bundle won't try to use an old common bundle's functions (or vice versa).

I had to change our template to use ejs rather than mustache because of the way I needed to retrieve the view bundle. But that gives us one less dependency, which I'm ok with.  I also did away with our custom html generator in favor of the html-webpack-plugin which webpack recommends and already provided the paths to the bundle names with the hashes.

It's worth keeping an eye on https://github.com/webpack/webpack/issues/959. The issue we were having looks similar, except that we don't see it locally.