### PR TITLE
Fix gh-1442: Remove Moderator Position

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -31,14 +31,6 @@ var Jobs = React.createClass({
                         <h3><FormattedMessage id='jobs.openings' /></h3>
                         <ul>
                             <li>
-                                <a href="/jobs/moderator">
-                                    Community Moderator
-                                </a>
-                                <span>
-                                    MIT Media Lab, Cambridge, MA (or Remote)
-                                </span>
-                            </li>
-                            <li>
                                 <a href="https://www.media.mit.edu/about/job-opportunities/junior-web-designer-scratch/">
                                     Junior Designer
                                 </a>


### PR DESCRIPTION
Fixes #1442 by removing the Moderator Position from the Jobs page.

/cc @chrisgarrity @mewtaylor @rschamp @thisandagain 