### PR TITLE
Fix gh-1157: Search Redirect

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -190,7 +190,7 @@
         "name": "search-redirect",
         "pattern": "^/search/?$",
         "routeAlias": "/search(?!/ajax)",
-        "redirect": "/search/projects",
+        "redirect": "/search/projects"
     },
     {
         "name": "terms",

--- a/src/routes.json
+++ b/src/routes.json
@@ -187,6 +187,12 @@
         "title": "Search"
     },
     {
+        "name": "search-redirect",
+        "pattern": "^/search/?$",
+        "routeAlias": "/search(?!/ajax)",
+        "redirect": "/search/projects",
+    },
+    {
         "name": "terms",
         "pattern": "^/terms_of_use/?$",
         "routeAlias": "/terms_of_use/?$",

--- a/src/routes.json
+++ b/src/routes.json
@@ -189,7 +189,7 @@
     {
         "name": "search-redirect",
         "pattern": "^/search/?$",
-        "routeAlias": "/search(?!/ajax)",
+        "routeAlias": "/search",
         "redirect": "/search/projects"
     },
     {


### PR DESCRIPTION
Should fix #1157 

Test cases:
- `/search/` should now redirect to `/search/projects/`