### PR TITLE
Provide fallback error messages

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -110,6 +110,7 @@
     "registration.choosePasswordStepTitle": "Create a password",
     "registration.choosePasswordStepTooltip": "Don't use your name or anything that's easy for someone else to guess.",
     "registration.classroomApiGeneralError": "Sorry, we could not find the registration information for this class",
+    "registration.generalError": "Sorry, an unexpected error occurred.",
     "registration.classroomInviteExistingStudentStepDescription": "you have been invited to join the class:",
     "registration.classroomInviteNewStudentStepDescription": "has invited you to join the class:",
     "registration.confirmYourEmail": "Confirm Your Email",

--- a/src/views/studentcompleteregistration/studentcompleteregistration.jsx
+++ b/src/views/studentcompleteregistration/studentcompleteregistration.jsx
@@ -86,11 +86,18 @@ var StudentCompleteRegistration = intl.injectIntl(React.createClass({
             method: 'post',
             useCsrf: true,
             formData: submittedData
-        }, function (err, body) {
+        }, function (err, body, res) {
             this.setState({waiting: false});
             if (err) return this.setState({registrationError: err});
             if (body.success) return this.advanceStep(formData);
-            this.setState({registrationErrors: body.errors});
+            this.setState({
+                registrationErrors:
+                    body.errors || {
+                        __all__:
+                            this.props.intl.formatMessage({id: 'registration.generalError'}) +
+                            ' (' + res.statusCode + ')'
+                    }
+            });
         }.bind(this));
     },
     goToClass: function () {

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -78,11 +78,15 @@ var StudentRegistration = intl.injectIntl(React.createClass({
                 classroom_id: this.props.classroomId,
                 classroom_token: this.props.classroomToken
             }
-        }, function (err, res) {
+        }, function (err, body, res) {
             this.setState({waiting: false});
             if (err) return this.setState({registrationError: err});
-            if (res[0].success) return this.advanceStep(formData);
-            this.setState({registrationError: res[0].msg});
+            if (body[0].success) return this.advanceStep(formData);
+            this.setState({
+                registrationError:
+                    body[0].msg ||
+                    this.props.intl.formatMessage({id: 'registration.generalError'}) + ' (' + res.statusCode + ')'
+            });
         }.bind(this));
     },
     goToClass: function () {

--- a/src/views/teacherregistration/teacherregistration.jsx
+++ b/src/views/teacherregistration/teacherregistration.jsx
@@ -66,14 +66,18 @@ var TeacherRegistration = React.createClass({
                 address_zip: this.state.formData.address.zip,
                 how_use_scratch: this.state.formData.useScratch
             }
-        }, function (err, res) {
+        }, function (err, body, res) {
             this.setState({waiting: false});
             if (err) return this.setState({registrationError: err});
-            if (res[0].success) {
+            if (body[0].success) {
                 this.props.dispatch(sessionActions.refreshSession());
                 return this.advanceStep(formData);
             }
-            this.setState({registrationError: res[0].msg});
+            this.setState({
+                registrationError:
+                    body[0].msg ||
+                    this.props.intl.formatMessage({id: 'registration.generalError'}) + ' (' + res.statusCode + ')'
+            });
         }.bind(this));
 
     },


### PR DESCRIPTION
Fixes #1107.  Right now I'm adding this into the frozen branch since it could be hotfix-worthy, but if @jwzimmer would like this to respect the freeze I'll update the base accordingly.

In case the response does not supply `msg` or `errors`, provide a default. If `registrationError(s)` is empty, we do not show the error card, which causes "silent" failures.

## Test cases
* The following should still work as expected:
  * Registering as a new teacher
  * Registering as a new student through a student sign-up link
  * Completing registration as a student when logging in for the first time after a teacher creates the student account
* You should see an error page rather than getting stuck on the second step after exceeding the registration rate limit (we can artificially limit this for testing) in the following cases:
  * Registering as a new teacher
  * Registering as a new student through a student sign-up link
* I'm not aware of which type of error could cause the user to become "stuck" during registration completion, but in any case it should not be possible anymore.