### PR TITLE
Fix GH-1089: Move margin to flex-row element

### DIFF
--- a/src/views/splash/hoc-banner/hoc-banner.scss
+++ b/src/views/splash/hoc-banner/hoc-banner.scss
@@ -13,8 +13,11 @@
     justify-content: space-between;
 }
 
-.hoc-banner-header-h1 {
+.flex-row.mod-hoc-banner-header {
     margin-bottom: 1.25rem;
+}
+
+.hoc-banner-header-h1 {
     color: $type-white;
 }
 


### PR DESCRIPTION
so that the header elements are evently aligned vertically. fixes #1089 