### PR TITLE
Fix gh-1292: Dropdown Mobile Un-Friendly

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -85,7 +85,7 @@
         }
     }
     
-    @media only screen and (max-width: $mobile - 1) {
+    @media only screen and (max-width: $tablet - 1) {
         min-width: 160px;
     }
 }

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -84,3 +84,7 @@
         }
     }
 }
+
+@media only screen and (max-width: $mobile - 1) {
+    min-width: 160px;
+}

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -84,8 +84,8 @@
             content: "";
         }
     }
-}
-
-@media only screen and (max-width: $mobile - 1) {
-    min-width: 160px;
+    
+    @media only screen and (max-width: $mobile - 1) {
+        min-width: 160px;
+    }
 }

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -1,4 +1,5 @@
 @import "../../colors";
+@import "../../frameless";
 
 .dropdown {
     display: none;


### PR DESCRIPTION
Fixes #1292 

Test cases:
- `min-width: 160px` should not be applied on desktop sized screens
- `min-width: 160px` should be applied to mobile sized screens

@mewtaylor @rschamp @thisandagain 