### PR TITLE
[Master] Hotfix: highlight unread message row in light blue

### DIFF
--- a/src/components/social-message/social-message.scss
+++ b/src/components/social-message/social-message.scss
@@ -12,6 +12,10 @@
     opacity: .25;
 }
 
+.social-message.mod-unread {
+    background-color: lighten($ui-blue, 40);
+}
+
 .social-message.mod-unread .social-message-icon {
     opacity: 1;
 }


### PR DESCRIPTION
This addresses issues with seeing unread notifications by highlighting them as light blue, along with more opaque icons. 

Here's an example of what it looks like:
<img width="887" alt="screen shot 2017-09-11 at 9 53 17 am" src="https://user-images.githubusercontent.com/1815772/30278364-2e9bd648-96d8-11e7-87e0-48c7687a4f39.png">

