### PR TITLE
Fix gh-1171: Add Slash to Footer Developers Link

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -76,7 +76,7 @@ var Footer = React.createClass({
                                 </a>
                             </dd>
                             <dd>
-                                <a href="/developers">
+                                <a href="/developers/">
                                     <FormattedMessage id='general.forDevelopers' />
                                 </a>
                             </dd>


### PR DESCRIPTION
Should fix #1171 

## Test cases:
- The URL for the 'Developers' link in the footer should now be https://scratch.mit.edu/developers/