### PR TITLE
Remove Dari (fa_AF)

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -11,7 +11,6 @@
     "cs": "Česky",
     "cy": "Cymraeg",
     "da": "Dansk",
-    "fa-af": "Dari",
     "de": "Deutsch",
     "yum": "Edible Scratch",
     "et": "Eesti",


### PR DESCRIPTION
Should fix #1174 (if I'm thinking straight)

## Test cases:
Dari (fa_AF) should no longer be a language option in any menus