### PR TITLE
Add ScratchJr to developers page

### DIFF
--- a/src/views/developers/developers.jsx
+++ b/src/views/developers/developers.jsx
@@ -97,6 +97,20 @@ var Developers = React.createClass({
 
                             <img className="sidebar column" src="/images/developers/www-sketch.png" alt="www" />
                         </FlexRow>
+                        <FlexRow className="sidebar-row">
+                            <div className="body-copy column">
+                                <h3>ScratchJr</h3>
+                                <p>
+                                    ScratchJr is an introductory programming language{' '}
+                                    that enables young children (ages 5-7) to create{' '}
+                                    their own interactive stories and games. For more{' '}
+                                    information, visit the{' '}
+                                    <a href="https://www.scratchjr.org/">ScratchJr website</a>{' '}
+                                    or access the code and documentation{' '}
+                                    <a href="https://github.com/LLK/scratchjr">here</a>.
+                                </p>
+                            </div>
+                        </FlexRow>
                     </section>
 
                     <section id="principles">


### PR DESCRIPTION
Fix #928. Following style of the rest of the developers page, assuming it's like this because of #924.

I took and slightly tweaked copy from the standard ScratchJr materials.

cc: @kaschm @thisandagain @chrisgarrity 