### PR TITLE
Fix GH-1568: hide overflow on comment component

### DIFF
--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -33,6 +33,7 @@
 
 .emoji-text.mod-comment {
     margin: 0;
+    overflow: hidden;
 }
 
 .comment-text-timestamp {


### PR DESCRIPTION
fixes #1568 by imposing a hidden state on overflow text.

### Test Cases ###
* Post a comment that uses "zalgo text" to someone's profile. Then, log in as that user, and look at their messages. The "zalgo text" should not overflow beyond the comment bubble