### PR TITLE
Fix Gh-1385 - Issue/smoke test signing in

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -15,5 +15,12 @@
 * To run a single file from the command-line: `$ node_modules/.bin/tap ./test/integration/smoke-testing/filename.js --timeout=3600`
   * The timeout var is for the length of the entire tap test-suite; if you are getting a timeout error, you may need to adjust this value (some of the Selenium tests take a while to run)
 
+### Configuration
+
+| Variable      		| Default               | Description                                 			    |
+| ---------------------	| --------------------- | --------------------------------------------------------- |
+| `SMOKE_USERNAME`    	| `None` 				| Username for Scratch user you're signing in with to test 	|
+| `SMOKE_PASSWORD`  	| `None`                | Password for Scratch user you're signing in with to test  |
+
 ## Using sauce
 * We're still working on setting this up; more info coming shortly

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -9,15 +9,8 @@
  *  - on a variety of instances (local, staging, prod)?
  */
 
-var path = require('path');
-var fs = require('fs');
-
-var dirPath = path.resolve(__dirname, '../not-tracked/');
-var filePath = dirPath + '/credentials.js';
-var credentials = fs.readFileSync(filePath,'utf8');
-
-var window = {};
-var credentials = eval(credentials);
+var username = process.env.USERNAME;
+var password = process.env.PASSWORD;
 
 var tap = require('tap');
 const test = tap.test;
