### PR TITLE
Fix gh-728: Align Misaligned Nav-bar Dropdown

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -8,7 +8,6 @@
     border-radius: 0 0 5px 5px;
     background-color: $ui-blue;
     padding: 10px;
-    min-width: 160px;
     max-width: 260px;
     overflow: visible;
     color: $type-white;


### PR DESCRIPTION
Fixes #728 

## Test cases:
- Click the dropdown in the nav-bar (where your username is). The dropdown should now be aligned with the nav-bar component, like so:
![screenshot](https://cloud.githubusercontent.com/assets/12952370/25041506/7f04c0f6-20de-11e7-9b99-dcf46b42b71f.png)
