### PR TITLE
Fixing some grammar mistakes in markdown files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ Here are some ways you can contribute:
 * [Work on bugs and make pull requests](https://github.com/LLK/scratch-www/wiki/Workflow-for-Repo-Contributions)
   * Make sure to check out how to [assign yourself bugs](https://github.com/LLK/scratch-www/wiki/Assigning-Yourself-Bugs) too.
 
-We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here, and looking to jump into our wonderful community, we have some resources for you to take a look at:
+We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here and looking to jump into our wonderful community, we have some resources for you to take a look at:
 
 * [README](https://github.com/LLK/scratch-www/blob/develop/README.md) (if you’re to read only one me in this repo, make it this one – it has all of the necessary information for getting a local Scratch UI running on your machine!)
 * [Community Guidelines](https://github.com/LLK/scratch-www/wiki/Community-Guidelines) (we find it important to maintain a constructive and welcoming community, just like on Scratch)
 * [Issues](https://github.com/LLK/scratch-www/issues) – where we keep track of all the things that need fixin’ on the website
-Road map
+Roadmap
 
 Beyond this repo, there are also some other resources that you might want to take a look at:
 [Scratch](https://scratch.mit.edu/) (the thing we work on)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Here are some ways you can contribute:
 * [Work on bugs and make pull requests](https://github.com/LLK/scratch-www/wiki/Workflow-for-Repo-Contributions)
   * Make sure to check out how to [assign yourself bugs](https://github.com/LLK/scratch-www/wiki/Assigning-Yourself-Bugs) too.
 
-We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here and looking to jump into our wonderful community, we have some resources for you to take a look at:
+We are always excited to have people join us in working to make Scratch a wonderful place for people of all ages to make projects together. If you’re new here, and looking to jump into our wonderful community, we have some resources for you to take a look at:
 
 * [README](https://github.com/LLK/scratch-www/blob/develop/README.md) (if you’re to read only one me in this repo, make it this one – it has all of the necessary information for getting a local Scratch UI running on your machine!)
 * [Community Guidelines](https://github.com/LLK/scratch-www/wiki/Community-Guidelines) (we find it important to maintain a constructive and welcoming community, just like on Scratch)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These currently exist in static/js/lib
 npm start
 ```
 
-During development, `npm start` watches any update you make to files in either `./static` or `./src` and triggers a rebuild of the project.  In development the build is stored in memory, and not served from the `./build` directory.
+During development, `npm start` watches any update you make to files in either `./static` or `./src` and triggers a rebuild of the project.  In development, the build is stored in memory, and not served from the `./build` directory.
 
 When running `npm start`, here are some important log messages to keep an eye out for:
 * `webpack: bundle is now VALID.` – the bundle has been loaded into memory and is now viewable in the browser. This will show up both once `npm start` has completed its setup, and also once updates you make to files have been re-compiled for viewing in the browser.
@@ -105,7 +105,7 @@ We're currently in the process of transitioning into this web client from Scratc
 #### FALLBACK
 On top of migrating to using this as our web client, Scratch is also transitioning into using a new API backend, Scratch REST API. As that is also currently in development and incomplete, we are set up to fall back to using existing Scratch endpoints if an API endpoint does not exist – which is where the `FALLBACK` comes in.
 
-Most of the issues we have currently revolve around the use of `FALLBACK`. This variable is used to specify what url to fall back onto should a request fail within the context of this webclient, or when using the `API_HOST`. If not specified in the process, it will not be used, and any request that is not made through the web client or the API will be unreachable.
+Most of the issues we have currently revolve around the use of `FALLBACK`. This variable is used to specify what URL to fall back onto should a request fail within the context of this web client, or when using the `API_HOST`. If not specified in the process, it will not be used, and any request that is not made through the web client or the API will be unreachable.
 
 Setting `FALLBACK=https://scratch.mit.edu` allows the web client to retrieve data from the Scratch website in your development environment. However, because of security concerns, trying to send data to Scratch through your development environment won't work. This means the following things will be broken for the time being:
 * Login on the splash page (*In the process of being fixed*)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm start
 During development, `npm start` watches any update you make to files in either `./static` or `./src` and triggers a rebuild of the project.  In development, the build is stored in memory, and not served from the `./build` directory.
 
 When running `npm start`, here are some important log messages to keep an eye out for:
-* `webpack: bundle is now VALID.` – the bundle has been loaded into memory and is now viewable in the browser. This will show up both once `npm start` has completed its setup, and also once updates you make to files have been re-compiled for viewing in the browser.
+* `webpack: bundle is now VALID.` – The bundle has been loaded into memory and is now viewable in the browser. This will show up both once `npm start` has completed its setup, and also once updates you make to files have been re-compiled for viewing in the browser.
 * `webpack: bundle is now INVALID.` – if you see this, then it means you have made updates to files that are still being compiled for browser viewing. Pages will still be viewable, but they will not see any updates you made yet.
 
 Once running, open `http://localhost:8333` in your browser. If you wish to have the server reload automatically, you can install either [nodemon](https://github.com/remy/nodemon) or [forever](https://github.com/foreverjs/forever).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ During development, `npm start` watches any update you make to files in either `
 
 When running `npm start`, here are some important log messages to keep an eye out for:
 * `webpack: bundle is now VALID.` – The bundle has been loaded into memory and is now viewable in the browser. This will show up both once `npm start` has completed its setup, and also once updates you make to files have been re-compiled for viewing in the browser.
-* `webpack: bundle is now INVALID.` – if you see this, then it means you have made updates to files that are still being compiled for browser viewing. Pages will still be viewable, but they will not see any updates you made yet.
+* `webpack: bundle is now INVALID.` – If you see this, then it means you have made updates to files that are still being compiled for browser viewing. Pages will still be viewable, but they will not see any updates you made yet.
 
 Once running, open `http://localhost:8333` in your browser. If you wish to have the server reload automatically, you can install either [nodemon](https://github.com/remy/nodemon) or [forever](https://github.com/foreverjs/forever).
 


### PR DESCRIPTION
After examining the "CONTRIBUTING" & "README" files, I found several grammar mistakes in them. 

## Things Fixed
- Fixed "road map" (It should all be one word)
- Adding necessary comma
- Capitalizing "url"
- Fixing "webclient" (Separate words) 
- Capitalizing another word

## Benefits of these fixes
- Makes the files simpler to read 
- Some sentences make more sense