### PR TITLE
Nit-picky Developer Class Type

### DIFF
--- a/src/views/developers/developers.jsx
+++ b/src/views/developers/developers.jsx
@@ -12,7 +12,7 @@ var TitleBanner = require('../../components/title-banner/title-banner.jsx');
 require('./developers.scss');
 
 var Developers = React.createClass({
-    type: 'About',
+    type: 'Developers',
     render: function () {
         return (
             <div className="developers">


### PR DESCRIPTION
Just noticed that the type on this page was `About` instead of `Developers`. No logged issues about this, it's just me being nit-picky.

I might be wrong about this, please correct me if I am.