### PR TITLE
Fix GH-930: Update wedo2 text for new Windows deploy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
         "eol-last": [2],
         "indent": [2, 4],
         "linebreak-style": [2, "unix"],
-        "max-len": [2, 120, 4],
+        "max-len": [2, 120, 4, {"ignoreUrls": true}],
         "no-trailing-spaces": [2, { "skipBlankLines": true }],
         "no-unused-vars": [2, {"args": "after-used", "varsIgnorePattern": "^_"}],
         "quotes": [2, "single"],

--- a/src/views/wedo2/l10n.json
+++ b/src/views/wedo2/l10n.json
@@ -1,9 +1,11 @@
 {
     "wedo2.intro": "The LEGO® Education WeDo 2.0 is an introductory invention kit you can use to build your own interactive machines. You can snap together Scratch programming blocks to interact with your LEGO WeDo creations and add animations on the screen.",
-    "wedo2.requirement": "The LEGO WeDo 2.0 extension is currently only available for Mac OSX. We plan to release a Windows version later in 2016.",
+    "wedo2.requirement": "The LEGO WeDo 2.0 extension is available for Mac OSX and Windows 10+.",
     "wedo2.getStarted": "Getting Started with LEGO WeDo 2.0",
     "wedo2.installTitle": "1. Install Device Manager",
-    "wedo2.installText": "The Device Manager lets you connect WeDo 2.0 to Scratch using Bluetooth <a href=\"https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1084869222&mt=12\">Download Here</a>",
+    "wedo2.installText": "The Device Manager lets you connect WeDo 2.0 to Scratch using Bluetooth",
+    "wedo2.downloadMac": "Download for Mac OSX",
+    "wedo2.downloadWin": "Download for Windows 10+",
     "wedo2.setupTitle": "2. Setup & Help",
     "wedo2.setupText": "Connect your WeDo 2.0 by following the steps in the <a href=\"/projects/editor/?tip_bar=ext2\">Tips Window</a>",
     "wedo2.createTitle": "3. Create",

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -49,7 +49,7 @@ var Wedo2 = React.createClass({
                                         <FormattedMessage id='wedo2.downloadMac' />
                                     </a>
                                     <br />
-                                    <a href="/">
+                                    <a href="https://downloads.scratch.mit.edu/device-manager/ScratchDeviceManager-1.1.0.exe">
                                         <FormattedMessage id='wedo2.downloadWin' />
                                     </a>
                                 </p>

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -44,6 +44,14 @@ var Wedo2 = React.createClass({
                                 </h4>
                                 <p>
                                     <FormattedHTMLMessage id='wedo2.installText' />
+                                    <br />
+                                    <a href="https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1084869222&mt=12">
+                                        <FormattedMessage id='wedo2.downloadMac' />
+                                    </a>
+                                    <br />
+                                    <a href="/">
+                                        <FormattedMessage id='wedo2.downloadWin' />
+                                    </a>
                                 </p>
                             </div>
                             <div className="column">


### PR DESCRIPTION
Fixes #930 by updating the text – this is still in progress, as a Windows device manager link is still needed.