### PR TITLE
Remove `routeAlias` from splash redirect

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -9,7 +9,6 @@
     {
         "name": "splash-redirect",
         "pattern": "^///?$",
-        "routeAlias": "/?$",
         "redirect": "/"
     },
     {


### PR DESCRIPTION
It’s not necessary, and I believe is causing confusion for the faslty config.