### PR TITLE
Fix blocks icon for windows

### DIFF
--- a/src/views/tips/tips.scss
+++ b/src/views/tips/tips.scss
@@ -46,7 +46,7 @@ $darken-button: rgba(0, 0, 0, .1);
     
     img {
         margin-right: 1rem;
-        width: 1rem;
+        height: 1.25rem;
         vertical-align: middle;
     }
     


### PR DESCRIPTION
Note for future reference - set the size for SVGs with height not width if using rem.
IE on Windows 7 doesn’t resize correctly if the width is set with rem. Height works with rem, and exact pixel width works, but that should be avoided.