### PR TITLE
Readme update for running standalone client on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ make deploy
 ### Current issues with the development
 We're currently in the process of transitioning into this web client from Scratch's existing structure. As we transition, there are going to be some issues along the way that relate to how this client needs to interact with the existing infrastructure to work properly in production.
 
+#### FALLBACK ####
 On top of migrating to using this as our web client, Scratch is also transitioning into using a new API backend, Scratch REST API. As that is also currently in development and incomplete, we are set up to fall back to using existing Scratch endpoints if an API endpoint does not exist – which is where the `FALLBACK` comes in.
 
 Most of the issues we have currently revolve around the use of `FALLBACK`. This variable is used to specify what url to fall back onto should a request fail within the context of this webclient, or when using the `API_HOST`. If not specified in the process, it will not be used, and any request that is not made through the web client or the API will be unreachable.
@@ -112,3 +113,5 @@ Setting `FALLBACK=https://scratch.mit.edu` allows the web client to retrieve dat
 
 Additionally, if you set `FALLBACK=https://scratch.mit.edu`, be aware that clicking on links to parts of the website not yet migrated over (currently such as `Explore`, `Discuss`, `Profile`, etc.) will take you to the Scratch website itself.
 
+#### Windows ####
+Some users have experienced difficulties when trying to get our web client to work on Windows. One solution could be to use [Cygwin](https://www.cygwin.com/). If that doesn't work, you might want to use [Wubi](https://wiki.ubuntu.com/WubiGuide) (Windows XP, Vista, 7) or [Wubiuefi](https://github.com/hakuna-m/wubiuefi) (Windows 8 or higher). Wubi(uefi) is a Windows Installer for Ubuntu that allows you to have Ubuntu and Windows on one disk, without the need of an extra partition.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ make deploy
 ### Current issues with the development
 We're currently in the process of transitioning into this web client from Scratch's existing structure. As we transition, there are going to be some issues along the way that relate to how this client needs to interact with the existing infrastructure to work properly in production.
 
-#### FALLBACK ####
+#### FALLBACK
 On top of migrating to using this as our web client, Scratch is also transitioning into using a new API backend, Scratch REST API. As that is also currently in development and incomplete, we are set up to fall back to using existing Scratch endpoints if an API endpoint does not exist – which is where the `FALLBACK` comes in.
 
 Most of the issues we have currently revolve around the use of `FALLBACK`. This variable is used to specify what url to fall back onto should a request fail within the context of this webclient, or when using the `API_HOST`. If not specified in the process, it will not be used, and any request that is not made through the web client or the API will be unreachable.
@@ -113,5 +113,5 @@ Setting `FALLBACK=https://scratch.mit.edu` allows the web client to retrieve dat
 
 Additionally, if you set `FALLBACK=https://scratch.mit.edu`, be aware that clicking on links to parts of the website not yet migrated over (currently such as `Explore`, `Discuss`, `Profile`, etc.) will take you to the Scratch website itself.
 
-#### Windows ####
+#### Windows
 Some users have experienced difficulties when trying to get our web client to work on Windows. One solution could be to use [Cygwin](https://www.cygwin.com/). If that doesn't work, you might want to use [Wubi](https://wiki.ubuntu.com/WubiGuide) (Windows XP, Vista, 7) or [Wubiuefi](https://github.com/hakuna-m/wubiuefi) (Windows 8 or higher). Wubi(uefi) is a Windows Installer for Ubuntu that allows you to have Ubuntu and Windows on one disk, without the need of an extra partition.


### PR DESCRIPTION
From the issues and from my own experience it seems that the standalone client doesn't work well on windows. I added a section "Windows" to the readme, to point windows users to two possible solutions. 
(1) Cygwin has not worked for me personally, but for @cwillisf it did. 
I tried (2) Wubi(uefi) which worked perfectly well. It is a simple .exe wich installs Ubuntu from within Windows and you can decide for Windows or Ubuntu when booting. No partitioning is needed. In Ubuntu you can still access your files from Windows. You have to install things like npm, node and git again for Ubuntu though. I hope my wording is okay, feel free to change it though. I also wasn't sure about how much information I should provide about the two solutions. 