### PR TITLE
Fix gh-1177: Tutorial Redirects

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -264,5 +264,23 @@
         "routeAlias": "/microworlds",
         "view": "microworldshomepage/microworldshomepage",
         "title": "Microworlds"
+    },
+    {
+        "name": "story-redirect",
+        "pattern": "^/story?$",
+        "routeAlias": "/story",
+        "redirect": "/projects/editor/?tip_bar=story"
+    },
+    {
+        "name": "fashion-redirect",
+        "pattern": "^/fashion?$",
+        "routeAlias": "/fashion",
+        "redirect": "/projects/editor/?tip_bar=fashion"
+    },
+    {
+        "name": "dressup-redirect",
+        "pattern": "^/dressup?$",
+        "routeAlias": "/dressup",
+        "redirect": "/projects/editor/?tip_bar=fashion"
     }
 ]


### PR DESCRIPTION
Should fix #1177 

## Test cases:
scratch.mit.edu/story should redirect to https://scratch.mit.edu/projects/editor/?tip_bar=story
scratch.mit.edu/fashion should redirect to https://scratch.mit.edu/projects/editor/?tip_bar=fashion
scratch.mit.edu/dressup should redirect to https://scratch.mit.edu/projects/editor/?tip_bar=fashion