### PR TITLE
Fix GH-[1505, 1507]: hide message counter on 0

### DIFF
--- a/src/redux/messages.js
+++ b/src/redux/messages.js
@@ -130,7 +130,7 @@ module.exports.clearMessageCount = function () {
                 dispatch(module.exports.setMessagesError(err));
                 return;
             }
-            if (!body.success) {
+            if (typeof body !== 'undefined' && !body.success) {
                 dispatch(module.exports.setStatus('CLEAR_STATUS', module.exports.Status.CLEAR_ERROR));
                 dispatch(module.exports.setMessagesError('messages not cleared'));
                 return;

--- a/src/views/messages/presentation.jsx
+++ b/src/views/messages/presentation.jsx
@@ -163,6 +163,14 @@ var SocialMessagesList = React.createClass({
         }
         return null;
     },
+    renderMessageCounter: function (numNewMessages) {
+        if (numNewMessages > 0) {
+            return <div className="messages-header-unread">
+                <FormattedNumber value={numNewMessages} />
+            </div>;
+        }
+        return null;
+    },
     render: function () {
         if (this.props.loadStatus === messageStatuses.MESSAGES_ERROR) {
             return (
@@ -183,9 +191,7 @@ var SocialMessagesList = React.createClass({
                     <div className="messages-social-title" key="messages-social-title">
                         <h4 className="messages-header">
                             <FormattedMessage id='messages.messageTitle' />
-                            <div className="messages-header-unread">
-                                <FormattedNumber value={this.props.numNewMessages} />
-                            </div>
+                            {this.renderMessageCounter(this.props.numNewMessages)}
                         </h4>
                     </div>,
                     <ul className="messages-social-list" key="messages-social-list">


### PR DESCRIPTION
This hides the messages counter if there are no unread messages. It also checks for `body` to exist on a clear messages api request before looking for `success` to prevent an extraneous console error.

Fixes #1507 and #1505 