### PR TITLE
Fix GH-966: Localize default “required” message

### DIFF
--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -1,4 +1,5 @@
 var defaults = require('lodash.defaultsdeep');
+var intl = require('../../lib/intl.jsx');
 var libphonenumber = require('google-libphonenumber');
 var phoneNumberUtil = libphonenumber.PhoneNumberUtil.getInstance();
 var React = require('react');
@@ -44,5 +45,5 @@ module.exports.validationHOCFactory = function (defaultValidationErrors) {
 };
 
 module.exports.defaultValidationHOC = module.exports.validationHOCFactory({
-    isDefaultRequiredValue: 'This field is required'
+    isDefaultRequiredValue: <intl.FormattedMessage id="teacherRegistration.validationRequired" />
 });

--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -45,5 +45,5 @@ module.exports.validationHOCFactory = function (defaultValidationErrors) {
 };
 
 module.exports.defaultValidationHOC = module.exports.validationHOCFactory({
-    isDefaultRequiredValue: <intl.FormattedMessage id="teacherRegistration.validationRequired" />
+    isDefaultRequiredValue: <intl.FormattedMessage id="form.validationRequired" />
 });

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -93,6 +93,8 @@
     "footer.help": "Help Page",
     "footer.scratchFamily": "Scratch Family",
 
+    "form.validationRequired": "This field is required",
+
     "login.forgotPassword": "Forgot Password?",
 
     "navigation.signOut": "Sign out",

--- a/src/views/teacherregistration/l10n.json
+++ b/src/views/teacherregistration/l10n.json
@@ -39,6 +39,5 @@
     "teacherRegistration.howUseScratch": "How do you plan to use Scratch at your organization?",
     "teacherRegistration.emailStepTitle": "Email Address",
     "teacherRegistration.emailStepDescription": "We will send you a confirmation email that will allow you to access your Scratch Teacher Account.",
-    "teacherRegistration.validationEmailMatch": "The emails do not match",
-    "teacherRegistration.validationRequired": "This field is required"
+    "teacherRegistration.validationEmailMatch": "The emails do not match"
 }


### PR DESCRIPTION
Fixes #966. I was trying, if possible, to not introduce localization at the component level in order to keep it in the views – but that seemed a bit too involved given that the fix in this way is only a few lines long.