### PR TITLE
Fix gh-1399: Misplaced Periods Fix

### DIFF
--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -24,7 +24,7 @@
   "download.otherVersionsOlder": "If you have an older computer, or cannot install the Scratch 2.0 offline editor, you can try installing <a href=\"http://scratch.mit.edu/scratch_1.4/\">Scratch 1.4</a>.",
   "download.otherVersionsAdmin": "If you are a network administrator: a Scratch 2.0 MSI has been created and maintained by a member of the community and hosted for public download <a href=\"http://llk.github.io/scratch-msi/\">here</a>.",
   "download.knownIssuesTitle": "Known issues",
-  "download.knownIssuesOne": "If your offline editor is crashing directly after Scratch is opened, install the Scratch 2 offline editor again (see step 2 above.) This issue is due to a bug introduced in Adobe Air version 14. (released April 2014).",
+  "download.knownIssuesOne": "If your offline editor is crashing directly after Scratch is opened, install the Scratch 2 offline editor again (see step 2 above). This issue is due to a bug introduced in Adobe Air version 14 (released April 2014).",
   "download.knownIssuesTwo": "Graphic effects blocks (in \"Looks\") may slow down projects due to a known Flash bug.",
   "download.knownIssuesThree": "The <b>backpack</b> is not yet available.",
   "download.reportBugs": "Report Bugs and Glitches",


### PR DESCRIPTION
Resolves #1399 

## Test cases:
- `This issue is due to a bug introduced in Adobe Air version 14. (released April 2014).` 
Should now read: 
`This issue is due to a bug introduced in Adobe Air version 14 (released April 2014).`

- `If your offline editor is crashing directly after Scratch is opened, install the Scratch 2 offline editor again (see step 2 above.)` 
Should now read: 
`If your offline editor is crashing directly after Scratch is opened, install the Scratch 2 offline editor again (see step 2 above).`