@@ -45,7 +38,7 @@ const clickButton = (text) => {
     return clickXpath(`//button[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
 var url = rootUrl + '/users/anyuser';
 
 tap.plan(5);
@@ -65,7 +58,7 @@ test('Sign in to Scratch using scratchr2 navbar', t => {
     .then(() => findByXpath('//input[@name="password"]'))
     .then((element) => element.sendKeys(password))
     .then(() => clickButton('Sign in'))
-    .then(() => findByXpath('//li[contains(@class, "logged-in-user")' 
+    .then(() => findByXpath('//li[contains(@class, "logged-in-user")'
         + 'and contains(@class, "dropdown")]/span'))
     .then((element) => element.getText('span'))
     .then((text) => t.match(text.toLowerCase(), username.substring(0,10).toLowerCase(),
@@ -135,4 +128,3 @@ test('Add To button should bring up a list of studios', t => {
     })
     .then(() => t.end());
 });
-   

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -3,14 +3,10 @@
  *
  * https://github.com/LLK/scratchr2/wiki/Smoke-Testing-Test-Cases
  *
- * Note that I am using a user with at least 1 project and at least 1 studio
- *  - I'm not sure how to handle this more elegantly... b/c I don't want to commit a password?
- *  - I could supply a password for a Staging user I guess... but then people may want to test
- *  - on a variety of instances (local, staging, prod)?
  */
 
-var username = process.env.USERNAME;
-var password = process.env.PASSWORD;
+var username = process.env.SMOKE_USERNAME;
+var password = process.env.SMOKE_PASSWORD;
 
 var tap = require('tap');
 const test = tap.test;

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -33,10 +33,6 @@ const findByXpath = (xpath) => {
     return driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
 };
 
-const findByCss = (css) => {
-    return driver.wait(until.elementLocated(By.css(css), 1000 * 5));
-};
-
 const clickXpath = (xpath) => {
     return findByXpath(xpath).then(el => el.click());
 };
@@ -139,4 +135,4 @@ test('Add To button should bring up a list of studios', t => {
     })
     .then(() => t.end());
 });
-    
+   

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -49,7 +49,8 @@ const clickButton = (text) => {
     return clickXpath(`//button[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu/users/anyuser';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
+var url = rootUrl + '/users/anyuser';
 
 tap.plan(5);
 
@@ -58,7 +59,7 @@ tap.tearDown(function () {
 });
 
 tap.beforeEach(function () {
-    return driver.get(rootUrl);
+    return driver.get(url);
 });
 
 test('Sign in to Scratch using scratchr2 navbar', t => {
@@ -77,8 +78,7 @@ test('Sign in to Scratch using scratchr2 navbar', t => {
 });
 
 test('Sign in to Scratch & verify My Stuff structure (tabs, title)', t => {
-    findByXpath('//a[@class="mystuff-icon"]')
-    .then((element) => element.click())
+    clickXpath('//a[@class="mystuff-icon"]')
     .then(() => findByXpath('//div[@class="box-head"]/h2'))
     .then((element) => element.getText('h2'))
     .then((text) => t.equal('My Stuff', text, 'title should be My Stuff'))
@@ -101,13 +101,11 @@ test('Sign in to Scratch & verify My Stuff structure (tabs, title)', t => {
 });
 
 test('clicking See Inside should take you to the editor', t => {
-    findByXpath('//a[@class="mystuff-icon"]')
-    .then((element) => element.click())
+    clickXpath('//a[@class="mystuff-icon"]')
     .then(() => findByXpath('//a[@data-control="edit"]'))
     .then((element) => element.getText('span'))
     .then((text) => t.equal(text, 'See inside', 'there should be a "See inside" button'))
-    .then(() => findByXpath('//a[@data-control="edit"]'))
-    .then((element) => element.click())
+    .then(() => clickXpath('//a[@data-control="edit"]'))
     .then(() => driver.getCurrentUrl())
     .then( function (url) {
         var expectedUrl = '/#editor';
@@ -117,10 +115,8 @@ test('clicking See Inside should take you to the editor', t => {
 });
 
 test('clicking a project title should take you to the project page', t => {
-    findByXpath('//a[@class="mystuff-icon"]')
-    .then((element) => element.click())
-    .then(() => findByXpath('//a[@data-control="edit"]'))
-    .then((element) => element.click())
+    clickXpath('//a[@class="mystuff-icon"]')
+    .then(() => clickXpath('//a[@data-control="edit"]'))
     .then(() => driver.getCurrentUrl())
     .then( function (url) {
         var expectedUrlRegExp = new RegExp('/projects/.*[0-9].*/?');
@@ -130,18 +126,16 @@ test('clicking a project title should take you to the project page', t => {
 });
 
 test('Add To button should bring up a list of studios', t => {
-    findByXpath('//a[@class="mystuff-icon"]')
-    .then((element) => element.click())
-    .then(() => findByXpath('//a[@data-control="edit"]'))
+    clickXpath('//a[@class="mystuff-icon"]')
+    .then(() => findByXpath('//div[@data-control="add-to"]'))
     .then((element) => element.getText('span'))
-    .then((text) => t.equal(text, 'Add to', 'there should be a "Add to" button'))
-    .then(() => findByXpath('//a[@data-control="edit"]'))
-    //there should be stuff in the dropdown, there should be a dropdown
-    .then((element) => element.click())
-    .then(() => driver.getCurrentUrl())
-    .then( function (url) {
-        var expectedUrl = '/#editor';
-        t.equal(url.substr(-expectedUrl.length), expectedUrl, 'after clicking, the URL should end in #editor');
+    .then((text) => t.equal(text, 'Add to', 'there should be an "Add to" button'))
+    .then(() => clickXpath('//div[@data-control="add-to"]'))
+    .then(() => findByXpath('//div[@class="dropdown-menu"]/ul/li'))
+    .then((element) => element.getText('span'))
+    .then( function (text) {
+        var expectedRegExp = new RegExp('.+');
+        t.match(text, expectedRegExp, 'the dropdown menu should have at least 1 text item in it');
     })
     .then(() => t.end());
 });

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -38,7 +38,7 @@ const clickButton = (text) => {
     return clickXpath(`//button[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 var url = rootUrl + '/users/anyuser';
 
 tap.plan(5);

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -1,0 +1,121 @@
+/*
+ * Tests signing in & My Stuff according to smoke-tests at:
+ *
+ * https://github.com/LLK/scratchr2/wiki/Smoke-Testing-Test-Cases
+ *
+ */
+
+var path = require('path');
+var fs = require('fs');
+
+var dirPath = path.resolve(__dirname, '../not-tracked/');
+var filePath = dirPath + '/credentials.js';
+var credentials = fs.readFileSync(filePath,'utf8');
+
+var window = {};
+var credentials = eval(credentials);
+
+var tap = require('tap');
+const test = tap.test;
+const webdriver = require('selenium-webdriver');
+const By = webdriver.By;
+const until = webdriver.until;
+
+const driver = new webdriver.Builder()
+    .forBrowser('chrome')
+    .build();
+
+/*
+const clickScriptsTab = () => driver.findElement(By.id('react-tabs-0')).click();
+const clickCostumeTab = () => driver.findElement(By.id('react-tabs-2')).click();
+const clickSoundsTab = () => driver.findElement(By.id('react-tabs-4')).click();
+*/
+
+const findByXpath = (xpath) => {
+    return driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
+};
+
+const findByCss = (css) => {
+    return driver.wait(until.elementLocated(By.css(css), 1000 * 5));
+};
+
+const findByText = (text) => {
+    return findByXpath(`//*[contains(text(), '${text}')]`);
+};
+
+const clickXpath = (xpath) => {
+    return findByXpath(xpath).then(el => el.click());
+};
+
+const clickText = (text) => {
+    return clickXpath(`//*[contains(text(), '${text}')]`);
+};
+
+const clickButton = (text) => {
+    return clickXpath(`//button[contains(text(), '${text}')]`);
+};
+
+var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu/users/anyuser/';
+
+tap.plan(1);
+
+tap.tearDown(function () {
+    //quit the instance of the browser
+    driver.quit();
+});
+
+tap.beforeEach(function () {
+    //load the page with the driver
+    return driver.get(rootUrl);
+});
+
+test('Sign in to Scratch & verify My Stuff contents', t => {
+    clickText('Sign in')
+    .then(() => findByXpath('//input[@id="login_dropdown_username"]'))
+    .then((element) => element.sendKeys(username))
+    .then(() => findByXpath('//input[@name="password"]'))
+    .then((element) => element.sendKeys(password))
+    .then(() => clickButton('Sign in'))
+    .then(() => findByXpath('//a[@class="mystuff-icon"]'))
+    .then((element) => element.click())
+    .then(() => findByXpath('//div[@class="box-head"]/h2'))
+    .then( function (element) {
+        return element.getText('h2');
+    })
+    .then( function (text) {
+        t.equal('My Stuff', text, 'Title should be My Stuff');
+    })
+    /*
+    //.then(() => clickText('Create'))
+    .then( function () {
+    	return clickText(username);
+    })
+    .then( function (element) {
+        console.log(element);
+    })
+    .then(() => clickCostumeTab())
+    .then(() => clickText('Add Costume'))
+    .then(() => findByXpath("//input[@placeholder='what are you looking for?']"))
+    .then((el) => el.sendKeys('abb'))
+    .then(() => clickText('abby-a')) // Should close the modal, then click the costumes in the selector
+    .then(() => clickText('costume1'))
+    .then(() => clickText('abby-a'))
+
+    .then(() => clickSoundsTab())
+    .then(() => clickText('Add Sound'))
+    .then(() => findByXpath("//input[@id='login_dropdown_username']"))
+    .then((el) => el.sendKeys('chom'))
+    .then(() => clickText('chomp')) // Should close the modal, then click the sounds in the selector
+    .then(() => clickText('meow'))
+    .then(() => clickText('chomp'))
+
+    .then(() => clickScriptsTab())
+    .then(() => clickText('Data'))
+    .then(() => clickText('Create variable...'))
+    .then(() => findByXpath("//input[@placeholder='']"))
+    .then((el) => el.sendKeys('score'))
+    .then(() => clickButton('OK'))
+    */
+
+    .then(() => t.end());
+});

--- a/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
+++ b/test/integration/smoke-testing/test_signing_in_and_my_stuff.js
@@ -117,12 +117,32 @@ test('clicking See Inside should take you to the editor', t => {
 });
 
 test('clicking a project title should take you to the project page', t => {
-    t.pass();
-    t.end();
+    findByXpath('//a[@class="mystuff-icon"]')
+    .then((element) => element.click())
+    .then(() => findByXpath('//a[@data-control="edit"]'))
+    .then((element) => element.click())
+    .then(() => driver.getCurrentUrl())
+    .then( function (url) {
+        var expectedUrlRegExp = new RegExp('/projects/.*[0-9].*/?');
+        t.match(url, expectedUrlRegExp, 'after clicking, the URL should end in projects/PROJECT_ID/');
+    })
+    .then(() => t.end());
 });
 
 test('Add To button should bring up a list of studios', t => {
-    t.pass();
-    t.end();
+    findByXpath('//a[@class="mystuff-icon"]')
+    .then((element) => element.click())
+    .then(() => findByXpath('//a[@data-control="edit"]'))
+    .then((element) => element.getText('span'))
+    .then((text) => t.equal(text, 'Add to', 'there should be a "Add to" button'))
+    .then(() => findByXpath('//a[@data-control="edit"]'))
+    //there should be stuff in the dropdown, there should be a dropdown
+    .then((element) => element.click())
+    .then(() => driver.getCurrentUrl())
+    .then( function (url) {
+        var expectedUrl = '/#editor';
+        t.equal(url.substr(-expectedUrl.length), expectedUrl, 'after clicking, the URL should end in #editor');
+    })
+    .then(() => t.end());
 });
     

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -23,7 +23,7 @@ const clickText = (text) => {
     return clickXpath(`//*[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 
 tap.plan(1);
 

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -22,10 +22,6 @@ const findByXpath = (xpath) => {
     return driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
 };
 
-const findByCss = (css) => {
-    return driver.wait(until.elementLocated(By.css(css), 1000 * 5));
-};
-
 const clickXpath = (xpath) => {
     return findByXpath(xpath).then(el => el.click());
 };
@@ -34,11 +30,7 @@ const clickText = (text) => {
     return clickXpath(`//*[contains(text(), '${text}')]`);
 };
 
-const clickButton = (text) => {
-    return clickXpath(`//button[contains(text(), '${text}')]`);
-};
-
-var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 
 tap.plan(1);
 

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -1,0 +1,66 @@
+var path = require('path');
+var fs = require('fs');
+
+var dirPath = path.resolve(__dirname, '../not-tracked/');
+var filePath = dirPath + '/credentials.js';
+var credentials = fs.readFileSync(filePath,'utf8');
+
+var window = {};
+var credentials = eval(credentials);
+
+var tap = require('tap');
+const test = tap.test;
+const webdriver = require('selenium-webdriver');
+const By = webdriver.By;
+const until = webdriver.until;
+
+const driver = new webdriver.Builder()
+    .forBrowser('chrome')
+    .build();
+
+const findByXpath = (xpath) => {
+    return driver.wait(until.elementLocated(By.xpath(xpath), 5 * 1000));
+};
+
+const findByCss = (css) => {
+    return driver.wait(until.elementLocated(By.css(css), 1000 * 5));
+};
+
+const clickXpath = (xpath) => {
+    return findByXpath(xpath).then(el => el.click());
+};
+
+const clickText = (text) => {
+    return clickXpath(`//*[contains(text(), '${text}')]`);
+};
+
+const clickButton = (text) => {
+    return clickXpath(`//button[contains(text(), '${text}')]`);
+};
+
+var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu/users/anyuser';
+
+tap.plan(5);
+
+tap.tearDown(function () {
+    driver.quit();
+});
+
+tap.beforeEach(function () {
+    return driver.get(rootUrl);
+});
+
+test('Sign in to Scratch using scratch-www navbar', t => {
+    clickText('Sign in')
+    .then(() => findByXpath('//input[@id="login_dropdown_username"]'))
+    .then((element) => element.sendKeys(username))
+    .then(() => findByXpath('//input[@name="password"]'))
+    .then((element) => element.sendKeys(password))
+    .then(() => clickButton('Sign in'))
+    .then(() => findByXpath('//li[contains(@class, "logged-in-user")'
+        + 'and contains(@class, "dropdown")]/span'))
+    .then((element) => element.getText('span'))
+    .then((text) => t.match(text.toLowerCase(), username.substring(0,10).toLowerCase(),
+            'first part of username should be displayed in navbar'))
+    .then(() => t.end());
+});

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -38,9 +38,9 @@ const clickButton = (text) => {
     return clickXpath(`//button[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu/users/anyuser';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
 
-tap.plan(5);
+tap.plan(1);
 
 tap.tearDown(function () {
     driver.quit();
@@ -52,14 +52,14 @@ tap.beforeEach(function () {
 
 test('Sign in to Scratch using scratch-www navbar', t => {
     clickText('Sign in')
-    .then(() => findByXpath('//input[@id="login_dropdown_username"]'))
+    .then(() => findByXpath('//input[@id="frc-username-1088"]'))
     .then((element) => element.sendKeys(username))
-    .then(() => findByXpath('//input[@name="password"]'))
+    .then(() => findByXpath('//input[@id="frc-password-1088"]'))
     .then((element) => element.sendKeys(password))
-    .then(() => clickButton('Sign in'))
-    .then(() => findByXpath('//li[contains(@class, "logged-in-user")'
-        + 'and contains(@class, "dropdown")]/span'))
-    .then((element) => element.getText('span'))
+    .then(() => clickXpath('//button[contains(@class, "button") and '
+        + 'contains(@class, "submit-button") and contains(@class, "white")]'))
+    .then(() => findByXpath('//span[@class="profile-name"]'))
+    .then((element) => element.getText())
     .then((text) => t.match(text.toLowerCase(), username.substring(0,10).toLowerCase(),
             'first part of username should be displayed in navbar'))
     .then(() => t.end());

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -1,5 +1,5 @@
-var username = process.env.USERNAME;
-var password = process.env.PASSWORD;
+var username = process.env.SMOKE_USERNAME;
+var password = process.env.SMOKE_PASSWORD;
 
 var tap = require('tap');
 const test = tap.test;

--- a/test/integration/smoke-testing/test_signing_in_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_homepage.js
@@ -1,12 +1,5 @@
-var path = require('path');
-var fs = require('fs');
-
-var dirPath = path.resolve(__dirname, '../not-tracked/');
-var filePath = dirPath + '/credentials.js';
-var credentials = fs.readFileSync(filePath,'utf8');
-
-var window = {};
-var credentials = eval(credentials);
+var username = process.env.USERNAME;
+var password = process.env.PASSWORD;
 
 var tap = require('tap');
 const test = tap.test;
@@ -30,7 +23,7 @@ const clickText = (text) => {
     return clickXpath(`//*[contains(text(), '${text}')]`);
 };
 
-var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
+var rootUrl = process.env.ROOT_URL || 'https://scratch.mit.edu';
 
 tap.plan(1);
 


### PR DESCRIPTION
It works! Fixes https://github.com/LLK/scratch-www/issues/1385. But.

Things I'm not sure about:
1. passing in the credentials from another file
2. assuming existence of projects, studios, and shared projects
  a. To address this we could make a test user solely for this on Staging & Production, but then where to put the credentials? Last pass and everyone makes their own un-checked-in credentials file?
3. using eval & window
4. we should refactor the helper functions rather than including them in multiple files; I could do that as a separate pr since it involves changing other tests as well as these? or I could do that here?
5. organizing it into two files, (a) my stuff + signing in on scratchr2 and (b) signing in on scratch-www. I did it that way b/c I have to sign in to get to My Stuff anyway, and My Stuff is in scratchr2, so I figured testing the sign in there made sense. But on the other hand, maybe it should be it's own file and get run before the My Stuff test? Would that involve passing the driver from one tap test file to another in order to not re-set the starting point of the browser...?