### PR TITLE
Fix gh-1382: Centre Align Note

### DIFF
--- a/src/views/download/download.scss
+++ b/src/views/download/download.scss
@@ -53,7 +53,11 @@ $developer-spot: $splash-blue;
     .sub-nav-item {
         margin: .5rem;
     }
-
+    
+    .callout {
+        text-align: center;
+    }
+    
     .download-content {
         padding-bottom: 2rem;
     }


### PR DESCRIPTION
Resolves #1382 

## Test cases:
- the "Note for Mac users" box should have its text centre-aligned now