### PR TITLE
Fix gh-1023: Localize Explore Title and Dropdown

### DIFF
--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -137,7 +137,7 @@ var Explore = injectIntl(React.createClass({
                 <div className='outer'>
                     <TitleBanner className="masthead">
                         <div className="inner">
-                            <h1>Explore</h1>
+                            <h1><FormattedMessage id='general.explore' /></h1>
                         </div>
                     </TitleBanner>
                     <Tabs>
@@ -156,9 +156,9 @@ var Explore = injectIntl(React.createClass({
                         <Form className='sort-mode'>
                             <Select name="sort"
                                     options={[
-                                        {value: 'trending', label: 'Trending'},
-                                        {value: 'popular', label: 'Popular'},
-                                        {value: 'recent', label: 'Recent'}
+                                        {value: 'trending', label: <FormattedMessage id='explore.trending' />},
+                                        {value: 'popular', label: <FormattedMessage id='explore.popular' />},
+                                        {value: 'recent', label: <FormattedMessage id='explore.recent' />}
                                     ]}
                                     value={this.props.mode}
                                     onChange={this.changeSortMode}/>

--- a/src/views/explore/l10n.json
+++ b/src/views/explore/l10n.json
@@ -1,0 +1,5 @@
+{
+  "explore.trending": "Trending",
+  "explore.popular": "Popular",
+  "explore.recent": "Recent"
+}


### PR DESCRIPTION
Should fix #1023 

Test cases:
-

- `h1` element at the title of the page should now be localized
- dropdown on the right side of the page should now be localized