### PR TITLE
Fix gh-1218: Community Moderator Page

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -182,7 +182,7 @@
     },
     {
         "name": "jobs-moderator",
-        "pattern": "^jobs/moderator/?$",
+        "pattern": "^/jobs/moderator/?$",
         "routeAlias": "/jobs",
         "view": "jobs/moderator/moderator",
         "title": "Community Moderator"

--- a/src/routes.json
+++ b/src/routes.json
@@ -181,6 +181,13 @@
         "title": "Jobs"
     },
     {
+        "name": "jobs-moderator",
+        "pattern": "^jobs/moderator/?$",
+        "routeAlias": "/jobs/moderator/?$",
+        "view": "jobs/moderator/moderator",
+        "title": "Community Moderator"
+    },
+    {
         "name": "privacypolicy",
         "pattern": "^/privacy_policy/?$",
         "routeAlias": "/privacy_policy/?$",

--- a/src/routes.json
+++ b/src/routes.json
@@ -183,7 +183,7 @@
     {
         "name": "jobs-moderator",
         "pattern": "^jobs/moderator/?$",
-        "routeAlias": "/jobs/moderator/?$",
+        "routeAlias": "/jobs",
         "view": "jobs/moderator/moderator",
         "title": "Community Moderator"
     },

--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -39,14 +39,6 @@ var Jobs = React.createClass({
                                 </span>
                             </li>
                             <li>
-                                <a href="http://media.mit.edu/about/opportunities/senior-backend-engineer-scratch">
-                                    Senior Back-end Engineer
-                                </a>
-                                <span>
-                                    (MIT Media Lab, Cambridge, MA)
-                                </span>
-                            </li>
-                            <li>
                                 <a href="http://bit.ly/2f5hABE">
                                     Trust &amp; Safety Manager
                                 </a>

--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -31,16 +31,24 @@ var Jobs = React.createClass({
                         <h3><FormattedMessage id='jobs.openings' /></h3>
                         <ul>
                             <li>
-                                <a href="http://bit.ly/2f5hABE">
-                                    Trust &amp; Safety Manager
+                                <a href="/jobs/moderator">
+                                    Community Moderator
+                                </a>
+                                <span>
+                                    MIT Media Lab, Cambridge, MA (or Remote)
+                                </span>
+                            </li>
+                            <li>
+                                <a href="http://media.mit.edu/about/opportunities/senior-backend-engineer-scratch">
+                                    Senior Back-end Engineer
                                 </a>
                                 <span>
                                     (MIT Media Lab, Cambridge, MA)
                                 </span>
                             </li>
                             <li>
-                                <a href="http://media.mit.edu/about/opportunities/senior-backend-engineer-scratch">
-                                    Senior Back-end Engineer
+                                <a href="http://bit.ly/2f5hABE">
+                                    Trust &amp; Safety Manager
                                 </a>
                                 <span>
                                     (MIT Media Lab, Cambridge, MA)

--- a/src/views/jobs/moderator/moderator.jsx
+++ b/src/views/jobs/moderator/moderator.jsx
@@ -1,0 +1,96 @@
+var React = require('react');
+var render = require('../../lib/render.jsx');
+
+var Page = require('../../components/page/www/page.jsx');
+var InformationPage = require('../../components/informationpage/informationpage.jsx');
+
+var Moderator = React.createClass({
+    type: 'Moderator',
+    render: function () {
+        return (
+            <InformationPage title={'Community Moderator'}>
+                <div className="inner info-inner">
+                    <p>
+                        Interested in kids, creativity, and online communities?
+                         We're seeking community moderators to work with the Scratch
+                         Team. Moderators will support creative activities and
+                         positive interactions on Scratch — a free online community
+                         where young people program and share interactive stories,
+                         games, and animations. Scratch has grown to more than 20
+                         million registered members (ages 8 and up), creating and
+                         sharing thousands of projects each day. Moderators will
+                         gain valuable experience working online with youth in a
+                         creative, interest driven setting.
+                    </p>
+                    <a href="https://twitter.com/share">Tweet</a>
+                    <h3>Responsibilities:</h3>
+                    <ul>
+                        <li>
+                            Participate actively in the Scratch online community as
+                             a mentor and resource for youth
+                        </li>
+                        <li>
+                            Help moderate projects, studios, and comments on the
+                             website
+                        </li>
+                        <li>
+                            Support youth volunteer programs in the online community
+                        </li>
+                        <li>
+                            Promote the values and core ideas of the Scratch project
+                             (such as remixing, creative collaboration, and
+                             constructive feedback)
+                        </li>
+                    </ul>
+                    <br/>
+                    <h3>Qualifications:</h3>
+                    <ul>
+                        <li>
+                            Active participation in online communities, forums, or
+                             other webbased media
+                        </li>
+                        <li>
+                            Excellent writing and communication skills
+                        </li>
+                        <li>
+                            Good at considering issues from multiple perspectives
+                        </li>
+                        <li>
+                            Able to work independently and as part of a team
+                        </li>
+                        <li>
+                            Interest in visual arts, programming, or teaching
+                        </li>
+                        <li>
+                            Not required, but would be cool: Ability to speak another
+                             language
+                        </li>
+                    </ul>
+                    <br/>
+                    <p>
+                        This position is part-time (10-12 hours per week) under contract.
+                         All candidates must be at least 18 years old and have
+                         authorization to work in the United States.
+                    </p>
+                    <p><b>MIT Media Lab, Cambridge, MA (or Remote)</b></p>
+                    <p>
+                        Send a copy of your resume, links to one or more of your online
+                         presences, and cover letter to{' '}
+                         <a href="mailto:jobs+moderator@scratch.mit.edu">
+                             jobs+moderator@scratch.mit.edu</a>.
+                    </p>
+                    <p>
+                        <i>
+                            Really want the gig? <a href="/create">Create</a> an
+                             awesome Scratch project to introduce yourself, share
+                             it on the Scratch website, and send us a link.
+                        </i>
+                    </p>
+                    <a href="https://twitter.com/share">Tweet</a>
+                </div>
+            </InformationPage>
+        );
+    }
+});
+
+render(<Page><Moderator /></Page>, document.getElementById('app'));

--- a/src/views/jobs/moderator/moderator.jsx
+++ b/src/views/jobs/moderator/moderator.jsx
@@ -22,7 +22,6 @@ var Moderator = React.createClass({
                          gain valuable experience working online with youth in a
                          creative, interest driven setting.
                     </p>
-                    <a href="https://twitter.com/share">Tweet</a>
                     <h3>Responsibilities:</h3>
                     <ul>
                         <li>
@@ -86,7 +85,6 @@ var Moderator = React.createClass({
                              it on the Scratch website, and send us a link.
                         </i>
                     </p>
-                    <a href="https://twitter.com/share">Tweet</a>
                 </div>
             </InformationPage>
         );

--- a/src/views/jobs/moderator/moderator.jsx
+++ b/src/views/jobs/moderator/moderator.jsx
@@ -1,8 +1,8 @@
 var React = require('react');
-var render = require('../../lib/render.jsx');
+var render = require('../../../lib/render.jsx');
 
-var Page = require('../../components/page/www/page.jsx');
-var InformationPage = require('../../components/informationpage/informationpage.jsx');
+var Page = require('../../../components/page/www/page.jsx');
+var InformationPage = require('../../../components/informationpage/informationpage.jsx');
 
 var Moderator = React.createClass({
     type: 'Moderator',

--- a/src/views/jobs/moderator/moderator.jsx
+++ b/src/views/jobs/moderator/moderator.jsx
@@ -71,7 +71,7 @@ var Moderator = React.createClass({
                          All candidates must be at least 18 years old and have
                          authorization to work in the United States.
                     </p>
-                    <p><b>MIT Media Lab, Cambridge, MA (or Remote)</b></p>
+                    <p><b>(MIT Media Lab, Cambridge, MA or Remote)</b></p>
                     <p>
                         Send a copy of your resume, links to one or more of your online
                          presences, and cover letter to{' '}


### PR DESCRIPTION
Should resolve #1218 

## Test cases:
- Back-End Engineer position removed from jobs page
- Community Moderator position added to jobs page
- Community Moderator page added at `/jobs/moderator`
- All links should be functional on the Community Moderators page (Twitter links, create link, mailto link)
