### PR TITLE
Turn off related videos in event row embed

### DIFF
--- a/src/views/splash/hoc-event-row/hoc-event-row.jsx
+++ b/src/views/splash/hoc-event-row/hoc-event-row.jsx
@@ -38,7 +38,7 @@ var HocEventRow = React.createClass({
                         <iframe
                             className="hoc-event-video-iframe"
                             title="Design a Character Studio"
-                            src="https://www.youtube.com/embed/_srMcH7oB3Y"
+                            src="https://www.youtube-nocookie.com/embed/_srMcH7oB3Y?rel=0"
                             frameborder="0"
                             webkitAllowFullScreen
                             mozallowfullscreen

--- a/src/views/splash/hoc-event-row/hoc-event-row.scss
+++ b/src/views/splash/hoc-event-row/hoc-event-row.scss
@@ -75,7 +75,7 @@
     }
 
     .flex-row.mod-hoc-event {
-        padding: 2.5rem;
+        padding: 3rem 2rem 2rem;
     }
 
     .hoc-event-studio,


### PR DESCRIPTION
See https://github.com/LLK/scratch-www/pull/1081#issuecomment-263746724. This also adjusts tracking that Youtube might do on the video to only apply to people who watch it, which can be adjusted if desired @kaschm. Also adjusts padding to accommodate https://github.com/LLK/scratch-www/pull/1081#issuecomment-263747658.