### PR TITLE
GH-1455: apply path explicitly rather than in `defaults`

### DIFF
--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -72,9 +72,9 @@ var Jar = {
     },
     set: function (name, value, opts) {
         defaults(opts, {
-            expires: new Date(new Date().setYear(new Date().getFullYear() + 1)),
-            path: '/'
+            expires: new Date(new Date().setYear(new Date().getFullYear() + 1))
         });
+        opts.path = '/';
         var obj = cookie.serialize(name, value, opts);
         document.cookie = obj;
     },

--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -71,6 +71,7 @@ var Jar = {
         });
     },
     set: function (name, value, opts) {
+        opts = opts || {};
         defaults(opts, {
             expires: new Date(new Date().setYear(new Date().getFullYear() + 1))
         });


### PR DESCRIPTION
This should fix #1455 by preventing the path from being changes via opts passed in, even though we don’t pass in a `path` anywhere.