### PR TITLE
Fix gh-1194: Remove Scratch Day from Localization

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -190,7 +190,7 @@ var Footer = React.createClass({
                             </dd>
                             <dd>
                                 <a href="http://day.scratch.mit.edu/">
-                                    <FormattedMessage id='general.scratchday' />
+                                    Scratch Day
                                 </a>
                             </dd>
                             <dd>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -59,7 +59,6 @@
     "general.profile": "Profile",
     "general.resourcesTitle": "Educator Resources",
     "general.scratchConference": "Scratch Conference",
-    "general.scratchday": "Scratch Day",
     "general.scratchEd": "ScratchEd",
     "general.scratchFoundation": "Scratch Foundation",
     "general.scratchJr": "ScratchJr",


### PR DESCRIPTION
Fixes #1194 

## Test cases:
- Footer text for the day.scratch.mit.edu should still read `Scratch Day`