### PR TITLE
Remove Khmer from language list

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -34,7 +34,6 @@
     "it": "Italiano",
     "kn": "ಭಾಷೆ-ಹೆಸರು",
     "rw": "Kinyarwanda",
-    "km": "សំលៀកបំពាក",
     "ht": "Kreyòl",
     "ku": "Kurdî",
     "la": "Latina",


### PR DESCRIPTION
This language needs some updates on the editor/block translations before we can add it back in – see https://github.com/LLK/scratch-flash/issues/1165