### PR TITLE
Fix GH-899: Re-searching should not search for 'undefined'

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -75,7 +75,11 @@ var Search = injectIntl(React.createClass({
         }.bind(this));
     },
     onSearchSubmit: function (formData) {
-        window.location.href = '/search/projects?q=' + formData.q;
+        if (!formData.q){
+            window.location.href = '/search/projects?q=' + this.props.searchTerm;
+        } else {
+            window.location.href = '/search/projects?q=' + formData.q;
+        }
     },
     getTab: function (type) {
         var term = this.props.searchTerm.split(' ').join('+');

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -75,11 +75,7 @@ var Search = injectIntl(React.createClass({
         }.bind(this));
     },
     onSearchSubmit: function (formData) {
-        if (!formData.q){
-            window.location.href = '/search/projects?q=' + this.props.searchTerm;
-        } else {
-            window.location.href = '/search/projects?q=' + formData.q;
-        }
+        window.location.href = '/search/projects?q=' + formData.q;
     },
     getTab: function (type) {
         var term = this.props.searchTerm.split(' ').join('+');
@@ -114,7 +110,7 @@ var Search = injectIntl(React.createClass({
                                         <Input type="text"
                                                aria-label={formatMessage({id: 'general.search'})}
                                                placeholder={formatMessage({id: 'general.search'})}
-                                               defaultValue={decodeURI(this.props.searchTerm)}
+                                               value={decodeURI(this.props.searchTerm)}
                                                name="q" />
                                     </Form>
                                 </div>


### PR DESCRIPTION
This PR resolves #899 by adding a check for an undefined formData.q value (the search page populates the search bar's defaultValue, but not actual value), and searches for `this.props.searchTerm` if the check fails. 

Another option would be to prevent the user from searching the same term repeatedly, but I'm not sure what UX is preferable (having the page react like it normally done when searching, vs saving bandwidth/time by assuming the user doesn't want to search for the same thing again).