### PR TITLE
Fix GH-1364: Change `help` to `tips` in footer

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -127,8 +127,8 @@ var Footer = React.createClass({
                                 <FormattedMessage id='general.support' />
                             </dt>
                             <dd>
-                                <a href="/help/">
-                                    <FormattedMessage id='footer.help' />
+                                <a href="/tips">
+                                    <FormattedMessage id='general.tips' />
                                 </a>
                             </dd>
                             <dd>


### PR DESCRIPTION
Fixes #1364.

/cc @SpeakkVisually (just fyi)