### PR TITLE
Redirect help

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -153,8 +153,8 @@
     },
     {
         "name": "help",
-        "pattern": "^/help/?(\\?.*)?$",
-        "routeAlias": "/help/?\\??",
+        "pattern": "^/help/?$",
+        "routeAlias": "/help",
         "redirect": "/tips"
     },
     {


### PR DESCRIPTION
Simplify help redirect so it doesn't match anything other than `/help/` (with the last slash optional).