### PR TITLE
Fix GH-590: initial automated test

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "sass-lint": "1.5.1",
     "sass-loader": "2.0.1",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
+    "selenium-webdriver": "^2.44.0",
     "slick-carousel": "1.5.8",
     "source-map-support": "0.3.2",
     "style-loader": "0.12.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "sass-lint": "1.5.1",
     "sass-loader": "2.0.1",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
-    "selenium-webdriver": "^2.44.0",
+    "selenium-webdriver": "2.44.0",
     "slick-carousel": "1.5.8",
     "source-map-support": "0.3.2",
     "style-loader": "0.12.3",

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -4,24 +4,26 @@
  * Test cases: https://github.com/LLK/scratch-www/wiki/Most-Important-Workflows#Create_should_take_you_to_the_editor
  */
 
-var tap=require('tap'),  
+var tap=require('tap'),
     seleniumWebdriver = require('selenium-webdriver');
 
 /*
  * Remove question comments after resolving them
  */
-//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate through the drivers for each browser here?
+//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate 
+//through the drivers for each browser here?
 //chrome driver
 var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
 //open scratch.ly in a new instance of the browser
-driver.get('https://scratch.ly')
+driver.get('https://scratch.ly');
 
 /*
  * Remove question comments after resolving them
  */
 //find the navbar
 //var navbarElement = driver.findElement(seleniumWebdriver.By.id("navigation"))
-//var createLinkSignedOut = navbarElement.findElement(seleniumWebdriver.By.xpath('//li[@class="link create"]/a')) <-- this doesn't work to force findElement to look in the scope of navbarElement
+//var createLinkSignedOut = navbarElement.findElement(seleniumWebdriver.By.xpath('//li[@class="link create"]/a'))
+//^^this doesn't work to force findElement to look in the scope of navbarElement
 
 //find the create link within the navbar
 //the create link depends on whether the user is signed in or not (tips window opens)
@@ -31,11 +33,11 @@ driver.get('https://scratch.ly')
  */
 //this xpath is fragile, can i look up by successive attributes instead?
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
-	var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath('//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a'));
-	createLinkSignedOut.getAttribute("href").then(function(href){
-		t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);
-		t.end();
-	});
+    var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath('//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a'));
+    createLinkSignedOut.getAttribute('href').then( function (href) {
+        t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);
+        t.end();
+    });
 });
  
 

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -14,15 +14,15 @@ driver.get('https://scratch.ly');
 
 //return only the part of the URL that is in the href in the page's html,
 //and the index that the href was found at
-function getHrefFromUrl(url, expectedHref) {
-	var hrefOnly = "";
-	var hrefIndex = url.lastIndexOf(expectedHref);
-	if (hrefIndex != -1) {
-        var hrefOnly = url.substr(hrefIndex);
-	};
+function getHrefFromUrl (url, expectedHref) {
+    var hrefOnly = '';
+    var hrefIndex = url.lastIndexOf(expectedHref);
+    if (hrefIndex != -1) {
+        hrefOnly = url.substr(hrefIndex);
+    }
     return {hrefIndex: hrefIndex,
             hrefOnly: hrefOnly};
-};
+}
 
 //find the create link within the navbar
 //the create link depends on whether the user is signed in or not (tips window opens)
