### PR TITLE
Fix 1303 Fallout: Apply defaults for untranslated pages too

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -208,6 +208,7 @@ async.forEachLimit(views, 5, function (view, cb) {
                             process.stdout.write('No translations for ' + view + isoCode + ', using english\n');
                         }
                         viewLocales[isoCode] = merge({}, generalLocales[isoCode], defaultLocales[view]);
+                        defaults(viewLocales[isoCode], generalLocales['en']);
                     }
                     return cb();
                 } else {


### PR DESCRIPTION
since we’ll need them for nav/footer strings

/cc @chrisgarrity 