### PR TITLE
Fix gh-1066: Localize Search Header

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -103,7 +103,7 @@ var Search = injectIntl(React.createClass({
                 <div className='outer'>
                         <TitleBanner className="masthead">
                             <div className="inner">
-                                <h1>Search</h1>
+                                <h1><FormattedMessage id="general.search" /></h1>
                                 <div className="search">
                                     <Form onSubmit={this.onSearchSubmit}>
                                         <Button type="submit" className="btn-search" />


### PR DESCRIPTION
Should fix #1066, brought up by @chrisgarrity here: https://github.com/LLK/scratch-www/issues/1023#issuecomment-262292730

Test cases:
-
- `h1` header at the top of the search page should now be localized.