### PR TITLE
URI-encode search string on form submit

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -171,7 +171,7 @@ var Navigation = React.createClass({
         this.closeRegistration();
     },
     onSearchSubmit: function (formData) {
-        window.location.href = '/search/projects?q=' + formData.q;
+        window.location.href = '/search/projects?q=' + encodeURIComponent(formData.q);
     },
     render: function () {
         var classes = classNames({

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -21,13 +21,25 @@ require('./search.scss');
 var Search = injectIntl(React.createClass({
     type: 'Search',
     getDefaultProps: function () {
-        var query = window.location.search;
         var pathname = window.location.pathname.toLowerCase();
         if (pathname[pathname.length - 1] === '/') {
             pathname = pathname.substring(0, pathname.length - 1);
         }
         var start = pathname.lastIndexOf('/');
         var type = pathname.substring(start + 1, pathname.length);
+        return {
+            tab: type,
+            loadNumber: 16
+        };
+    },
+    getInitialState: function () {
+        return {
+            loaded: [],
+            offset: 0
+        };
+    },
+    componentDidMount: function () {
+        var query = window.location.search;
         var q = query.lastIndexOf('q=');
         var term = '';
         if (q !== -1) {
@@ -40,22 +52,8 @@ var Search = injectIntl(React.createClass({
             term = term.substring(0, term.indexOf('&'));
         }
         term = term.split('+').join(' ');
-
-        return {
-            tab: type,
-            searchTerm: term,
-            loadNumber: 16
-        };
-    },
-    getInitialState: function () {
-        return {
-            loaded: [],
-            offset: 0
-        };
-    },
-    componentDidMount: function () {
         this.getSearchMore();
-        this.props.dispatch(navigationActions.setSearchTerm(this.props.searchTerm));
+        this.props.dispatch(navigationActions.setSearchTerm(decodeURI(term)));
     },
     getSearchMore: function () {
         var termText = '';
@@ -113,7 +111,7 @@ var Search = injectIntl(React.createClass({
                                         <Input type="text"
                                                aria-label={formatMessage({id: 'general.search'})}
                                                placeholder={formatMessage({id: 'general.search'})}
-                                               value={decodeURI(this.props.searchTerm)}
+                                               value={this.props.searchTerm}
                                                name="q" />
                                     </Form>
                                 </div>
@@ -143,7 +141,7 @@ var Search = injectIntl(React.createClass({
 
 var mapStateToProps = function (state) {
     return {
-        navigation: state.searchTerm
+        searchTerm: state.navigation
     };
 };
 


### PR DESCRIPTION
This prevents the search form from setting an invalid URL.

Also, clean up usage of Redux for the searchTerm on /search.  Now that the search term is encoded, we need to be sure both the search fields get a decoded string. Parse, decode and set this string via Redux in componentDidMount, and use it in both places.

Resolves #1153.