@@ -30,17 +30,17 @@ tap.test('checkCreateLinkWhenSignedOut', function (t) {
     var xPathLink = '//li[contains(@class, "link") and contains(@class, "create")]/a';
     var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath(xPathLink));
     createLinkSignedOut.getAttribute('href').then( function (url) {
-    	//expected value of the href
-    	var expectedHref = '/projects/editor/?tip_bar=home';
-    	var hrefInfo = getHrefFromUrl(url, expectedHref);
-    	var hrefIndex = hrefInfo.hrefIndex;
-    	var hrefOnly = hrefInfo.hrefOnly;
-    	//the create href should match `/projects/editor/?tip_bar=home`
+        //expected value of the href
+        var expectedHref = '/projects/editor/?tip_bar=home';
+        var hrefInfo = getHrefFromUrl(url, expectedHref);
+        var hrefIndex = hrefInfo.hrefIndex;
+        var hrefOnly = hrefInfo.hrefOnly;
+        //the create href should match `/projects/editor/?tip_bar=home`
         t.equal(expectedHref, hrefOnly);
         //the create href should be at the end of the URL
         var urlLength = url.length;
         var urlLengthFromHrefInfo = hrefOnly.length + hrefIndex;
-        t.equal(urlLengthFromHrefInfo, urlLength)
+        t.equal(urlLengthFromHrefInfo, urlLength);
         t.end();
     });
 });

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -33,7 +33,7 @@ driver.get('https://scratch.ly');
  */
 //this xpath is fragile, can i look up by successive attributes instead?
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
-	var xPathLink = '//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a';
+    var xPathLink = '//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a';
     var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath(xPathLink));
     createLinkSignedOut.getAttribute('href').then( function (href) {
         t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -7,36 +7,40 @@
 var tap=require('tap');
 var seleniumWebdriver = require('selenium-webdriver');
 
-/*
- * Remove question comments after resolving them
- */
-//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate
-//through the drivers for each browser here?
 //chrome driver
 var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
 //open scratch.ly in a new instance of the browser
 driver.get('https://scratch.ly');
 
-/*
- * Remove question comments after resolving them
- */
-//find the navbar
-//var navbarElement = driver.findElement(seleniumWebdriver.By.id("navigation"))
-//var createLinkSignedOut = navbarElement.findElement(seleniumWebdriver.By.xpath('//li[@class="link create"]/a'))
-//^^this doesn't work to force findElement to look in the scope of navbarElement
+//return only the part of the URL that is in the href in the page's html,
+//and the index that the href was found at
+function getHrefFromUrl(url, expectedHref) {
+	var hrefOnly = "";
+	var hrefIndex = url.lastIndexOf(expectedHref);
+	if (hrefIndex != -1) {
+        var hrefOnly = url.substr(hrefIndex);
+	};
+    return {hrefIndex: hrefIndex,
+            hrefOnly: hrefOnly};
+};
 
 //find the create link within the navbar
 //the create link depends on whether the user is signed in or not (tips window opens)
-
-/*
- * Remove question comments after resolving them
- */
-//this xpath is fragile, can i look up by successive attributes instead?
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
-    var xPathLink = '//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a';
+    var xPathLink = '//li[contains(@class, "link") and contains(@class, "create")]/a';
     var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath(xPathLink));
-    createLinkSignedOut.getAttribute('href').then( function (href) {
-        t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);
+    createLinkSignedOut.getAttribute('href').then( function (url) {
+    	//expected value of the href
+    	var expectedHref = '/projects/editor/?tip_bar=home';
+    	var hrefInfo = getHrefFromUrl(url, expectedHref);
+    	var hrefIndex = hrefInfo.hrefIndex;
+    	var hrefOnly = hrefInfo.hrefOnly;
+    	//the create href should match `/projects/editor/?tip_bar=home`
+        t.equal(expectedHref, hrefOnly);
+        //the create href should be at the end of the URL
+        var urlLength = url.length;
+        var urlLengthFromHrefInfo = hrefOnly.length + hrefIndex;
+        t.equal(urlLengthFromHrefInfo, urlLength)
         t.end();
     });
 });

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -1,0 +1,38 @@
+/*
+ * Checks that the links in the navbar on the homepage have the right URLs to redirect to
+ *
+ * Test cases: https://github.com/LLK/scratch-www/wiki/Most-Important-Workflows#Create_should_take_you_to_the_editor
+ */
+
+var tap=require('tap'),  
+    seleniumWebdriver = require('selenium-webdriver');
+
+//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate through the drivers for each browser here?
+//chrome driver
+var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
+//open scratch.ly in a new instance of the browser
+driver.get('https://scratch.ly')
+
+/*
+ * Remove later after resolving these questions
+ */
+//find the navbar
+//var navbarElement = driver.findElement(seleniumWebdriver.By.id("navigation"))
+//var createLinkSignedOut = navbarElement.findElement(seleniumWebdriver.By.xpath('//li[@class="link create"]/a')) <-- this doesn't work to force findElement to look in the scope of navbarElement
+
+//find the create link within the navbar
+//the create link depends on whether the user is signed in or not (tips window opens)
+
+//this xpath is fragile, can i look up by successive attributes instead?
+tap.test('checkCreateLinkWhenSignedOut', function (t) {
+	var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath('//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a'));
+	createLinkSignedOut.getAttribute("href").then(function(href){
+		t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);
+		t.end();
+	});
+});
+ 
+
+// close the instance of the browser
+driver.quit();
+

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -7,6 +7,9 @@
 var tap=require('tap'),  
     seleniumWebdriver = require('selenium-webdriver');
 
+/*
+ * Remove question comments after resolving them
+ */
 //how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate through the drivers for each browser here?
 //chrome driver
 var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
@@ -14,7 +17,7 @@ var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.
 driver.get('https://scratch.ly')
 
 /*
- * Remove later after resolving these questions
+ * Remove question comments after resolving them
  */
 //find the navbar
 //var navbarElement = driver.findElement(seleniumWebdriver.By.id("navigation"))
