### PR TITLE
fix column count for IE and Edge

### DIFF
--- a/src/components/masonrygrid/masonrygrid.scss
+++ b/src/components/masonrygrid/masonrygrid.scss
@@ -7,18 +7,18 @@
     -webkit-perspective: 1;
 }
 
-// working around Firefox issue that requires column-count, using explicit -moz-column-count
+// column-count required for Firefox, IE and Edge
 //4 columns
 @media only screen and (max-width: $mobile - 1) {
     .masonry {
-        -moz-column-count: 1;
+        column-count: 1;
     }
 }
 
 //6 columns
 @media only screen and (min-width: $mobile) and (max-width: $tablet - 1) {
     .masonry {
-        -moz-column-count: 1;
+        column-count: 1;
     }
 }
 
@@ -26,13 +26,13 @@
 //8 columns
 @media only screen and (min-width: $tablet) and (max-width: $desktop - 1) {
     .masonry {
-        -moz-column-count: 2;
+        column-count: 2;
     }
 }
 
 // 12 columns
 @media only screen and (min-width: $desktop) {
     .masonry {
-        -moz-column-count: 3;
+        column-count: 3;
     }
 }


### PR DESCRIPTION
Set column-count for all widths since it’s needed for Firefox, IE and Edge browsers