### PR TITLE
Fix gh-1438: Update Community Guidelines

### DIFF
--- a/src/views/guidelines/l10n.json
+++ b/src/views/guidelines/l10n.json
@@ -13,5 +13,5 @@
   "guidelines.honestybody": "Don’t try to impersonate other Scratchers, spread rumors, or otherwise try to trick the community.",
   "guidelines.friendlyheader": "Help keep the site friendly.",
   "guidelines.friendlybody": "If you think a project or comment is mean, insulting, too violent, or otherwise inappropriate, click “Report” to let us know about it.",
-  "guidelines.footer": "Scratch welcomes people of all ages, races, ethnicities, religions, sexual orientations, and gender identities."
+  "guidelines.footer": "Scratch welcomes people of all ages, races, ethnicities, religions, abilities, sexual orientations, and gender identities."
 }


### PR DESCRIPTION
Resolves #1438 

## Test cases:
The text at the bottom of the page should now read `Scratch welcomes people of all ages, races, ethnicities, religions, abilities, sexual orientations, and gender identities.` instead of `Scratch welcomes people of all ages, races, ethnicities, religions, sexual orientations, and gender identities.`