### PR TITLE
Fix GH-1351: Make version dependent on xml call

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -137,7 +137,7 @@ var Footer = React.createClass({
                                 </a>
                             </dd>
                             <dd>
-                                <a href="/scratch2download/">
+                                <a href="/download">
                                     <FormattedMessage id='general.offlineEditor' />
                                 </a>
                             </dd>

--- a/src/routes.json
+++ b/src/routes.json
@@ -168,8 +168,8 @@
     },
     {
         "name": "download",
-        "pattern": "^/scratch2download/",
-        "routeAlias": "/scratch2download/?$",
+        "pattern": "^/download/",
+        "routeAlias": "/download/?$",
         "view": "download/download",
         "title": "Scratch Offline Editor"
     },
@@ -251,6 +251,12 @@
         "pattern": "^/explore/studios/?$",
         "routeAlias": "/explore(?!/ajax)",
         "redirect": "/explore/studios/all"
+    },
+    {
+        "name": "download-redirect",
+        "pattern": "^/scratch2download/?$",
+        "routeAlias": "/scratch2download",
+        "view": "/download"
     },
     {
         "name": "microworld-art",

--- a/src/routes.json
+++ b/src/routes.json
@@ -256,7 +256,7 @@
         "name": "download-redirect",
         "pattern": "^/scratch2download/?$",
         "routeAlias": "/scratch2download",
-        "view": "/download"
+        "redirect": "/download"
     },
     {
         "name": "microworld-art",

--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -4,6 +4,7 @@ var render = require('../../lib/render.jsx');
 var FormattedHTMLMessage = require('react-intl').FormattedHTMLMessage;
 var FormattedMessage = require('react-intl').FormattedMessage;
 
+var api = require('../../lib/api');
 var Page = require('../../components/page/www/page.jsx');
 var TitleBanner = require('../../components/title-banner/title-banner.jsx');
 var FlexRow = require('../../components/flex-row/flex-row.jsx');
@@ -14,7 +15,33 @@ require('../../components/forms/button.scss');
 
 var Download = React.createClass({
     type: 'Download',
+    getInitialState: function () {
+        return {
+            swfVersion: '456.0.3'
+        };
+    },
+    componentDidMount: function () {
+        api({
+            host: '',
+            uri: '/scratchr2/static/sa/version.xml',
+            responseType: 'string'
+        }, function (err, body) {
+            if (err) return;
+
+            var doc = new DOMParser().parseFromString(body, 'text/xml');
+            return this.setState({
+                swfVersion: doc.getElementsByTagName('versionNumber')[0].childNodes[0].nodeValue
+            });
+        }.bind(this));
+    },
     render: function () {
+        var downloadUrls = {
+            mac: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.dmg',
+            mac105: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air',
+            windows: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.exe',
+            linux: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air'
+        };
+
         return (
             <div className="download">
                 <TitleBanner className="masthead">
@@ -95,25 +122,25 @@ var Download = React.createClass({
                                     <ul className="installation-downloads">
                                         <li className="installation-downloads-item">
                                             <FormattedMessage id='download.macOSX' /> -
-                                            {' '}<a href="http://get.adobe.com/air/">
+                                            {' '}<a href={downloadUrls.mac}>
                                                 <FormattedMessage id='download.download' />
                                             </a>
                                         </li>
                                         <li className="installation-downloads-item">
                                             <FormattedMessage id='download.macOlder' /> -
-                                            {' '}<a href="http://airdownload.adobe.com/air/mac/download/2.6/AdobeAIR.zip">
+                                            {' '}<a href={downloadUrls.mac105}>
                                                 <FormattedMessage id='download.download' />
                                             </a>
                                         </li>
                                         <li className="installation-downloads-item">
                                             <FormattedMessage id='download.windows' /> -
-                                            {' '}<a href="http://get.adobe.com/air/">
+                                            {' '}<a href={downloadUrls.windows}>
                                                 <FormattedMessage id='download.download' />
                                             </a>
                                         </li>
                                         <li className="installation-downloads-item">
                                             <FormattedMessage id='download.linux' /> -
-                                            {' '}<a href="http://airdownload.adobe.com/air/lin/download/2.6/AdobeAIRInstaller.bin">
+                                            {' '}<a href={downloadUrls.linux}>
                                                 <FormattedMessage id='download.download' />
                                             </a>
                                         </li>
@@ -150,7 +177,14 @@ var Download = React.createClass({
                             <span className="nav-spacer"></span>
                             <h2><FormattedMessage id='download.updatesTitle' /></h2>
                             <p><FormattedMessage id='download.updatesBody' /></p>
-                            <p><FormattedMessage id='download.currentVersion' /></p>
+                            <p>
+                                <FormattedMessage
+                                    id='download.currentVersion'
+                                    values={{
+                                        version: this.state.swfVersion
+                                    }}
+                                />
+                            </p>
                         </section>
 
                         <section id="other">

--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -17,7 +17,7 @@ var Download = React.createClass({
     type: 'Download',
     getInitialState: function () {
         return {
-            swfVersion: '456.0.3'
+            swfVersion: ''
         };
     },
     componentDidMount: function () {
@@ -25,8 +25,12 @@ var Download = React.createClass({
             host: '',
             uri: '/scratchr2/static/sa/version.xml',
             responseType: 'string'
-        }, function (err, body) {
-            if (err) return;
+        }, function (err, body, res) {
+            if (err || res.statusCode >= 400) {
+                return this.setState({
+                    swfVersion: -1
+                });
+            }
 
             var doc = new DOMParser().parseFromString(body, 'text/xml');
             return this.setState({
@@ -35,12 +39,14 @@ var Download = React.createClass({
         }.bind(this));
     },
     render: function () {
-        var downloadUrls = {
-            mac: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.dmg',
-            mac105: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air',
-            windows: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.exe',
-            linux: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air'
-        };
+        if (this.state.swfVersion.length > 0 && this.state.swfVersion !== -1) {
+            var downloadUrls = {
+                mac: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.dmg',
+                mac105: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air',
+                windows: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.exe',
+                linux: '/scratchr2/static/sa/Scratch-'+ this.state.swfVersion + '.air'
+            };
+        }
 
         return (
             <div className="download">
@@ -82,43 +88,42 @@ var Download = React.createClass({
                     </div>
                 </TitleBanner>
                 <div className="download-content">
-                    <div className="inner">
-                        <section id="installation">
-                            <span className="nav-spacer"></span>
-                            <FlexRow className="three-col-row">
-                                <div className="installation-column">
-                                    <h3><FormattedMessage id='download.airTitle' /></h3>
-                                    <p><FormattedHTMLMessage id='download.airBody' /></p>
-                                    <ul className="installation-downloads">
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.macOSX' /> -
-                                            {' '}<a href="http://get.adobe.com/air/">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.macOlder' /> -
-                                            {' '}<a href="http://airdownload.adobe.com/air/mac/download/2.6/AdobeAIR.zip">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.windows' /> -
-                                            {' '}<a href="http://get.adobe.com/air/">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.linux' /> -
-                                            {' '}<a href="http://airdownload.adobe.com/air/lin/download/2.6/AdobeAIRInstaller.bin">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div className="installation-column">
-                                    <h3><FormattedMessage id='download.offlineEditorTitle' /></h3>
-                                    <p><FormattedMessage id='download.offlineEditorBody' /></p>
+                    <section id="installation" className="installation">
+                        <FlexRow className="three-col-row inner">
+                            <div className="installation-column">
+                                <h3><FormattedMessage id='download.airTitle' /></h3>
+                                <p><FormattedHTMLMessage id='download.airBody' /></p>
+                                <ul className="installation-downloads">
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.macOSX' /> -
+                                        {' '}<a href="http://get.adobe.com/air/">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.macOlder' /> -
+                                        {' '}<a href="http://airdownload.adobe.com/air/mac/download/2.6/AdobeAIR.zip">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.windows' /> -
+                                        {' '}<a href="http://get.adobe.com/air/">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.linux' /> -
+                                        {' '}<a href="http://airdownload.adobe.com/air/lin/download/2.6/AdobeAIRInstaller.bin">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="installation-column">
+                                <h3><FormattedMessage id='download.offlineEditorTitle' /></h3>
+                                <p><FormattedMessage id='download.offlineEditorBody' /></p>
+                                {downloadUrls ? [
                                     <ul className="installation-downloads">
                                         <li className="installation-downloads-item">
                                             <FormattedMessage id='download.macOSX' /> -
@@ -145,46 +150,52 @@ var Download = React.createClass({
                                             </a>
                                         </li>
                                     </ul>
-                                </div>
-                                <div className="installation-column">
-                                    <h3><FormattedMessage id='download.supportMaterialsTitle' /></h3>
-                                    <p><FormattedMessage id='download.supportMaterialsBody' /></p>
-                                    <ul className="installation-downloads">
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.starterProjects' /> -
-                                            {' '}<a href="https://scratch.mit.edu/scratchr2/static/sa/Scratch2StarterProjects.zip">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.gettingStarted' /> -
-                                            {' '}<a href="https://cdn.scratch.mit.edu/scratchr2/static/__709da8e5f3d72129538a4ccdbcbf5f2a__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id='download.scratchCards' /> -
-                                            {' '}<a href="https://cdn.scratch.mit.edu/scratchr2/static/__709da8e5f3d72129538a4ccdbcbf5f2a__/pdfs/help/Scratch2Cards.pdf">
-                                                <FormattedMessage id='download.download' />
-                                            </a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </FlexRow>
-                        </section>
-
+                                ] : []}
+                                {this.state.swfVersion === -1 ? [
+                                    <p><i><FormattedMessage id='download.notAvailable' /></i></p>
+                                ] : []}
+                            </div>
+                            <div className="installation-column">
+                                <h3><FormattedMessage id='download.supportMaterialsTitle' /></h3>
+                                <p><FormattedMessage id='download.supportMaterialsBody' /></p>
+                                <ul className="installation-downloads">
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.starterProjects' /> -
+                                        {' '}<a href="https://scratch.mit.edu/scratchr2/static/sa/Scratch2StarterProjects.zip">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.gettingStarted' /> -
+                                        {' '}<a href="https://cdn.scratch.mit.edu/scratchr2/static/__709da8e5f3d72129538a4ccdbcbf5f2a__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                    <li className="installation-downloads-item">
+                                        <FormattedMessage id='download.scratchCards' /> -
+                                        {' '}<a href="https://cdn.scratch.mit.edu/scratchr2/static/__709da8e5f3d72129538a4ccdbcbf5f2a__/pdfs/help/Scratch2Cards.pdf">
+                                            <FormattedMessage id='download.download' />
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </FlexRow>
+                    </section>
+                    <div className="inner">
                         <section id="updates">
                             <span className="nav-spacer"></span>
                             <h2><FormattedMessage id='download.updatesTitle' /></h2>
                             <p><FormattedMessage id='download.updatesBody' /></p>
-                            <p>
-                                <FormattedMessage
-                                    id='download.currentVersion'
-                                    values={{
-                                        version: this.state.swfVersion
-                                    }}
-                                />
-                            </p>
+                            {this.state.swfVersion !== -1 ? [
+                                <p>
+                                    <FormattedMessage
+                                        id='download.currentVersion'
+                                        values={{
+                                            version: this.state.swfVersion
+                                        }}
+                                    />
+                                </p>
+                            ] : []}
                         </section>
 
                         <section id="other">

--- a/src/views/download/download.scss
+++ b/src/views/download/download.scss
@@ -10,6 +10,7 @@ $developer-spot: $splash-blue;
 .download {
     .title-banner {
         &.masthead {
+            margin-bottom: 0;
             background-color: $developer-spot;
             padding-bottom: 0;
 
@@ -48,40 +49,39 @@ $developer-spot: $splash-blue;
             }
         }
     }
-    
+
     .download-content {
         padding-bottom: 2rem;
     }
-    
+
     .three-col-row {
         align-items: flex-start;
     }
-    
+
     .installation {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: flex-start;
-        justify-content: space-between;
+        $background-gray: hsla(0, 0, 0, .05);
+        background-color: $background-gray;
+        padding: 2rem;
     }
-        
+
     .installation-column {
         max-width: $cols4;
     }
-    
+
     .installation-downloads {
         padding-left: 0;
         list-style: none;
     }
-    
+
     .installation-downloads-item {
         margin: .25rem;
         padding: 0;
     }
-    
+
     section {
         margin-bottom: 2rem;
     }
-    
+
     .mod-link {
         color: $ui-white;
     }
@@ -92,7 +92,7 @@ $developer-spot: $splash-blue;
                 max-width: 100%;
             }
         }
-        
+
         .three-col-row {
             align-items: center;
         }

--- a/src/views/download/download.scss
+++ b/src/views/download/download.scss
@@ -59,8 +59,7 @@ $developer-spot: $splash-blue;
     }
 
     .installation {
-        $background-gray: hsla(0, 0, 0, .05);
-        background-color: $background-gray;
+        background-color: $ui-gray;
         padding: 2rem;
     }
 

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -19,7 +19,7 @@
   "download.scratchCards": "Scratch Cards",
   "download.updatesTitle": "Updates",
   "download.updatesBody": "The Offline Editor can update itself (with user permission). It will check for updates at startup or you can use the \"Check for updates\" command in the file menu.",
-  "download.currentVersion": "The current version is 454.",
+  "download.currentVersion": "The current version is {version}.",
   "download.otherVersionsTitle": "Other Versions of Scratch",
   "download.otherVersionsOlder": "If you have an older computer, or cannot install the Scratch 2.0 offline editor, you can try installing <a href=\"http://scratch.mit.edu/scratch_1.4/\">Scratch 1.4</a>.",
   "download.otherVersionsAdmin": "If you are a network administrator: a Scratch 2.0 MSI has been created and maintained by a member of the community and hosted for public download <a href=\"http://llk.github.io/scratch-msi/\">here</a>.",

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -27,5 +27,6 @@
   "download.knownIssuesOne": "If your offline editor is crashing directly after Scratch is opened, install the Scratch 2 offline editor again (see step 2 above.) This issue is due to a bug introduced in Adobe Air version 14. (released April 2014).",
   "download.knownIssuesTwo": "Graphic effects blocks (in \"Looks\") may slow down projects due to a known Flash bug.",
   "download.knownIssuesThree": "The <b>backpack</b> is not yet available.",
-  "download.reportBugs": "Report Bugs and Glitches"
+  "download.reportBugs": "Report Bugs and Glitches",
+  "download.notAvailable": "Hmm, editor downloads are not available right now - please refresh the page to try again."
 }

--- a/src/views/privacypolicy/privacypolicy.jsx
+++ b/src/views/privacypolicy/privacypolicy.jsx
@@ -55,7 +55,7 @@ var Privacypolicy = React.createClass({
                                  Scratch Team is responsible for moderation, we have access to all
                                  content stored on the Scratch website, including unshared projects.
                                  If you prefer to work on projects in complete privacy, you can use
-                                 either the <a href="/scratch2download">Scratch 2 offline editor</a>{' '}
+                                 either the <a href="/download">Scratch 2 offline editor</a>{' '}
                                  or <a href="/scratch_1.4">Scratch 1.4</a>.
                             </dd>
                             <dt>Usage Information: </dt>


### PR DESCRIPTION
Fixes #1351 by including a call to `version.xml` to get the most up-to-date offline build version, defaulting to the current version, `456.0.3`. This also fixes #1352 by switching the route to `/download`, with a redirect from `/scratch2download/`

### Test Cases ###
* Go to download page. All downloads for the offline editor should download
* Go to `/scratch2download` – you should be redirected to `/download`
* click on `offline editor` in the footer – you should be directed to `/download`