### PR TITLE
Fix gh-1239: Update Conference Dates

### DIFF
--- a/src/views/conference/2017/index/index.jsx
+++ b/src/views/conference/2017/index/index.jsx
@@ -225,7 +225,7 @@ var ConferenceSplash = React.createClass({
                                         />
                                         {' - '}
                                         <FormattedDate
-                                            value={new Date(2017, 10, 15)}
+                                            value={new Date(2017, 10, 12)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'

--- a/src/views/conference/2017/index/index.jsx
+++ b/src/views/conference/2017/index/index.jsx
@@ -218,7 +218,7 @@ var ConferenceSplash = React.createClass({
                                     <td><FormattedMessage id='conference-2017.date' /></td>
                                     <td>
                                         <FormattedDate
-                                            value={new Date(2017, 10, 13)}
+                                            value={new Date(2017, 10, 10)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'
@@ -459,14 +459,14 @@ var ConferenceSplash = React.createClass({
                                     <td><FormattedMessage id='conference-2017.date' /></td>
                                     <td>
                                         <FormattedDate
-                                            value={new Date(2017, 5, 20)}
+                                            value={new Date(2017, 4, 20)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'
                                         />
                                         {' - '}
                                         <FormattedDate
-                                            value={new Date(2017, 5, 21)}
+                                            value={new Date(2017, 4, 21)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'


### PR DESCRIPTION
Costa Rica dates were updated, plus fixed a gotcha with the China dates. (Wasn't counting on the month number being 0-based)

Oh yeah, I forgot to reference this one to #1239 

## Test cases:
- Costa Rica's conference dates should now be November 10, 2017 - November 12, 2017
- China dates should be May, not June. (Whoops!)