### PR TITLE
Automated integration test framework for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.DS_Store
+.dockerignore
+.eslintignore
+.eslintrc
+.sass-lint.yml
+.travis.yml
+build/
+intl/
+node_modules/
+Dockerfile
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,7 @@
 build/
 intl/
 node_modules/
+reports/
+screenshots/
 Dockerfile
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # NPM
-/node_modules
+node_modules/
 npm-*
 
 # Build
@@ -22,3 +22,5 @@ ENV
 # Test
 /.nyc_output
 /coverage
+reports/
+screenshots/

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ env:
 install:
   - sudo -H pip install -r requirements.txt
   - npm --production=false install
+services:
+  - docker
+script:
+  - npm test && make integration
 deploy:
 - provider: script
   skip_cleanup: $SKIP_CLEANUP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Start with an official Node LTS release.
+FROM node:boron
+
+# This will be the user that the app is run under
+# rather than running as a privileged user.
+ENV APP_USER "app"
+RUN useradd --user-group --create-home --shell /bin/false $APP_USER
+
+# Copy the package.json from the app to the
+# container and install the node requirements.
+ENV HOME /home/$APP_USER
+ENV APP_DIR $HOME/scratch-www
+WORKDIR $APP_DIR
+COPY package.json $APP_DIR/package.json
+RUN npm config set registry http://registry.npmjs.org/ \
+    && npm set progress=false \
+    && npm --loglevel error install \
+    && rm -rf /tmp/* /root/.npm
+
+# Now copy over the rest of the application source code.
+# This is done AFTER the packages are installed so that
+# unless the requirements are changed, the image from
+# the steps up to this point can be reused.
+#
+# Note that to improve performance, files and folders to
+# exclude are specified in the .dockerignore file.
+COPY . $APP_DIR
+RUN chown -R $APP_USER:$APP_USER $HOME/*
+USER $APP_USER
+
+RUN make clean && make translations
+
+# Run webpack to build the static files
+ENV WEBPACK=./node_modules/.bin/webpack
+ENV NODE_ENV=production
+RUN $WEBPACK
+
+EXPOSE 8333
+
+CMD ["make", "start"]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,
 TAP=./node_modules/.bin/tap
 WATCH=./node_modules/.bin/watch
 WEBPACK=./node_modules/.bin/webpack
+COMPOSE_FILE=test/integration/docker-compose.yml
 
 # ------------------------------------
 
@@ -65,7 +66,7 @@ functional:
 	$(TAP) ./test/functional/*.js
 
 integration:
-	$(TAP) ./test/integration/*.js
+	docker-compose --file $(COMPOSE_FILE) run --rm scratch-test make test
 
 localization:
 	$(TAP) ./test/localization/*.js

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Where am I?
 Physically? No idea.
 
-Digitally? You’re at Scratch’s open source web client! 
+Digitally? You’re at Scratch’s open source web client!
 
 We’re working to update the [Scratch website](https://scratch.mit.edu) to use a new codebase, contained in this repository.
 
@@ -22,6 +22,54 @@ We’re currently building Scratch using [React](https://facebook.github.io/reac
 
 
 ### Before Getting Started
+
+#### Docker Development Environment
+* You first need some basic understanding of how Docker works and have a working [Docker installation](https://docs.docker.com/engine/installation/).
+* We will be running a container with the scratch-www application served by webpack-dev-middleware
+* The application code will be linked in a volume so that you can develop and edit it using your
+  favorite editor or IDE and those changes will be reflected in the running environment.
+
+##### Building the containerized dev server image locally and tagging it.
+Note that its Dockfile is here at the repo root.
+```bash
+docker build -t scratch-www .
+```
+
+##### Once this is finished, you will be able to see your image listed by docker with:
+```bash
+docker images
+```
+
+##### Running the application image in development mode:
+* Run your built image named "scrach-www" and port 8333 mapped through locally.
+  The default command is "make start".
+* Note that in the command below, you must substitute "<local-path>" with an
+  absolute path to this folder, such as "~/repos/llk/scratch-www".
+  Symbols such as "~" are allowed, but relative references such as "." are not.
+* This uses a volume mount so that you can edit the files locally.
+* Also override the NODE_ENV value, setting it to 'development' so that
+  the application source files will be watched.
+* Now you will be able to access the application in your local browser at the url http://localhost:8333
+```bash
+docker run --rm -it -p 8333:8333 -e NODE_ENV=development -v <local-path>:/home/app/scratch-www scratch-www
+```
+* To start up in a bash shell, override the "make start" command with "/bin/bash".
+```bash
+docker run --rm -it -p 8333:8333 -e NODE_ENV=development -v <local-path>:/home/app/scratch-www scratch-www /bin/bash
+```
+##### Running the application image in production mode:
+* This will serve the static files from the build directory
+```bash
+docker run --rm -it -p 8333:8333 scratch-www
+```
+
+#### Delete all running and stopped containers
+```bash
+docker down
+docker rm -f $(docker ps -aq)
+```
+
+#### Local Development Environment
 * Make sure you have node (v4.2 or higher) and npm [installed](https://docs.npmjs.com/getting-started/installing-node)
 
 ### To Build
@@ -58,7 +106,7 @@ When running `npm start`, here are some important log messages to keep an eye ou
 Once running, open `http://localhost:8333` in your browser. If you wish to have the server reload automatically, you can install either [nodemon](https://github.com/remy/nodemon) or [forever](https://github.com/foreverjs/forever).
 
 ### To stop
-Use `^C` to stop the node process `npm start` starts. 
+Use `^C` to stop the node process `npm start` starts.
 
 #### Configuration
 

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -20,13 +20,20 @@ routes.forEach(route => {
     app.get(route.pattern, handler(route));
 });
 
-app.use(webpackDevMiddleware(compiler));
+if (process.env.NODE_ENV !== 'production') {
+    // serve the content using webpack
+    app.use(webpackDevMiddleware(compiler));
 
-var proxyHost = process.env.FALLBACK || '';
-if (proxyHost !== '') {
-    // Fall back to scratchr2 in development
-    // This proxy middleware must come last
-    app.use('/', proxy(proxyHost));
+    var proxyHost = process.env.FALLBACK || '';
+    if (proxyHost !== '') {
+        // Fall back to scratchr2 in development
+        // This proxy middleware must come last
+        app.use('/', proxy(proxyHost));
+    }
+
+} else {
+    // serve the content using static directory
+    app.use(express.static('./build'));
 }
 
 // Start listening

--- a/test/integration/.dockerignore
+++ b/test/integration/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+docker-compose*.yml
+Dockerfile
+README.md
+reports/
+screenshots/

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,0 +1,25 @@
+# Start with an official Node LTS release.
+FROM node:boron
+
+# This will be the user that the app is run under
+# rather than running as a priviliged user.
+RUN useradd --user-group --create-home --shell /bin/false test
+
+# Global install nightwatch in the quickest way possible
+RUN npm config set registry http://registry.npmjs.org/ \
+    && npm set progress=false \
+    && npm --loglevel warn install -g nightwatch \
+    && rm -rf /tmp/* /root/.npm
+ENV APP_USER "test"
+ENV APP_NAME "integration"
+ENV HOME /home/$APP_USER
+ENV APP_DIR $HOME/$APP_NAME
+WORKDIR $APP_DIR
+
+# Note that to improve performance, files and folders to
+# exclude are specified in the .dockerignore file.
+COPY . $APP_DIR
+RUN chown -R $APP_USER:$APP_USER $HOME/*
+USER $APP_USER
+
+CMD ["make", "test"]

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -1,0 +1,10 @@
+clean:
+	rm -rf ./reports
+	rm -rf ./screenshots
+	mkdir -p reports
+	mkdir -p screenshots
+
+test:
+	nightwatch ./test
+
+.PHONY: clean test

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,42 @@
+# Integration Tests
+
+These tests verify the integration with the Scratch APIs, and are written
+using the [Nightwatch.js](http://nightwatchjs.org/) automated testing framework.
+To run them locally, you will need a working
+[Nightwatch.js installation](http://nightwatchjs.org/getingstarted#installation).
+
+You can run these integration tests against the application that is running in
+a docker container on your local machine.
+
+# Docker Container Setup
+* You first need some basic understanding of how Docker works and have a
+working [Docker installation](https://docs.docker.com/engine/installation/).
+* We will be running 3 containers:
+  * scratch-www
+  * selenium standalone with firefox (for this we use an offical image from DockerHub)
+  * these tests, driving Firefox against the running scratch-www app
+
+# Running the Nightwatch tests
+```bash
+docker-compose run --rm scratch-test make test
+```
+# Developing tests
+Note that the contents of this test/integration folder are linked between host machine
+and container, so you can edit them from either environment.
+This works because the volume is specified in docker-compose.override.yml, which
+is loaded automatically if you do not specify a docker-compose configuration file
+with the -f option.
+```bash
+docker-compose run --rm scratch-test bash
+```
+From the shell of the scratch-test machine you can kick off the tests with:
+```bash
+make test
+```
+
+# Cleanup
+## Delete all running and stopped continers
+```bash
+docker-compose down
+docker rm -f $(docker ps -aq)
+```

--- a/test/integration/docker-compose.override.yml
+++ b/test/integration/docker-compose.override.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  scratch-test:
+    depends_on:
+      - scratch-www
+      - selenium
+    command: /bin/bash
+    volumes:
+      - .:/home/test/integration

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  scratch-www:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    user: app
+    container_name: scratch-www
+    ports:
+      - "8333:8333"
+  selenium:
+    image: selenium/standalone-firefox
+    container_name: selenium
+    ports:
+      - "4444:4444"
+  scratch-test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    user: test
+    depends_on:
+      - scratch-www
+      - selenium

--- a/test/integration/nightwatch.conf.js
+++ b/test/integration/nightwatch.conf.js
@@ -1,0 +1,31 @@
+module.exports = {
+    'src_folders': ['test'],
+    'output_folder': 'reports',
+    'custom_commands_path': '',
+    'custom_assertions_path': '',
+    'page_objects_path': 'pages',
+    'globals_path': '',
+    'test_settings': {
+        'default': {
+            'silent': true,
+            'selenium_host': 'selenium.integration_default',
+            'launch_url': 'http://scratch-www.integration_default:8333',
+            'screenshots': {
+                'path': './screenshots',
+                'enabled': true
+            },
+            'globals': {
+                'waitForConditionTimeout': 5000
+            },
+            'desiredCapabilities': {
+                'browserName': 'firefox'
+            }
+        },
+        'firefox': {
+            'desiredCapabilities': {
+                'browserName': 'firefox',
+                'javascriptEnabled': true
+            }
+        }
+    }
+};

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "test": "make test"
+  },
+  "dependencies": {
+    "nightwatch": "^0.9.9"
+  }
+}

--- a/test/integration/pages/splashPage.js
+++ b/test/integration/pages/splashPage.js
@@ -1,0 +1,22 @@
+module.exports = {
+    url: function () {
+        return this.api.launchUrl;
+    },
+    elements: {
+        createLink: {
+            selector: 'div#navigation li.create a'
+        },
+        exploreLink: {
+            selector: 'div#navigation li.explore a'
+        },
+        discussLink: {
+            selector: 'div#navigation li.discuss a'
+        },
+        aboutLink: {
+            selector: 'div#navigation li.about a'
+        },
+        helpLink: {
+            selector: 'div#navigation li.help a'
+        }
+    }
+};

--- a/test/integration/test/testSplashPage.js
+++ b/test/integration/test/testSplashPage.js
@@ -1,0 +1,25 @@
+module.exports = {
+    before : function (client) {
+        this.splash = client.page.splashPage();
+        this.splash.navigate();
+    },
+    'When you click Create, you should be redirected to the URL for the editor': function () {
+        var expectedHref = '/projects/editor/?tip_bar=home';
+        this.splash.assert.title('Scratch - Imagine, Program, Share')
+            .assert.visible('@createLink')
+            .assert.attributeEquals('@createLink', 'href', this.client.launchUrl + expectedHref);
+    },
+    'Explore should take you to the Explore page': function () {
+        var expectedHref = '/explore/projects/all';
+        this.splash.assert.visible('@exploreLink')
+            .assert.attributeEquals('@exploreLink', 'href', this.client.launchUrl + expectedHref);
+    },
+    'Discuss should take you to the Forums': function () {
+        var expectedHref = '/discuss';
+        this.splash.assert.visible('@discussLink')
+            .assert.attributeEquals('@discussLink', 'href', this.client.launchUrl + expectedHref);
+    },
+    after : function (client) {
+        client.end();
+    }
+};


### PR DESCRIPTION
Addresses #925

@jwzimmer I've been thinking about how we best set up the automated testing for the integration with the backend Scratch APIs, and coded up this approach as a proposal. Would love your feedback.

Important points:
* Dockerized the development environment. This should also make onboarding of new devs easier.
* Using pre-built, supported containers for Selenium standalone and firefox. We could easily extend this to test other browsers also if we want.
* Using the [Nightwatch.js](http://nightwatchjs.org/) Selenium framework.
  * This has a built-in Page Object support, which will make the tests more maintainable.
  * It also exposes helper methods for waiting. We can use these to help with synchronization, which IMO is the trickiest part in any browser-based automation.
* Warning: These tests do take some time to set up and run in CI.
  * They currently increase build time on travis by about 8 minutes (from <3 to <11 minutes)
  * Mitigated somewhat by the fact that they will only run if the other tests pass. E.g., if a PR fails the linters on travis, it fails fast.
  * In the future, we should publish the app container for scratch-www on DockerHub so that it can be pulled as a base. If the node requirements haven't changed, then there will be no need to download and install them, which is the bulk of the time spent.
