### PR TITLE
Fix r2-3978: Use regex in express patterns to limit scope

### DIFF
--- a/bin/lib/fastly-config-methods.js
+++ b/bin/lib/fastly-config-methods.js
@@ -37,7 +37,8 @@ var FastlyConfigMethods = {
      * all :arguments become .+?
      */
     expressPatternToRegex: function (pattern) {
-        return pattern.replace(/(:[^/]+)/gi, '.+?');
+        pattern = pattern.replace(/(:\w+)(\([^\)]+\))/gi, '$2');
+        return pattern.replace(/(:\w+)/gi, '.+?');
     },
 
     /*

--- a/bin/lib/fastly-config-methods.js
+++ b/bin/lib/fastly-config-methods.js
@@ -33,8 +33,10 @@ var FastlyConfigMethods = {
     },
 
     /*
-     * Translate an express-style pattern e.g. /path/:arg/ to a regex
-     * all :arguments become .+?
+     * Translate an express-style pattern to regex one in two ways:
+     *
+     * 1. /path/:arg/ – all :arg's become .+?
+     * 2. /path/:arg([regex]) – :arg is removed, leaving just /path/([regex])
      */
     expressPatternToRegex: function (pattern) {
         pattern = pattern.replace(/(:\w+)(\([^\)]+\))/gi, '$2');

--- a/src/routes.json
+++ b/src/routes.json
@@ -127,7 +127,7 @@
     },
     {
         "name": "explore",
-        "pattern": "^/explore/:projects/:all/?$",
+        "pattern": "^/explore/:projects(projects|studios)/:all/?$",
         "routeAlias": "/explore(?!/ajax)",
         "view": "explore/explore",
         "title": "Explore"


### PR DESCRIPTION
This fixes https://github.com/LLK/scratchr2/issues/3798 by using regex in expressjs patterns, and then also parsing those regex patterns for fastly, such that we can limit the scope of the regex created for a specific view.