### PR TITLE
Search view fixes

### DIFF
--- a/src/components/grid/grid.jsx
+++ b/src/components/grid/grid.jsx
@@ -27,12 +27,12 @@ var Grid = React.createClass({
         return (
             <div className={classes}>
                 <FlexRow>
-                    {this.props.items.map(function (item) {
+                    {this.props.items.map(function (item, key) {
                         var href = '/' + this.props.itemType + '/' + item.id + '/';
 
                         if (this.props.itemType == 'projects') {
                             return (
-                                <Thumbnail key={item.id}
+                                <Thumbnail key={key}
                                            showLoves={this.props.showLoves}
                                            showFavorites={this.props.showFavorites}
                                            showRemixes={this.props.showRemixes}
@@ -53,7 +53,7 @@ var Grid = React.createClass({
                         }
                         else {
                             return (
-                                <Thumbnail key={item.id}
+                                <Thumbnail key={key}
                                            type={'gallery'}
                                            href={href}
                                            title={item.title}

--- a/src/components/thumbnail/thumbnail.jsx
+++ b/src/components/thumbnail/thumbnail.jsx
@@ -75,10 +75,12 @@ var Thumbnail = React.createClass({
         }
         var imgElement,titleElement,avatarElement;
         if (this.props.linkTitle) {
-            imgElement = <a className="thumbnail-image" href={this.props.href}>
+            imgElement = <a className="thumbnail-image" href={this.props.href} key="imgElement">
                              <img src={this.props.src} alt={this.props.alt} />
                          </a>;
-            titleElement =  <a href={this.props.href}>{this.props.title}</a>;
+            titleElement =  <a href={this.props.href} key="titleElement">
+                                {this.props.title}
+                            </a>;
         } else {
             imgElement = <img src={this.props.src} />;
             titleElement = this.props.title;

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -54,8 +54,8 @@ var Search = injectIntl(React.createClass({
         term = decodeURI(term.split('+').join(' '));
         this.props.dispatch(navigationActions.setSearchTerm(term));
     },
-    componentDidUpdate: function (nextProps) {
-        if (this.props.searchTerm !== nextProps.searchTerm) this.getSearchMore();
+    componentDidUpdate: function (prevProps) {
+        if (this.props.searchTerm !== prevProps.searchTerm) this.getSearchMore();
     },
     getSearchMore: function () {
         var termText = '';

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -51,14 +51,16 @@ var Search = injectIntl(React.createClass({
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = term.split('+').join(' ');
-        this.getSearchMore();
-        this.props.dispatch(navigationActions.setSearchTerm(decodeURI(term)));
+        term = decodeURI(term.split('+').join(' '));
+        this.props.dispatch(navigationActions.setSearchTerm(term));
+    },
+    componentDidUpdate: function (nextProps) {
+        if (this.props.searchTerm !== nextProps.searchTerm) this.getSearchMore();
     },
     getSearchMore: function () {
         var termText = '';
         if (this.props.searchTerm !== '') {
-            termText = '&q=' + this.props.searchTerm;
+            termText = '&q=' + encodeURIComponent(this.props.searchTerm.split(' ').join('+'));
         }
         api({
             uri: '/search/' + this.props.tab +

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -76,7 +76,7 @@ var Search = injectIntl(React.createClass({
         }.bind(this));
     },
     onSearchSubmit: function (formData) {
-        window.location.href = '/search/projects?q=' + formData.q;
+        window.location.href = '/search/projects?q=' + encodeURIComponent(formData.q);
     },
     getTab: function (type) {
         var term = this.props.searchTerm.split(' ').join('+');


### PR DESCRIPTION
* Fixes #1189: Wait for the search term prop before performing the search. Also encode the term sent to the API, so the API request uses a valid URL.
* Also fixes an unlogged error, the same as #1153, but from the search form on the search page (not in the nav bar).
* Finally, clean up keys to resolve warnings from React. There were so many on the search page that my browser was locking up (only affects development).