### PR TITLE
Fix GH-1278: Use birthOffset for age check

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -340,7 +340,7 @@ module.exports = {
             );
             if (((Date.now() - birthdate) / (24*3600*1000*365.25)) < this.props.birthOffset) {
                 return invalidate({
-                    'user.birth.month': this.props.intl.formatMessage({id: 'teacherRegistration.validationAge'})
+                    'user.birth.year': this.props.intl.formatMessage({id: 'teacherRegistration.validationAge'})
                 });
             }
             return this.props.onNextStep(formData);

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -338,7 +338,7 @@ module.exports = {
               formData.user.birth.month - 1,
               1
             );
-            if (((Date.now() - birthdate) / (24*3600*1000*365.25)) < 13) {
+            if (((Date.now() - birthdate) / (24*3600*1000*365.25)) < this.props.birthOffset) {
                 return invalidate({
                     'user.birth.month': this.props.intl.formatMessage({id: 'teacherRegistration.validationAge'})
                 });


### PR DESCRIPTION
This fixes #1278 by ensuring that the `birthOffset`, not a hardcoded value, is used for validation – meaning that students will not be checked if they're younger than 13. It also changes to show the error on the year field for UX purposes.