### PR TITLE
Fix r2-4195: Handle double slash in splash pattern

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -1,10 +1,16 @@
 [
     {
         "name": "splash",
-        "pattern": "^/{1,2}?$",
+        "pattern": "^/?$",
         "routeAlias": "/?$",
         "view": "splash/splash",
         "title": "Imagine, Program, Share"
+    },
+    {
+        "name": "splash-redirect",
+        "pattern": "^//?$",
+        "routeAlias": "/?$",
+        "redirect": "/"
     },
     {
         "name": "about",

--- a/src/routes.json
+++ b/src/routes.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "splash",
-        "pattern": "^/?$",
+        "pattern": "^/{1,2}?$",
         "routeAlias": "/?$",
         "view": "splash/splash",
         "title": "Imagine, Program, Share"

--- a/src/routes.json
+++ b/src/routes.json
@@ -8,7 +8,7 @@
     },
     {
         "name": "splash-redirect",
-        "pattern": "^//?$",
+        "pattern": "^///?$",
         "routeAlias": "/?$",
         "redirect": "/"
     },


### PR DESCRIPTION
This fixes https://github.com/LLK/scratchr2/issues/4195 by updating the regex to catch two slashes. I decided to intentionally not catch more than 2 – it’ll 404 on 3 or more, which seems appropriate.

We could also redirect on 2 slashes to the homepage, but this seemed just as well.