### PR TITLE
Changed 'Animate a Name' educator guide link

### DIFF
--- a/src/views/tips/l10n-static.json
+++ b/src/views/tips/l10n-static.json
@@ -13,7 +13,7 @@
     "cards.pongCardsLink": "https://resources.scratch.mit.edu/www/cards/en/pongCards.pdf",
     "cards.raceCardsLink": "https://resources.scratch.mit.edu/www/cards/en/raceCards.pdf",
     "cards.storyCardsLink": "https://resources.scratch.mit.edu/www/cards/en/storyCards.pdf",
-    "guides.AnimateYourNameGuideLink": "https://resources.scratch.mit.edu/www/guides/en/AnimateYourNameGuide.pdf",
+    "guides.AnimateYourNameGuideLink": "https://resources.scratch.mit.edu/www/guides/en/NameGuide.pdf",
     "guides.CatchGuideLink": "https://resources.scratch.mit.edu/www/guides/en/CatchGuide.pdf",
     "guides.DanceGuideLink": "https://resources.scratch.mit.edu/www/guides/en/DanceGuide.pdf",
     "guides.FashionGuideLink": "https://resources.scratch.mit.edu/www/guides/en/FashionGuide.pdf",


### PR DESCRIPTION
Resolved GH-1509

- Updated the 'Animate a Name' educator guide link as per instructions in #1509 