### PR TITLE
Fix gh-706: "This field is required" when phone number is null

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -455,7 +455,11 @@ module.exports = {
             };
         },
         onValidSubmit: function (formData, reset, invalidate) {
-            if (!formData.phone || formData.phone.national_number === '+') {
+            if (!formData.phone) {
+                return invalidate({
+                    'phone': this.props.intl.formatMessage({id: 'teacherRegistration.validationRequired'})
+                });
+            } else if (formData.phone.national_number === '+') {
                 return invalidate({
                     'phone': this.props.intl.formatMessage({id: 'teacherRegistration.validationPhoneNumber'})
                 });

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -455,13 +455,9 @@ module.exports = {
             };
         },
         onValidSubmit: function (formData, reset, invalidate) {
-            if (!formData.phone) {
+            if (!formData.phone || formData.phone.national_number === '+') {
                 return invalidate({
                     'phone': this.props.intl.formatMessage({id: 'teacherRegistration.validationRequired'})
-                });
-            } else if (formData.phone.national_number === '+') {
-                return invalidate({
-                    'phone': this.props.intl.formatMessage({id: 'teacherRegistration.validationPhoneNumber'})
                 });
             }
             return this.props.onNextStep(formData);


### PR DESCRIPTION
Should fix #706 

Separated the null check from the area code check so that when the field is null the 'required' popup will be displayed.
