### PR TITLE
Match `routeAlias` with that of `/jobs` route

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -183,7 +183,7 @@
     {
         "name": "jobs-moderator",
         "pattern": "^/jobs/moderator/?$",
-        "routeAlias": "/jobs",
+        "routeAlias": "/jobs/?$",
         "view": "jobs/moderator/moderator",
         "title": "Community Moderator"
     },


### PR DESCRIPTION
this `routeAlias` is being added as it’s own path pattern since it’s not matching the other one, causing us to hit our 512 char limit.

/cc @thisandagain @chrisgarrity – now we know where we're at when we want to add new pages :).