### PR TITLE
Fix gh-1488: Add Tracy Tang to Credits Page

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -103,6 +103,11 @@ var Credits = React.createClass({
                     </li>
                     
                     <li>
+                        <img src="//cdn.scratch.mit.edu/get_image/user/18417774_170x170.png" alt="Tracy Avatar" />
+                        <span className="name">Tracy Tang</span>
+                    </li>
+                    
+                    <li>
                         <img src="//cdn.scratch.mit.edu/get_image/user/4373707_170x170.png" alt="Matthew Avatar" />
                         <span className="name">Matthew Taylor</span>
                     </li>


### PR DESCRIPTION
Resolves #1488 

## Test cases:
- 'Tracy Tang' should now be added under the list of current ST members
- the avatar for Tracy should be https://cdn.scratch.mit.edu/get_image/user/18417774_170x170.png