### PR TITLE
Fix GH-1494: fix formatting for dismiss icon, unread message count

### DIFF
--- a/src/redux/messages.js
+++ b/src/redux/messages.js
@@ -3,6 +3,7 @@ var keyMirror = require('keymirror');
 
 var api = require('../lib/api');
 var log = require('../lib/log');
+var messageCountActions = require('./message-count.js');
 
 module.exports.Status = keyMirror({
     FETCHED: null,
@@ -135,7 +136,7 @@ module.exports.clearMessageCount = function () {
     };
 };
 
-module.exports.clearAdminMessage = function (messageType, messageId, adminMessages) {
+module.exports.clearAdminMessage = function (messageType, messageId, messageCount, adminMessages) {
     return function (dispatch) {
         dispatch(module.exports.setStatus('CLEAR_STATUS', module.exports.Status.FETCHING));
         api({
@@ -156,6 +157,7 @@ module.exports.clearAdminMessage = function (messageType, messageId, adminMessag
             if (!body.success) {
                 dispatch(module.exports.setStatus('DELETE_STATUS', module.exports.Status.DELETE_ERROR));
                 dispatch(module.exports.setMessagesError('messages not cleared'));
+                return;
             }
 
             if (messageType === 'invite') {
@@ -173,6 +175,7 @@ module.exports.clearAdminMessage = function (messageType, messageId, adminMessag
                 adminMessages.splice(toRemove, 1);
                 dispatch(module.exports.setAdminMessages(adminMessages));
             }
+            dispatch(messageCountActions.setCount(messageCount - 1));
             dispatch(module.exports.setStatus('DELETE_STATUS', module.exports.Status.FETCHED));
         });
     };

--- a/src/views/messages/container.jsx
+++ b/src/views/messages/container.jsx
@@ -95,7 +95,9 @@ var Messages = React.createClass({
             adminMessages = this.props.adminMessages;
         }
         this.props.dispatch(
-            messageActions.clearAdminMessage(messageType, messageId, adminMessages)
+            messageActions.clearAdminMessage(
+                messageType, messageId, this.props.numNewMessages, adminMessages
+            )
         );
     },
     handleLoadMoreMessages: function () {

--- a/src/views/messages/message-rows/admin-message.jsx
+++ b/src/views/messages/message-rows/admin-message.jsx
@@ -21,10 +21,10 @@ var AdminMessage = React.createClass({
                     </span>
                     <Button
                         className="mod-admin-message-dismiss"
-                        onClick={this.props.onDismiss.bind(this, 'notification', this.props.id)}
+                        onClick={this.props.onDismiss}
                     >
                         <img
-                            className="mod-admin-message-icon"
+                            className="admin-message-icon"
                             src="/svgs/modal/close-x.svg"
                             alt="close-icon"
                         />

--- a/src/views/messages/message-rows/scratcher-invite.jsx
+++ b/src/views/messages/message-rows/scratcher-invite.jsx
@@ -25,11 +25,7 @@ var AdminMessage = injectIntl(React.createClass({
                     </span>
                     <Button
                         className="mod-scratcher-invite-dismiss"
-                        onClick={
-                            function () {
-                                this.props.onDismiss('invite', this.props.id);
-                            }.bind(this)
-                        }
+                        onClick={this.props.onDismiss}
                     >
                         <img
                             className="mod-scratcher-invite-icon"

--- a/src/views/messages/messages.scss
+++ b/src/views/messages/messages.scss
@@ -39,6 +39,20 @@
     list-style-type: none;
 }
 
+.messages-header {
+    display: flex;
+    align-items: center;
+}
+
+.messages-header-unread {
+    margin-left: 1rem;
+    border-radius: 1rem;
+    background-color: $ui-orange;
+    padding: .25rem .5rem;
+    line-height: 1rem;
+    color: $type-white;
+}
+
 .admin-message {
     border: 1px solid darken($ui-gray, 10);
     border-radius: 5px;
@@ -49,6 +63,10 @@
 .admin-message-header {
     justify-content: space-between;
     align-items: center;
+}
+
+.admin-message-icon {
+    vertical-align: middle;
 }
 
 .admin-message-content {
@@ -68,14 +86,6 @@
     &:hover {
         box-shadow: none;
     }
-}
-
-.messages-social-title-unread {
-    margin-left: 1rem;
-    border-radius: 1rem;
-    background-color: $ui-orange;
-    padding: .25rem .5rem;
-    color: $type-white;
 }
 
 .messages-social-list {

--- a/src/views/messages/presentation.jsx
+++ b/src/views/messages/presentation.jsx
@@ -181,11 +181,11 @@ var SocialMessagesList = React.createClass({
             <section className="messages-social">
                 {this.props.messages.length > 0 ? [
                     <div className="messages-social-title" key="messages-social-title">
-                        <h4>
+                        <h4 className="messages-header">
                             <FormattedMessage id='messages.messageTitle' />
-                            <span className="messages-social-title-unread">
+                            <div className="messages-header-unread">
                                 <FormattedNumber value={this.props.numNewMessages} />
-                            </span>
+                            </div>
                         </h4>
                     </div>,
                     <ul className="messages-social-list" key="messages-social-list">
@@ -270,11 +270,11 @@ var MessagesPresentation = injectIntl(React.createClass({
                     {this.props.adminMessages.length > 0 || Object.keys(this.props.scratcherInvite).length > 0 ? [
                         <section className="messages-admin">
                             <div className="messages-admin-title">
-                                <h4>
+                                <h4 className="messages-header">
                                     <FormattedMessage id='messages.scratchTeamTitle' />
-                                    <span className="messages-social-title-unread">
+                                    <div className="messages-header-unread">
                                         <FormattedNumber value={adminMessageLength} />
-                                    </span>
+                                    </div>
                                 </h4>
                             </div>
                             <ul className="messages-admin-list">
@@ -283,7 +283,9 @@ var MessagesPresentation = injectIntl(React.createClass({
                                         id={this.props.scratcherInvite.id}
                                         username={this.props.user.username}
                                         datetimeCreated={this.props.scratcherInvite.datetime_created}
-                                        onDismiss={this.props.handleAdminDismiss}
+                                        onDismiss={function () {
+                                            this.props.handleAdminDismiss('invite', this.props.scratcherInvite.id);
+                                        }.bind(this)}
                                     />
                                 ] : []}
                                 {this.props.adminMessages.map(function (item) {
@@ -292,11 +294,9 @@ var MessagesPresentation = injectIntl(React.createClass({
                                         id={item.id}
                                         message={item.message}
                                         datetimeCreated={item.datetime_created}
-                                        onDismiss={
-                                            function () {
-                                                this.props.handleAdminDismiss('notification', item.id);
-                                            }.bind(this)
-                                        }
+                                        onDismiss={function () {
+                                            this.props.handleAdminDismiss('notification', item.id);
+                                        }.bind(this)}
                                     />;
                                 }.bind(this))}
                             </ul>


### PR DESCRIPTION
This also fixes a bug in which the unread message count remains the same after dismissing an admin message successfully (by reducing the count, not by making another request, in order to reduce back-and-forth with the servers)