### PR TITLE
[Master] Use no-cache so ETags are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ESLINT=./node_modules/.bin/eslint
 NODE=node
 SASSLINT=./node_modules/.bin/sass-lint -v
-S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:public,max-age=3600
+S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600
 TAP=./node_modules/.bin/tap
 WATCH=./node_modules/.bin/watch
 WEBPACK=./node_modules/.bin/webpack


### PR DESCRIPTION
See #968 

From https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching

> "no-cache" indicates that the returned response can't be used to satisfy a subsequent request to the same URL without first checking with the server if the response has changed. As a result, if a proper validation token (ETag) is present, no-cache incurs a roundtrip to validate the cached response, but can eliminate the download if the resource has not changed.

This is what we want to happen.