### PR TITLE
[Master] Allow querystring in /hoc URL

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -121,7 +121,7 @@
     },
     {
         "name": "hoc",
-        "pattern": "^/hoc/?$",
+        "pattern": "^/hoc/?(\\?.*)?$",
         "routeAlias": "/hoc/?\\??",
         "view": "hoc/hoc",
         "title": "Hour of Code"

--- a/src/routes.json
+++ b/src/routes.json
@@ -122,7 +122,7 @@
     {
         "name": "hoc",
         "pattern": "^/hoc/?$",
-        "routeAlias": "/hoc/?$",
+        "routeAlias": "/hoc/?\\??",
         "view": "hoc/hoc",
         "title": "Hour of Code"
     },


### PR DESCRIPTION
@kaschm needs `/hoc?somequerystring=1` to work, but it currently doesn't because of the regex we use for Fastly.  This should allow the hoc url with a querystring to resolve to the page currently visible at `/hoc`.

Eventually we should fix this for every URL, but that is too large of a change for a hotfix.