### PR TITLE
Updated selenium & chromedriver versions, which fixed test failures i…

### DIFF
--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,6 +1,6 @@
 {
     "testDependencies": {
-        "selenium-webdriver": "2.44.0",
-        "chromedriver": "2.27.0"
+        "selenium-webdriver": "2.45.0",
+        "chromedriver": "2.33.0"
     }
 }

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,5 +1,5 @@
 {
-    "testDependencies": {
+    "devDependencies": {
         "selenium-webdriver": "2.45.0",
         "chromedriver": "2.33.0"
     }

--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -4,16 +4,15 @@
  * Test cases: https://github.com/LLK/scratch-www/wiki/Most-Important-Workflows
  */
  
-require('chromedriver');
 var tap = require('tap');
-var seleniumWebdriver = require('selenium-webdriver');
-
-// Selenium's promise driver will be deprecated, so we should not rely on it
-seleniumWebdriver.SELENIUM_PROMISE_MANAGER=0;
 
 const {
-    driver
+    driver,
+    webdriver
 } = require('../../helpers/selenium-helpers.js');
+
+// Selenium's promise driver will be deprecated, so we should not rely on it
+webdriver.SELENIUM_PROMISE_MANAGER=0;
 
 var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 
@@ -36,9 +35,9 @@ tap.beforeEach(function () {
 // Function clicks the link and returns the url of the resulting page
 
 function clickFooterLinks (linkText) {
-    return driver.wait(seleniumWebdriver.until.elementLocated(seleniumWebdriver.By.id('footer')))
+    return driver.wait(webdriver.until.elementLocated(webdriver.By.id('footer')))
     .then( function (element) {
-        return element.findElement(seleniumWebdriver.By.linkText(linkText)); })
+        return element.findElement(webdriver.By.linkText(linkText)); })
     .then( function (element) {
         return element.click(); })
     .then(function () {

--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -11,13 +11,14 @@ var seleniumWebdriver = require('selenium-webdriver');
 // Selenium's promise driver will be deprecated, so we should not rely on it
 seleniumWebdriver.SELENIUM_PROMISE_MANAGER=0;
 
-//chrome driver
-var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome()).build();
+const {
+    driver
+} = require('../../helpers/selenium-helpers.js');
 
 var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 
 //timeout for each test; timeout for suite set at command line level
-var options = { timeout: 20000 };
+var options = { timeout: 30000 };
 
 //number of tests in the plan
 tap.plan(25);
@@ -33,20 +34,16 @@ tap.beforeEach(function () {
 });
 
 // Function clicks the link and returns the url of the resulting page
-function clickFooterLinks ( linkText ) {
-    // Not sure if I need this first wait - maybe it solved intermittent initial failure problem?
-    return driver.wait(seleniumWebdriver.until.elementLocated(seleniumWebdriver.By.id('view')))
-        .then( function () {
-            return driver.wait(seleniumWebdriver.until.elementLocated(seleniumWebdriver.By
-                    .id('footer')))
-                .then( function () {
-                    return driver.findElement(seleniumWebdriver.By.linkText(linkText)); })
-                .then( function (element) {
-                    return element.click(); })
-                .then(function () {
-                    return driver.getCurrentUrl();
-                });
-        });
+
+function clickFooterLinks (linkText) {
+    return driver.wait(seleniumWebdriver.until.elementLocated(seleniumWebdriver.By.id('footer')))
+    .then( function (element) {
+        return element.findElement(seleniumWebdriver.By.linkText(linkText)); })
+    .then( function (element) {
+        return element.click(); })
+    .then(function () {
+        return driver.getCurrentUrl();
+    });
 }
 
 // ==== ABOUT SCRATCH column ====


### PR DESCRIPTION
…n test_footer_links. Also fixed the clickFooterLinks function so it only checks links in the footer, to remove false positives (e.g. test finds 'Tips' in navbar and passes).

Fixes https://github.com/LLK/scratch-www/issues/1569.

Changes:
- Update selenium & chromedriver versions in package.json
  - I checked that all smoketests still pass with the updated versions (by running them with `make smoke`)
- Removed initial wait in the clickFooterLinks function; I still don't know if it mattered for the occasional timeout, but the tests passed without it, so I took it out
  - Relatedly, I increased the timeout to 30000 (from 20000) because I saw the `About` link hit the timeout even though that link is clearly working and there doesn't seem to be anything amiss with the test... so I just increased the limit a bit in the hopes that that wouldn't happen again (? bad idea ?)
- I changed the clickFooterLinks function so that the test only checks within the footer. 
  - When I initially noticed the failing tests, the Tips test was still passing, and what was happening was that the test found the Tips link in the navbar and accepted that, because I hadn't passed the found footer element through to the next function. Now that is being passed through.