### PR TITLE
Fix gh-1296: Add DD Liu to Credits Page

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -51,6 +51,11 @@ var Credits = React.createClass({
                         <img src="//cdn.scratch.mit.edu/get_image/user/2752403_170x170.png" alt="Saskia Avatar" />
                         <span className="name">Saskia Leggett</span>
                     </li>
+                                        
+                    <li>
+                        <img src="//cdn.scratch.mit.edu/get_image/user/527836_170x170.png" alt="DD Avatar" />
+                        <span className="name">DD Liu</span>
+                    </li>
                     
                     <li>
                         <img src="//cdn.scratch.mit.edu/get_image/user/3714374_170x170.png" alt="Shruti Avatar" />


### PR DESCRIPTION
Resolves #1296 

## Test cases:
- DD Liu should now be added to the "Scratch is designed and developed by the Lifelong Kindergarten Group at MIT Media Lab:" section
- Icon for DD Liu should be https://cdn.scratch.mit.edu/get_image/user/527836_170x170.png

@mewtaylor @rschamp @thisandagain 