### PR TITLE
Fix GH-1208: add height to svg

### DIFF
--- a/src/views/conference/2017/index/index.scss
+++ b/src/views/conference/2017/index/index.scss
@@ -69,6 +69,7 @@ td {
 
 .conf2017-panel-row-icon-image {
     width: 1.75rem;
+    height: 1.75rem;
 }
 
 .button.mod-2017-panel {


### PR DESCRIPTION
needed by ie11 to render correctly. fixes #1208