### PR TITLE
Fix GH-933: Put label for “Not Required” above input

### DIFF
--- a/src/components/forms/row.scss
+++ b/src/components/forms/row.scss
@@ -20,3 +20,8 @@
         }
     }
 }
+
+.row-label {
+    margin-bottom: .75rem;
+    line-height: 1.7rem;
+}

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -741,8 +741,15 @@ module.exports = {
                                         required /> :
                                 []
                             }
-                            <Input label={formatMessage({id: 'teacherRegistration.zipCode'})}
-                                   type="text"
+                            <b className="row-label">
+                                <intl.FormattedMessage id="teacherRegistration.zipCode" />
+                            </b>
+                            {this.state.countryChoice !== 'us' ?
+                                <p className="help-text">
+                                    <intl.FormattedMessage id="teacherRegistration.notRequired" />
+                                </p> : []
+                            }
+                            <Input type="text"
                                    name="address.zip"
                                    validations={{
                                        maxLength: 10
@@ -752,7 +759,7 @@ module.exports = {
                                            id: 'registration.validationMaxLength'
                                        })
                                    }}
-                                   required={(this.state.countryChoice === 'us')} />
+                                   required={(this.state.countryChoice === 'us') ? true : 'isFalse'} />
                             <GeneralError name="all" />
                             <NextStepButton waiting={this.props.waiting || this.state.waiting}
                                             text={<intl.FormattedMessage id="registration.nextStep" />} />


### PR DESCRIPTION
Fixes #933 by giving the "Not Required" styling used in organization url (i.e. separated out label elements)

/cc @rschamp 