### PR TITLE
Fix GH-1097: Don’t validate username server side unless it passes client-side checks

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -185,7 +185,6 @@ module.exports = {
                                 <Input className={this.state.validUsername}
                                        type="text"
                                        name="user.username"
-                                       ref="thing"
                                        onBlur={this.onUsernameBlur}
                                        validations={{
                                            matchRegexp: /^[\w-]*$/,

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -136,7 +136,9 @@ module.exports = {
             }.bind(this));
         },
         onUsernameBlur: function (event) {
-            this.validateUsername(event.currentTarget.value);
+            if (this.refs.form.refs.formsy.inputs[0].isValidValue(event.currentTarget.value)) {
+                this.validateUsername(event.currentTarget.value);
+            }
         },
         onValidSubmit: function (formData) {
             this.setState({waiting: true});
@@ -183,6 +185,7 @@ module.exports = {
                                 <Input className={this.state.validUsername}
                                        type="text"
                                        name="user.username"
+                                       ref="thing"
                                        onBlur={this.onUsernameBlur}
                                        validations={{
                                            matchRegexp: /^[\w-]*$/,


### PR DESCRIPTION
Fixes #1097 by not making the server-side username validation call if the client side validations have failed. It runs the [isValidValue()](https://github.com/christianalfoni/formsy-react/blob/master/API.md#isvalidvalue) check on the input `onBlur` to make sure it is a valid value before trying, preventing a possible 404 from a username with disallowed characters.

This is not the ideal way to do this, since it’s getting the input from an array, and an array buried multiple levels of `refs` deep. However, to make this different would require significant refactor, given our current use of `formsy-react-components`. I'd like to not do that refactor unless we also have a conversation about our registration UX regarding when we want validation to occur generally – i.e., do we want to move to having it occur more `onBlur`, keep as is, only validate on submit, some combination, etc?