### PR TITLE
Fix gh-1178: 24 hours => one day

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -131,7 +131,7 @@
     "registration.selectCountry": "select country",
     "registration.studentPersonalStepDescription": "This information will not appear on the Scratch website.",
     "registration.showPassword": "Show password",
-    "registration.usernameStepDescription": "Fill in the following forms to request an account. The approval process may take up to 24 hours.",
+    "registration.usernameStepDescription": "Fill in the following forms to request an account. The approval process may take up to one day.",
     "registration.studentUsernameStepDescription": "You can make games, animations, and stories using Scratch. Setting up an account is easy and it's free. Fill in the form below to get started.",
     "registration.studentUsernameStepHelpText": "Already have a Scratch account?",
     "registration.studentUsernameStepTooltip": "You'll need to create a new Scratch account to join this class.",

--- a/src/views/teachers/faq/l10n.json
+++ b/src/views/teachers/faq/l10n.json
@@ -4,7 +4,7 @@
     "teacherfaq.teacherWhatBody": "A Scratch Teacher Account provides teachers and other educators with additional features to manage student participation on Scratch, including the ability to create student accounts, organize student projects into studios, and monitor student comments. Learn more about Teacher Accounts in the video below:",
     "teacherfaq.teacherSignUpTitle": "How do I request a teacher account?",
     "teacherfaq.teacherSignUpBody": "To request a Teacher Account, go to the teacher account <a href=\"/educators/register\">request form</a>.",
-    "teacherfaq.teacherWaitTitle": "Why do I have to wait 24 hours for my account?",
+    "teacherfaq.teacherWaitTitle": "Why do I have to wait one day for my account?",
     "teacherfaq.teacherWaitBody": "The Scratch Team uses this time to manually review account creation submissions to verify the account creator is an educator.",
     "teacherfaq.teacherPersonalTitle": "Why do you need to know my personal information during registration?",
     "teacherfaq.teacherPersonalBody": "We use this information to verify the account creator is an educator. We will not share this information with anyone else, and it will not be shared publicly on the site.",


### PR DESCRIPTION
Fixes #1178 

## Test cases:
**On teacher FAQ:**
Question should now read `Why do I have to wait one day for my account?` instead of `Why do I have to wait 24 hours for my account?`

**On teacher account registration:**
Sentence should now read `The approval process may take up to one day.` instead of `The approval process may take up to 24 hours.`