### PR TITLE
Allow empty response, again

### DIFF
--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -84,7 +84,7 @@ var StudentRegistration = intl.injectIntl(React.createClass({
             if (body[0] && body[0].success) return this.advanceStep(formData);
             this.setState({
                 registrationError:
-                    body[0].msg ||
+                    (body[0] && body[0].msg) ||
                     this.props.intl.formatMessage({id: 'registration.generalError'}) + ' (' + res.statusCode + ')'
             });
         }.bind(this));

--- a/src/views/teacherregistration/teacherregistration.jsx
+++ b/src/views/teacherregistration/teacherregistration.jsx
@@ -75,7 +75,7 @@ var TeacherRegistration = React.createClass({
             }
             this.setState({
                 registrationError:
-                    body[0].msg ||
+                    (body[0] && body[0].msg) ||
                     this.props.intl.formatMessage({id: 'registration.generalError'}) + ' (' + res.statusCode + ')'
             });
         }.bind(this));


### PR DESCRIPTION
Missed in #1128, this fixes the rest of the handler to not expect a body from the request. Fixes #1124 again.