### PR TITLE
Fix CSS class of forum post message row

### DIFF
--- a/src/views/messages/message-rows/forum-topic-post.jsx
+++ b/src/views/messages/message-rows/forum-topic-post.jsx
@@ -16,7 +16,7 @@ var ForumPostMessage = React.createClass({
         var topicLink = '/discuss/topic/' + this.props.topicId + '/unread/';
 
         var classes = classNames(
-            'mod-studio-activity',
+            'mod-forum-activity',
             this.props.className
         );
         return (


### PR DESCRIPTION
Fixes #1526.

Changes the CSS class `.mod-studio-activity` to `.mod-forum-activity` in the forum post message row. (I picked the class name because it's consistent with the `.mod-studio-activity` class; the SVG icon is also named `forum-activity.svg`.)