### PR TITLE
Fix GH-1083: switch to column in tablet

### DIFF
--- a/src/views/splash/hoc-banner/hoc-banner.scss
+++ b/src/views/splash/hoc-banner/hoc-banner.scss
@@ -1,4 +1,5 @@
 @import "../../../colors";
+@import "../../../frameless";
 
 .title-banner.mod-splash-hoc {
     background: url("/images/blocks-pattern.png");
@@ -35,4 +36,10 @@
 
 .ttt-tile.mod-banner {
     background-color: $background-color;
+}
+
+@media only screen and (min-width: $tablet) and (max-width: $desktop - 1) {
+    .flex-row.mod-hoc-banner-header {
+        flex-direction: column;
+    }
 }


### PR DESCRIPTION
since that’s whats in the specs, and it handles centering with `align-items`. Fixes #1083