### PR TITLE
Fix gh-1404: Add Junior Designer Position

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -38,6 +38,14 @@ var Jobs = React.createClass({
                                     MIT Media Lab, Cambridge, MA (or Remote)
                                 </span>
                             </li>
+                            <li>
+                                <a href="https://www.media.mit.edu/about/job-opportunities/junior-web-designer-scratch/">
+                                    Junior Designer
+                                </a>
+                                <span>
+                                    MIT Media Lab, Cambridge, MA
+                                </span>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Resolves #1404 

## Test cases:
- 'Junior Developer' should be the position title
- the link should lead to https://www.media.mit.edu/about/job-opportunities/junior-web-designer-scratch/