### PR TITLE
[Master] Fix GH-1059: Still build url localization for languages with none

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -120,11 +120,12 @@ for (var v in routes) {
         localizedAssetUrls[routes[v].name] = {};
 
         var assetUrls = require(l10nStatic);
-        for (var lang in localizedUrls) {
+        for (var lang in languages) {
             localizedAssetUrls[routes[v].name][lang] = {};
+            var langUrls = localizedUrls[lang] || {};
             for (var key in assetUrls) {
-                if (localizedUrls[lang].hasOwnProperty(key)) {
-                    localizedAssetUrls[routes[v].name][lang][key] = localizedUrls[lang][key];
+                if (langUrls.hasOwnProperty(key)) {
+                    localizedAssetUrls[routes[v].name][lang][key] = langUrls[key];
                 } else {
                     localizedAssetUrls[routes[v].name][lang][key] = assetUrls[key];
                 }

--- a/src/views/cards/l10n-static.json
+++ b/src/views/cards/l10n-static.json
@@ -5,7 +5,7 @@
     "cards.raceLink": "/pdfs/cards/RaceGameCards.pdf",
     "cards.musicLink": "/pdfs/cards/MusicCards.pdf",
     "cards.hideLink": "/pdfs/cards/Hide-and-Seek-Cards.pdf",
-    "cards.storyLink": "/scratch.mit.edu/pdfs/cards/StoryCards.pdf",
+    "cards.storyLink": "/pdfs/cards/StoryCards.pdf",
     "cards.dressupLink": "/pdfs/cards/DressupCards.pdf",
     "cards.pongLink": "/pdfs/cards/PongCards.pdf",
     "cards.danceLink": "/pdfs/cards/DanceCards.pdf",


### PR DESCRIPTION
otherwise, they will get the id for the url, rather than the english version. Fixes #1059.

/cc @rschamp 

### Test Cases ###
* Links on `/cards/` page for the `Getting Started` pdf should be localized in Spanish and Brasilian Portuguese
* Links for other cards on the `/cards/` page should be in English
* Links for the pdfs in `ttt` should all be in English, for Spanish, Brasilian Portuguese, Persian and Furlan.