### PR TITLE
remove obsolete strings

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -13,7 +13,6 @@
     "general.country": "Country",
     "general.create": "Create",
     "general.credits": "Credits",
-    "general.discuss": "Discuss",
     "general.dmca": "DMCA",
     "general.emailAddress": "Email Address",
     "general.error": "Oops! Something went wrong",
@@ -26,7 +25,6 @@
     "general.getStarted": "Get Started",
     "general.gender": "Gender",
     "general.guidelines": "Community Guidelines",
-    "general.help": "Help",
     "general.jobs": "Jobs",
     "general.joinScratch": "Join Scratch",
     "general.legal": "Legal",
@@ -90,9 +88,7 @@
 
     "general.teacherAccounts": "Teacher Accounts",
 
-
     "footer.discuss": "Discussion Forums",
-    "footer.help": "Help Page",
     "footer.scratchFamily": "Scratch Family",
 
     "form.validationRequired": "This field is required",


### PR DESCRIPTION
‘Help’ and ‘Discuss’ are not needed now that they’ve been replaced with the Tips page.

Fixes #1362