@@ -23,6 +26,9 @@ driver.get('https://scratch.ly')
 //find the create link within the navbar
 //the create link depends on whether the user is signed in or not (tips window opens)
 
+/*
+ * Remove question comments after resolving them
+ */
 //this xpath is fragile, can i look up by successive attributes instead?
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
 	var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath('//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a'));

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -12,18 +12,6 @@ var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.
 //open scratch.ly in a new instance of the browser
 driver.get('https://scratch.ly');
 
-//return only the part of the URL that is in the href in the page's html,
-//and the index that the href was found at
-function getHrefFromUrl (url, expectedHref) {
-    var hrefOnly = '';
-    var hrefIndex = url.lastIndexOf(expectedHref);
-    if (hrefIndex != -1) {
-        hrefOnly = url.substr(hrefIndex);
-    }
-    return {hrefIndex: hrefIndex,
-            hrefOnly: hrefOnly};
-}
-
 //find the create link within the navbar
 //the create link depends on whether the user is signed in or not (tips window opens)
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
@@ -32,15 +20,10 @@ tap.test('checkCreateLinkWhenSignedOut', function (t) {
     createLinkSignedOut.getAttribute('href').then( function (url) {
         //expected value of the href
         var expectedHref = '/projects/editor/?tip_bar=home';
-        var hrefInfo = getHrefFromUrl(url, expectedHref);
-        var hrefIndex = hrefInfo.hrefIndex;
-        var hrefOnly = hrefInfo.hrefOnly;
         //the create href should match `/projects/editor/?tip_bar=home`
-        t.equal(expectedHref, hrefOnly);
         //the create href should be at the end of the URL
-        var urlLength = url.length;
-        var urlLengthFromHrefInfo = hrefOnly.length + hrefIndex;
-        t.equal(urlLengthFromHrefInfo, urlLength);
+        t.equal(url.substr(-expectedHref.length), expectedHref);
+        console.log(url.substr(-expectedHref.length));
         t.end();
     });
 });

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -23,7 +23,6 @@ tap.test('checkCreateLinkWhenSignedOut', function (t) {
         //the create href should match `/projects/editor/?tip_bar=home`
         //the create href should be at the end of the URL
         t.equal(url.substr(-expectedHref.length), expectedHref);
-        console.log(url.substr(-expectedHref.length));
         t.end();
     });
 });

--- a/test/integration/check_navbar_links.js
+++ b/test/integration/check_navbar_links.js
@@ -4,13 +4,13 @@
  * Test cases: https://github.com/LLK/scratch-www/wiki/Most-Important-Workflows#Create_should_take_you_to_the_editor
  */
 
-var tap=require('tap'),
-    seleniumWebdriver = require('selenium-webdriver');
+var tap=require('tap');
+var seleniumWebdriver = require('selenium-webdriver');
 
 /*
  * Remove question comments after resolving them
  */
-//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate 
+//how to generalize for other browsers... how will this work in saucelabs? Do I need to iterate
 //through the drivers for each browser here?
 //chrome driver
 var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
@@ -33,7 +33,8 @@ driver.get('https://scratch.ly');
  */
 //this xpath is fragile, can i look up by successive attributes instead?
 tap.test('checkCreateLinkWhenSignedOut', function (t) {
-    var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath('//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a'));
+	var xPathLink = '//div[@id="navigation"]/div[@class="inner"]/ul/li[@class="link create"]/a';
+    var createLinkSignedOut = driver.findElement(seleniumWebdriver.By.xpath(xPathLink));
     createLinkSignedOut.getAttribute('href').then( function (href) {
         t.equal('https://scratch.ly/projects/editor/?tip_bar=home', href);
         t.end();


### PR DESCRIPTION
This is what I have for the initial automated test per https://github.com/LLK/scratch-www/issues/590#issuecomment-243812155. The initial test is to check that the URL in the Create link in the navbar is correct when the user is signed out (without navigating to the editor, and using selenium and tap, as discussed).
There are some questions I have about it:
- A better solution than brittle XPath (I can continue looking into this; first I wanted to get something working)
- I set it up with a driver for Chrome; should I enumerate through the other available drivers here? How does this work with saucelabs?
- I created an integration folder in the test folder for these kinds of automated tests, but I am open to changing the structure
- Integration with travis? (I think it should be simple?)
- I looked at your existing test files in scratch-www and tried to copy your conventions in terms of naming files, functions, etc., but obviously please let me know of any corrections
- Should I add selenium to [devDependencies](https://github.com/LLK/scratch-www/blob/develop/package.json)? I see that tap is in the list, but you guys use tap for unit tests as well, so I wanted to check what would be appropriate?

/cc @rschamp & @mewtaylor 