### PR TITLE
Fix gh-1009: Add Tutorials Button

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -83,8 +83,9 @@
     "general.art": "Art",
     "general.games": "Games",
     "general.music": "Music",
-    "general.stories": "Stories",
     "general.results": "Results",
+    "general.stories": "Stories",
+    "general.tutorials": "Tutorials",
 
     "general.teacherAccounts": "Teacher Accounts",
 

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -28,7 +28,7 @@ var Explore = injectIntl(React.createClass({
             games: 'games',
             music: 'music',
             stories: 'stories',
-            tutorials: 'tutorials'
+            tutorials: 'tutorial'
         };
         var typeOptions = ['projects','studios'];
         var modeOptions = ['trending', 'popular', 'recent', ''];

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -27,7 +27,8 @@ var Explore = injectIntl(React.createClass({
             art: 'art',
             games: 'games',
             music: 'music',
-            stories: 'stories'
+            stories: 'stories',
+            tutorials: 'tutorials'
         };
         var typeOptions = ['projects','studios'];
         var modeOptions = ['trending', 'popular', 'recent', ''];
@@ -152,6 +153,7 @@ var Explore = injectIntl(React.createClass({
                             {this.getBubble('games')}
                             {this.getBubble('music')}
                             {this.getBubble('stories')}
+                            {this.getBubble('tutorials')}
                         </SubNavigation>
                         <Form className='sort-mode'>
                             <Select name="sort"


### PR DESCRIPTION
Should (start to) fix #1009 

Not entirely sure about the xhr thing, but I think it might be covered already.

Test cases:
-

- There is a new button with the text 'tutorials' to the right of the 'stories' button on the explore page
- When clicking it, it should take you to [the explore tutorials page](https://scratch.mit.edu/explore/projects/tutorials/)