### PR TITLE
Pass to legacy on message routes with `ajax`

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -144,7 +144,7 @@
     {
         "name": "messages",
         "pattern": "^/messages/?$",
-        "routeAlias": "/messages",
+        "routeAlias": "/messages(?!/ajax)",
         "view": "messages/container",
         "title": "Messages"
     },


### PR DESCRIPTION
Currenlty, some legacy endpoints are failing because they’re being directed to www. A similar thing happened with `/explore`, and this is the same fix