### PR TITLE
[Staging] Hotfix: allow querystrings for `/go`

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -134,8 +134,8 @@
     },
     {
         "name": "things-to-try",
-        "pattern": "^/go/?$",
-        "routeAlias": "/go/?$",
+        "pattern": "^/go/?(\\?.*)?$",
+        "routeAlias": "/go/?\\??$",
         "view": "thingstotry/thingstotry",
         "title": "Things to Try"
     },


### PR DESCRIPTION
See #1064 