### PR TITLE
Fix GH-1101: only apply right margin to radio input

### DIFF
--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -62,10 +62,10 @@
     &.demographics-step {
         .radio {
             margin: 1.5rem 1.5rem 0 0;
+        }
 
-            input {
-                margin-right: 1rem;
-            }
+        input[type="radio"] {
+            margin-right: 1rem;
         }
 
         .demographics-step-input-other {


### PR DESCRIPTION
fixes #1101. I wanted to apply a custom class to the input, however that is unfortunately obscured and unreachable with our current implementation of `formsy-react-components`