### PR TITLE
Use no-cache so ETags are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ESLINT=./node_modules/.bin/eslint
 NODE=node
 SASSLINT=./node_modules/.bin/sass-lint -v
-S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:public,max-age=3600
+S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600
 TAP=./node_modules/.bin/tap
 WATCH=./node_modules/.bin/watch
 WEBPACK=./node_modules/.bin/webpack

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -86,7 +86,7 @@ for (var v in routes) {
     if (typeof routes[v].redirect !== 'undefined') {
         continue;
     }
-    
+
     views.push(routes[v].name);
     try {
         var subdir = routes[v].view.split('/');
@@ -97,7 +97,8 @@ for (var v in routes) {
             en: ids
         };
         idsWithICU = merge(idsWithICU, localeCompare.idToICUMap(routes[v].name, ids));
-        icuWithIds = merge(icuWithIds, localeCompare.icuToIdMap(routes[v].name, ids));
+        // Note: if lodash.merge gets updated to 4.0 or higher this needs to be mergeWith instead
+        icuWithIds = merge(icuWithIds, localeCompare.icuToIdMap(routes[v].name, ids), localeCompare.customMerge);
     } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND') {
             throw err;

--- a/bin/lib/locale-compare.js
+++ b/bin/lib/locale-compare.js
@@ -6,7 +6,7 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 var po2icu = require('po2icu');
-var isArray = require('lodash.isArray');
+var isArray = require('lodash.isarray');
 
 var Helpers = {};
 

--- a/bin/lib/locale-compare.js
+++ b/bin/lib/locale-compare.js
@@ -6,6 +6,7 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 var po2icu = require('po2icu');
+var isArray = require('lodash.isArray');
 
 var Helpers = {};
 
@@ -18,6 +19,21 @@ var Helpers = {};
 Helpers.getMD5 = function (string) {
     var cleanedString = string.replace(/\s+/g, '');
     return crypto.createHash('md5').update(cleanedString, 'utf8').digest('hex');
+};
+
+/**
+ * Customizer for icuWithIds merge.
+ * If icu key already has an id value, concatenate additional ids instead
+ * of replacing.
+ *
+ * @param {array} objVal current value
+ * @param {string} srcVal new value
+ * @return {array} objVal with srcVal concatenated
+ */
+Helpers.customMerge = function (objVal, srcVal) {
+    if (isArray(objVal)) {
+        return objVal.concat(srcVal);
+    }
 };
 
 /*
@@ -33,7 +49,9 @@ Helpers.mergeNewTranslations = function (existingTranslations, newTranslations, 
     for (var id in newTranslations) {
         var md5 = Helpers.getMD5(id);
         if (md5Map.hasOwnProperty(md5) && newTranslations[id].length > 0) {
-            existingTranslations[md5Map[md5]] = newTranslations[id];
+            md5Map[md5].forEach(function (msgId) {
+                existingTranslations[msgId] = newTranslations[id];
+            });
         }
     }
 
@@ -103,7 +121,7 @@ Helpers.getTranslationsForLanguage = function (lang, idsWithICU, md5WithIds, sep
             throw err;
         }
     }
-    
+
     var translationsByView = {};
     for (var id in translations) {
         var ids = id.split(separator); // [viewName, stringId]
@@ -132,7 +150,7 @@ Helpers.writeTranslationsToJS = function (outputDir, viewName, translationObject
 Helpers.idToICUMap = function (viewName, ids, separator) {
     var idsToICU = {};
     separator = separator || ':';
-    
+
     for (var id in ids) {
         idsToICU[viewName + separator + id] = ids[id];
     }
@@ -146,7 +164,7 @@ Helpers.icuToIdMap = function (viewName, ids, separator) {
     separator = separator || ':';
 
     for (var id in ids) {
-        icuToIds[ids[id]] = viewName + separator + id;
+        icuToIds[ids[id]] = [viewName + separator + id];
     }
     return icuToIds;
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "keymirror": "0.1.1",
     "lodash.clone": "3.0.3",
     "lodash.defaultsdeep": "3.10.0",
-    "lodash.isarray": "^3.0.4",
+    "lodash.isarray": "3.0.4",
     "lodash.merge": "3.3.2",
     "lodash.omit": "3.1.0",
     "lodash.range": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "keymirror": "0.1.1",
     "lodash.clone": "3.0.3",
     "lodash.defaultsdeep": "3.10.0",
+    "lodash.isarray": "^3.0.4",
     "lodash.merge": "3.3.2",
     "lodash.omit": "3.1.0",
     "lodash.range": "3.0.1",

--- a/src/components/activity/activity.jsx
+++ b/src/components/activity/activity.jsx
@@ -11,8 +11,7 @@ require('./activity.scss');
 
 var defaultMessages = defineMessages({
     whatsHappening: {
-        id: 'general.whatsHappening',
-        defaultMessage: 'What\'s Happening?'
+        id: 'general.whatsHappening'
     }
 });
 

--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -273,7 +273,8 @@ var Credits = React.createClass({
                     <a href="https://saucelabs.com/"> SauceLabs</a>,
                     <a href="https://screenhero.com/"> Screenhero</a>,
                     <a href="https://getsentry.com/welcome/"> Sentry</a>,
-                    and <a href="http://www.git-tower.com/"> Tower</a>.
+                    <a href="http://www.git-tower.com/"> Tower</a>,
+                    and <a href="https://travis-ci.org/"> Travis-CI</a>.
                 </p>
 
                 <p>

--- a/src/views/privacypolicy/privacypolicy.jsx
+++ b/src/views/privacypolicy/privacypolicy.jsx
@@ -203,7 +203,7 @@ var Privacypolicy = React.createClass({
                              Policy on a regular basis.
                         </p>
                     </section>
-                    <p><b>The Scratch Privacy Policy was last updated: October 2016</b></p>
+                    <p>The Scratch Privacy Policy was last updated: October 2016</p>
                 </div>
                 <nav>
                     <ol>

--- a/src/views/privacypolicy/privacypolicy.jsx
+++ b/src/views/privacypolicy/privacypolicy.jsx
@@ -114,7 +114,7 @@ var Privacypolicy = React.createClass({
                             <li>
                                 Parents and guardians who register their under-13 year olds for
                                  Scratch may also receive additional updates from the{' '}
-                                 <a href="http://www.codetolearn.org/">Scratch Foundation</a>,
+                                 <a href="http://www.scratchfoundation.org/">Scratch Foundation</a>,
                                  a non-profit that supports Scratch educational initiatives.
                                  The Scratch Foundation will never sell or share your email
                                  address without your permission. You can unsubscribe from these
@@ -203,6 +203,7 @@ var Privacypolicy = React.createClass({
                              Policy on a regular basis.
                         </p>
                     </section>
+                    <p><b>The Scratch Privacy Policy was last updated: October 2016</b></p>
                 </div>
                 <nav>
                     <ol>

--- a/src/views/splash/l10n.json
+++ b/src/views/splash/l10n.json
@@ -1,7 +1,7 @@
 {
     "splash.featuredProjects": "Featured Projects",
     "splash.featuredStudios": "Featured Studios",
-    "splash.projectsCuratedBy": "Projects Curated by",
+    "splash.projectsCuratedBy": "Projects Curated by ",
     "splash.scratchDesignStudioTitle": "Scratch Design Studio",
     "splash.visitTheStudio": "Visit the studio",
     "splash.recentlySharedProjects": "Recently Shared Projects",

--- a/src/views/splash/l10n.json
+++ b/src/views/splash/l10n.json
@@ -1,7 +1,7 @@
 {
     "splash.featuredProjects": "Featured Projects",
     "splash.featuredStudios": "Featured Studios",
-    "splash.projectsCuratedBy": "Projects Curated by ",
+    "splash.projectsCuratedBy": "Projects Curated by",
     "splash.scratchDesignStudioTitle": "Scratch Design Studio",
     "splash.visitTheStudio": "Visit the studio",
     "splash.recentlySharedProjects": "Recently Shared Projects",

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -215,7 +215,7 @@ var Splash = injectIntl(React.createClass({
                 <Box
                         key="curator_top_projects"
                         title={
-                            formatMessage({id: 'splash.projectsCuratedBy'}) + " " +
+                            formatMessage({id: 'splash.projectsCuratedBy'}) + ' ' +
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
                         moreTitle={formatMessage({id: 'general.learnMore'})}
                         moreHref="/studios/386359/">

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -217,7 +217,7 @@ var Splash = injectIntl(React.createClass({
                         title={
                             formatMessage({id: 'splash.projectsCuratedBy'}) +
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
-                        moreTitle={formatMessage({id: 'general.learnMore', defaultMessage: 'Learn More'})}
+                        moreTitle={formatMessage({id: 'general.learnMore'})}
                         moreHref="/studios/386359/">
 
                     <Carousel items={this.state.featuredGlobal.curator_top_projects} />
@@ -234,7 +234,7 @@ var Splash = injectIntl(React.createClass({
                         title={
                             formatMessage({id: 'splash.scratchDesignStudioTitle'})
                             + ' - ' + this.state.featuredGlobal.scratch_design_studio[0].gallery_title}
-                        moreTitle={formatMessage({id: 'splash.visitTheStudio', defaultMessage: 'Visit the studio'})}
+                        moreTitle={formatMessage({id: 'splash.visitTheStudio'})}
                         moreHref={'/studios/' + this.state.featuredGlobal.scratch_design_studio[0].gallery_id + '/'}>
 
                     <Carousel items={this.state.featuredGlobal.scratch_design_studio} />

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -215,11 +215,11 @@ var Splash = injectIntl(React.createClass({
                 <Box
                         key="curator_top_projects"
                         title={
-                            'Projects Curated by ' +
+                            formatMessage({id: 'splash.projectsCuratedBy', defaultMessage: 'Projects Curated by '}) +
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
                         moreTitle={formatMessage({id: 'general.learnMore', defaultMessage: 'Learn More'})}
                         moreHref="/studios/386359/">
-                    
+
                     <Carousel items={this.state.featuredGlobal.curator_top_projects} />
                 </Box>
             );
@@ -236,7 +236,7 @@ var Splash = injectIntl(React.createClass({
                             + ' - ' + this.state.featuredGlobal.scratch_design_studio[0].gallery_title}
                         moreTitle={formatMessage({id: 'splash.visitTheStudio', defaultMessage: 'Visit the studio'})}
                         moreHref={'/studios/' + this.state.featuredGlobal.scratch_design_studio[0].gallery_id + '/'}>
-                    
+
                     <Carousel items={this.state.featuredGlobal.scratch_design_studio} />
                 </Box>
             );
@@ -260,7 +260,7 @@ var Splash = injectIntl(React.createClass({
             rows.push(
                 <Box title={formatMessage({id: 'splash.projectsByScratchersFollowing'})}
                      key="custom_projects_by_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_by_following} />
                 </Box>
             );
@@ -271,7 +271,7 @@ var Splash = injectIntl(React.createClass({
             rows.push(
                 <Box title={formatMessage({id: 'splash.projectsLovedByScratchersFollowing'})}
                      key="custom_projects_loved_by_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_loved_by_following} />
                 </Box>
             );
@@ -283,7 +283,7 @@ var Splash = injectIntl(React.createClass({
             rows.push(
                 <Box title={formatMessage({id:'splash.projectsInStudiosFollowing'})}
                      key="custom_projects_in_studios_following">
-                    
+
                     <Carousel items={this.state.featuredCustom.custom_projects_in_studios_following} />
                 </Box>
             );

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -215,7 +215,7 @@ var Splash = injectIntl(React.createClass({
                 <Box
                         key="curator_top_projects"
                         title={
-                            formatMessage({id: 'splash.projectsCuratedBy'}) +
+                            formatMessage({id: 'splash.projectsCuratedBy'}) + " " +
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
                         moreTitle={formatMessage({id: 'general.learnMore'})}
                         moreHref="/studios/386359/">

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -215,7 +215,7 @@ var Splash = injectIntl(React.createClass({
                 <Box
                         key="curator_top_projects"
                         title={
-                            formatMessage({id: 'splash.projectsCuratedBy', defaultMessage: 'Projects Curated by '}) +
+                            formatMessage({id: 'splash.projectsCuratedBy'}) +
                             this.state.featuredGlobal.curator_top_projects[0].curator_name}
                         moreTitle={formatMessage({id: 'general.learnMore', defaultMessage: 'Learn More'})}
                         moreHref="/studios/386359/">

--- a/src/views/wedo2/l10n.json
+++ b/src/views/wedo2/l10n.json
@@ -1,6 +1,6 @@
 {
     "wedo2.intro": "The LEGO® Education WeDo 2.0 is an introductory invention kit you can use to build your own interactive machines. You can snap together Scratch programming blocks to interact with your LEGO WeDo creations and add animations on the screen.",
-    "wedo2.requirement": "The LEGO WeDo 2.0 extension is currently only available for Mac OSX. We plan to release a Windows version later in 2016.",
+    "wedo2.requirement": "The LEGO WeDo 2.0 extension is available for Mac OSX and Windows 10+",
     "wedo2.getStarted": "Getting Started with LEGO WeDo 2.0",
     "wedo2.installTitle": "1. Install Device Manager",
     "wedo2.installText": "The Device Manager lets you connect WeDo 2.0 to Scratch using Bluetooth <a href=\"https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1084869222&mt=12\">Download Here</a>",

--- a/test/fixtures/test_es_md5map.json
+++ b/test/fixtures/test_es_md5map.json
@@ -1,4 +1,4 @@
 {
-    "2ec20d41b181e1a41c071e13f414a74d": "test.id1",
-    "37ba6d5ef524504215f478912155f9ba": "test.id2"
+    "2ec20d41b181e1a41c071e13f414a74d": ["test.id1"],
+    "37ba6d5ef524504215f478912155f9ba": ["test.id2"]
 }

--- a/test/functional/build_locales_icuMap.js
+++ b/test/functional/build_locales_icuMap.js
@@ -1,0 +1,23 @@
+var merge = require('lodash.merge');
+var tap = require('tap');
+
+var buildLocales = require('../../bin/lib/locale-compare');
+
+tap.test('buildIcuMap', function (t) {
+    var ids1 = {
+        'first.test1' : 'We know where we\'re going, but we don\'t know where we\'ve been',
+        'first.test2' : 'You may find yourself living in a shotgun shack'
+    };
+    var ids2 = {
+        'second.test1' : 'We know where we\'re going, but we don\'t know where we\'ve been',
+        'second.test2' : 'Gadji beri bimba clandridi'
+    };
+
+    var testicuMap = buildLocales.icuToIdMap('first', ids1);
+    testicuMap = merge(testicuMap, buildLocales.icuToIdMap('second', ids2), buildLocales.customMerge);
+
+    t.ok(testicuMap['We know where we\'re going, but we don\'t know where we\'ve been'].length === 2);
+    t.ok(testicuMap['You may find yourself living in a shotgun shack'].length === 1);
+    t.ok(testicuMap['Gadji beri bimba clandridi'].length === 1);
+    t.end();
+});

--- a/test/functional/build_locales_mergeDupStrings.js
+++ b/test/functional/build_locales_mergeDupStrings.js
@@ -1,0 +1,25 @@
+var tap = require('tap');
+
+var buildLocales = require('../../bin/lib/locale-compare');
+
+tap.test('buildLocalesMergeDupStrings', function (t) {
+    var existingTranslations = {
+        'test.test1': 'It\'s like raaayaaain, on your wedding day',
+        'test.test2': 'Free to flyyy, when you already paid',
+        'test.test4': 'Free to flyyy, when you already paid'
+    };
+    var newTranslations = {
+        'Isn\'t it ironic? No.': 'Es irónico? No.'
+    };
+    var md5map = {
+        'c21ce5ceefe167028182032d4255a384': ['test.test1'],
+        '9c40648034e467e16f8d6ae24bd610ab': ['test.test2', 'test.test4'],
+        '6885a345adafb3a9dd43d9f549430c88': ['test.test3', 'test.test5']
+    };
+
+    var mergedTranslations = buildLocales.mergeNewTranslations(existingTranslations, newTranslations, {}, md5map);
+    t.ok(mergedTranslations['test.test2'] !== undefined);
+    t.ok(mergedTranslations['test.test3'] !== undefined);
+    t.ok(mergedTranslations['test.test5'] !== undefined);
+    t.end();
+});

--- a/test/functional/build_locales_mergeTranslations.js
+++ b/test/functional/build_locales_mergeTranslations.js
@@ -11,9 +11,9 @@ tap.test('buildLocalesMergeTranslations', function (t) {
         'Isn\'t it ironic? No.': 'Es irónico? No.'
     };
     var md5map = {
-        'c21ce5ceefe167028182032d4255a384': 'test.test1',
-        '9c40648034e467e16f8d6ae24bd610ab': 'test.test2',
-        '6885a345adafb3a9dd43d9f549430c88': 'test.test3'
+        'c21ce5ceefe167028182032d4255a384': ['test.test1'],
+        '9c40648034e467e16f8d6ae24bd610ab': ['test.test2'],
+        '6885a345adafb3a9dd43d9f549430c88': ['test.test3']
     };
 
     var mergedTranslations = buildLocales.mergeNewTranslations(existingTranslations, newTranslations, {}, md5map);


### PR DESCRIPTION
Fixes #787 (again).

From https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching

> "no-cache" indicates that the returned response can't be used to satisfy a subsequent request to the same URL without first checking with the server if the response has changed. As a result, if a proper validation token (ETag) is present, no-cache incurs a roundtrip to validate the cached response, but can eliminate the download if the resource has not changed.

This is what we want to happen.