### PR TITLE
[Master] Hotfix GH-1265: Update jobs route to include moderator

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -176,14 +176,14 @@
     {
         "name": "jobs",
         "pattern": "^/jobs/?$",
-        "routeAlias": "/jobs/?$",
+        "routeAlias": "/jobs(/moderator)?/?$",
         "view": "jobs/jobs",
         "title": "Jobs"
     },
     {
         "name": "jobs-moderator",
         "pattern": "^/jobs/moderator/?$",
-        "routeAlias": "/jobs/?$",
+        "routeAlias": "/jobs(/moderator)?/?$",
         "view": "jobs/moderator/moderator",
         "title": "Community Moderator"
     },


### PR DESCRIPTION
Fixes #1265 by updating the logic for checking the route to include an optional moderator endpoint check.