### PR TITLE
Fix gh-1479: Re-Add Community Moderator

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -31,6 +31,14 @@ var Jobs = React.createClass({
                         <h3><FormattedMessage id='jobs.openings' /></h3>
                         <ul>
                             <li>
+                                <a href="/jobs/moderator">
+                                    Community Moderator (Remote)
+                                </a>
+                                <span>
+                                    MIT Media Lab, Cambridge, MA (or Remote)
+                                </span>
+                            </li>
+                            <li>
                                 <a href="https://www.media.mit.edu/about/job-opportunities/junior-web-designer-scratch/">
                                     Junior Designer
                                 </a>


### PR DESCRIPTION
Resolves #1479 

Test cases:
- Community Moderator position should be visible again on the jobs page
- Link for the job should lead to https://scratch.mit.edu/jobs/moderator

@thisandagain 