### PR TITLE
Add dependency for node-dir 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash.omit": "3.1.0",
     "lodash.range": "3.0.1",
     "minilog": "2.0.8",
+    "node-dir": "0.1.16",
     "node-sass": "3.3.3",
     "pako": "0.2.8",
     "po2icu": "0.0.2",


### PR DESCRIPTION
FIxes problem where webpack wasn’t copying static or intl to the build directory.

Gory details:
node-dir is a dependency of copy-webpack-plugin. If you don’t already have it installed, the latest version (0.1.17) gets installed and that one breaks copy-webpack (https://github.com/fshost/node-dir/issues/50). Webpack build will complete. but there will be an error `ERROR in this is not a typed array.` We didn’t see it earlier because node-modules are cached.