### PR TITLE
[Master] Hotfix: allow querystrings for `/go`

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -134,8 +134,8 @@
     },
     {
         "name": "things-to-try",
-        "pattern": "^/go/?$",
-        "routeAlias": "/go/?$",
+        "pattern": "^/go/?(\\?.*)?$",
+        "routeAlias": "/go/?\\??$",
         "view": "thingstotry/thingstotry",
         "title": "Things to Try"
     },

--- a/src/routes.json
+++ b/src/routes.json
@@ -135,7 +135,7 @@
     {
         "name": "things-to-try",
         "pattern": "^/go/?(\\?.*)?$",
-        "routeAlias": "/go/?\\??$",
+        "routeAlias": "/go/?\\??",
         "view": "thingstotry/thingstotry",
         "title": "Things to Try"
     },


### PR DESCRIPTION
again, the same as #1004, but needed too soon for a full fix of this issue.