### PR TITLE
Rename Albanian correctly

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -61,7 +61,7 @@
     "ro": "Română",
     "ru": "Русский",
     "sc": "Sardu",
-    "sq": "Shqiptar",
+    "sq": "Shqip",
     "sk": "Slovenčina",
     "sl": "Slovenščina",
     "sr": "Српски",


### PR DESCRIPTION
My bad on the misunderstanding! This correctly names Albanian in the language menu. Towards https://github.com/LLK/scratchr2/pull/4013.