### PR TITLE
Fix GH-1540: Direct studio activity link to the activity tab

### DIFF
--- a/src/views/messages/message-rows/studio-activity.jsx
+++ b/src/views/messages/message-rows/studio-activity.jsx
@@ -12,7 +12,7 @@ var StudioActivityMessage = React.createClass({
         datetimeCreated: React.PropTypes.string.isRequired
     },
     render: function () {
-        var studioLink = '/studios/' + this.props.studioId;
+        var studioLink = '/studios/' + this.props.studioId + '/activity';
 
         var classes = classNames(
             'mod-studio-activity',


### PR DESCRIPTION
Fixes #1540 by ensuring that the anchor link for studio activity is directed to the activity tab of the studio. Thanks @towerofnix for bringing this over to github from the suggestions forum!