### PR TITLE
key api calls on `username` check

### DIFF
--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -36,7 +36,7 @@ var Splash = injectIntl(React.createClass({
     },
     componentDidUpdate: function (prevProps) {
         if (this.props.user != prevProps.user) {
-            if (this.props.user) {
+            if (this.props.user.username) {
                 this.getActivity(this.props.user.username);
                 this.getSharedByFollowing(this.props.user.token);
                 this.getInStudiosFollowing(this.props.user.token);
@@ -59,7 +59,7 @@ var Splash = injectIntl(React.createClass({
     },
     componentDidMount: function () {
         this.getFeaturedGlobal();
-        if (this.props.user) {
+        if (this.props.user.username) {
             this.getActivity(this.props.user.username);
             this.getSharedByFollowing(this.props.user.token);
             this.getInStudiosFollowing(this.props.user.token);


### PR DESCRIPTION
`this.props.user` will now return `true` because there is a default user object that’s empty. So, instead, wait for an actual user object. This is fallout from #1416 