### PR TITLE
Fix typos in Terms of Service and Messages l10n

### DIFF
--- a/src/views/messages/l10n.json
+++ b/src/views/messages/l10n.json
@@ -26,5 +26,5 @@
     "messages.studioCommentReply": "{profileLink} replied to your comment in {commentLink}",
     "messages.userJoinText": "Welcome to Scratch! After you make projects and comments, you'll get messages about them here. Go {exploreLink} or {makeProjectLink}.",
     "messages.userJoinMakeProject": "make a project",
-    "messages.requestError": "oops! Looks like there was a problem getting some of your messages. Please try to reload this page"
+    "messages.requestError": "Oops! Looks like there was a problem getting some of your messages. Please try to reload this page."
 }

--- a/src/views/terms/terms.jsx
+++ b/src/views/terms/terms.jsx
@@ -274,7 +274,7 @@ var Terms = React.createClass({
                             5.4 The Scratch name, Scratch logo, Scratch Day logo, Scratch Cat, and Gobo
                              are Trademarks owned by the Scratch Team. The MIT name and logo are Trademarks
                              owned by the Massachusetts Institute of Technology. Unless you are licensed by
-                             Scratch under a specific licensing program or agreement, you many not use
+                             Scratch under a specific licensing program or agreement, you may not use
                              these logos to label, promote, or endorse any product or service. You may use
                              the Scratch Logo to refer to the Scratch website and programming language.
                         </p>


### PR DESCRIPTION
Typos fixed:
Resolves #1595 - "many not" -> "may not" in Terms of Service
Resolves #1593 - "oops!... this page" -> "Oops!... this page." in `/src/messages/l10n.json`