### PR TITLE
Fix GH-1501: handle logout on messages page

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -138,7 +138,7 @@ var Navigation = React.createClass({
         }, function (err) {
             if (err) log.error(err);
             this.closeLogin();
-            this.props.dispatch(sessionActions.refreshSession());
+            window.location = '/';
         }.bind(this));
     },
     handleAccountNavClick: function (e) {

--- a/src/views/messages/container.jsx
+++ b/src/views/messages/container.jsx
@@ -44,6 +44,12 @@ var Messages = React.createClass({
                 this.props.dispatch(
                     messageActions.getScratcherInvite(this.props.user.username, this.props.user.token)
                 );
+            } else {
+                // user is logged out, empty messages
+                this.props.dispatch(messageActions.setMessages([]));
+                this.props.dispatch(messageActions.setAdminMessages([]));
+                this.props.dispatch(messageActions.setScratcherInvite({}));
+                this.props.dispatch(messageActions.setMessagesOffset(0));
             }
         }
     },


### PR DESCRIPTION
Go back to redirecting to splash on logout, and empty messages page too.