### PR TITLE
Fix GH-1196: Don’t localize an empty string

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -516,11 +516,10 @@ module.exports = {
             'orgChoiceAfterschool',
             'orgChoiceMuseum',
             'orgChoiceLibrary',
-            'orgChoiceCamp',
-            'orgChoiceOther'
+            'orgChoiceCamp'
         ],
         getOrganizationOptions: function () {
-            return this.organizationL10nStems.map(function (choice, id) {
+            var options = this.organizationL10nStems.map(function (choice, id) {
                 return {
                     value: id,
                     label: this.props.intl.formatMessage({
@@ -528,6 +527,12 @@ module.exports = {
                     })
                 };
             }.bind(this));
+            
+            // Add "Other" option with empty string, since input field is used
+            var otherId = options.length;
+            options.push({value: otherId, label: ' '});
+            
+            return options;
         },
         onChooseOrganization: function (name, values) {
             this.setState({otherDisabled: values.indexOf(this.organizationL10nStems.indexOf('orgChoiceOther')) === -1});

--- a/src/views/teacherregistration/l10n.json
+++ b/src/views/teacherregistration/l10n.json
@@ -21,7 +21,6 @@
     "teacherRegistration.orgChoiceMuseum": "Museum",
     "teacherRegistration.orgChoiceLibrary": "Library",
     "teacherRegistration.orgChoiceCamp": "Camp",
-    "teacherRegistration.orgChoiceOther": " ",
     "teacherRegistration.notRequired": "Not Required",
     "teacherRegistration.addressValidationError": "This doesn't look like a real address",
     "teacherRegistration.addressLine1": "Address Line 1",


### PR DESCRIPTION
Fixes #1196 by removing the other empty string from the localization file, and just adding it to the options list separately.