### PR TITLE
Fix GH-962: use width for radio buttons, not margin

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -360,24 +360,24 @@ module.exports = {
                                         options={[
                                             {value: 'female', label: formatMessage({id: 'general.female'})},
                                             {value: 'male', label: formatMessage({id: 'general.male'})},
-                                            {value: 'other', label: ''}
+                                            {value: 'other', label: <Input
+                                                className="demographics-step-input-other"
+                                                name="user.genderOther"
+                                                type="text"
+                                                validations={{
+                                                    maxLength: 25
+                                                }}
+                                                validationErrors={{
+                                                    maxLength: formatMessage({
+                                                        id: 'registration.validationMaxLength'
+                                                    })
+                                                }}
+                                                disabled={this.state.otherDisabled}
+                                                required={!this.state.otherDisabled}
+                                                help={null}
+                                            />}
                                         ]}
                                         required />
-                            <div className="gender-input">
-                                <Input name="user.genderOther"
-                                       type="text"
-                                       validations={{
-                                           maxLength: 25
-                                       }}
-                                       validationErrors={{
-                                           maxLength: formatMessage({
-                                               id: 'registration.validationMaxLength'
-                                           })
-                                       }}
-                                       disabled={this.state.otherDisabled}
-                                       required={!this.state.otherDisabled}
-                                       help={null} />
-                            </div>
                             <Select label={formatMessage({id: 'general.country'})}
                                     name="user.country"
                                     options={getCountryOptions(this.props.intl, DEFAULT_COUNTRY)}

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -66,8 +66,9 @@
         }
 
         .radio {
-            margin-right: 2.5rem;
+            width: 50%;
             line-height: 3rem;
+            white-space: nowrap;
 
             input {
                 margin-right: 1rem;

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -13,7 +13,6 @@
         border-radius: 8px;
     }
 
-    .gender-input,
     .other-input {
         float: right;
         width: 90%;
@@ -61,17 +60,19 @@
     }
 
     &.demographics-step {
-        .gender-input {
-            margin-top: -5.5rem;
-        }
-
         .radio {
-            width: 50%;
-            line-height: 3rem;
-            white-space: nowrap;
+            margin: 1.5rem 1.5rem 0 0;
 
             input {
                 margin-right: 1rem;
+            }
+        }
+
+        .demographics-step-input-other {
+            display: inline-block;
+
+            .col-sm-9 {
+                display: inline-block;
             }
         }
     }


### PR DESCRIPTION
This fixes #962 – the margin was causing flex to overflow the radio buttons when the text was long, causing the male and other options to render on top of each other. This fixes that by giving the radio buttons a fixed with relative to the parent container, and by ensuring that languages with long localizations will still be visible in overflow text.

### Test Cases ###
* In any language (specifically pt_BR, en, and es to test), all three options should show up for this question
* If the input field is selected, it should require text be added in the input before the selection is valid
* If the input field is given a gender, that should be the gender recorded for the user in the db