### PR TITLE
Fix GH-1546: Use new filters on api endpoint

### DIFF
--- a/src/views/messages/container.jsx
+++ b/src/views/messages/container.jsx
@@ -12,8 +12,7 @@ var Messages = React.createClass({
     type: 'ConnectedMessages',
     getInitialState: function () {
         return {
-            filterValues: [],
-            displayedMessages: []
+            filter: ''
         };
     },
     getDefaultProps: function () {
@@ -26,14 +25,17 @@ var Messages = React.createClass({
         };
     },
     componentDidUpdate: function (prevProps) {
-        if (this.props.user != prevProps.user) {
+        if (this.props.user.username !== prevProps.user.username) {
             if (this.props.user.token) {
                 this.props.dispatch(
                     messageActions.getMessages(
                         this.props.user.username,
                         this.props.user.token,
-                        this.props.messages,
-                        this.props.messageOffset
+                        {
+                            messages: this.props.messages,
+                            offset: this.props.messageOffset,
+                            filter: this.state.filter
+                        }
                     )
                 );
                 this.props.dispatch(
@@ -59,8 +61,11 @@ var Messages = React.createClass({
                 messageActions.getMessages(
                     this.props.user.username,
                     this.props.user.token,
-                    this.props.messages,
-                    this.props.messageOffset
+                    {
+                        messages: this.props.messages,
+                        offset: this.props.messageOffset,
+                        filter: this.state.filter
+                    }
                 )
             );
             this.props.dispatch(
@@ -74,26 +79,19 @@ var Messages = React.createClass({
         }
     },
     handleFilterClick: function (field, choice) {
-        switch (choice) {
-        case 'comments':
-            return this.setState({filterValues: ['addcomment']});
-        case 'projects':
-            return this.setState({filterValues: [
-                'loveproject',
-                'favoriteproject',
-                'remixproject'
-            ]});
-        case 'studios':
-            return this.setState({filterValues: [
-                'curatorinvite',
-                'studioactivity',
-                'becomeownerstudio'
-            ]});
-        case 'forums':
-            return this.setState({filterValues: ['forumpost']});
-        default:
-            return this.setState({filterValues: []});
+        if (this.props.user.token) {
+            this.props.dispatch(
+                messageActions.getMessages(
+                    this.props.user.username,
+                    this.props.user.token,
+                    {
+                        filter: choice,
+                        clearCount: false
+                    }
+                )
+            );
         }
+        this.setState({filter: choice});
     },
     handleMessageDismiss: function (messageType, messageId) {
         var adminMessages = null;
@@ -111,19 +109,14 @@ var Messages = React.createClass({
             messageActions.getMessages(
                 this.props.user.username,
                 this.props.user.token,
-                this.props.messages,
-                this.props.messageOffset
+                {
+                    messages: this.props.messages,
+                    offset: this.props.messageOffset,
+                    filter: this.state.filter,
+                    clearCount: false
+                }
             )
         );
-    },
-    filterMessages: function (messages, typesAllowed) {
-        var filteredMessages = [];
-        for (var i in messages) {
-            if (typesAllowed.indexOf(messages[i].type) > -1) {
-                filteredMessages.push(messages[i]);
-            }
-        }
-        return filteredMessages;
     },
     render: function () {
         var loadMore = true;
@@ -131,16 +124,11 @@ var Messages = React.createClass({
             loadMore = false;
         }
 
-        var messages = this.props.messages;
-        if (this.state.filterValues.length > 0) {
-            messages = this.filterMessages(messages, this.state.filterValues);
-        }
-
         return(
             <MessagesPresentation
                 sessionStatus={this.props.sessionStatus}
                 user={this.props.user}
-                messages={messages}
+                messages={this.props.messages}
                 adminMessages={this.props.adminMessages}
                 scratcherInvite={this.props.invite}
                 numNewMessages={this.props.numNewMessages}
@@ -149,6 +137,7 @@ var Messages = React.createClass({
                 loadMore={loadMore}
                 loadMoreMethod={this.handleLoadMoreMessages}
                 requestStatus={this.props.requestStatus}
+                filter={this.props.filter}
             />
         );
     }

--- a/src/views/messages/presentation.jsx
+++ b/src/views/messages/presentation.jsx
@@ -217,12 +217,14 @@ var MessagesPresentation = injectIntl(React.createClass({
         handleAdminDismiss: React.PropTypes.func.isRequired,
         loadMore: React.PropTypes.bool.isRequired,
         loadMoreMethod: React.PropTypes.func,
-        requestStatus: React.PropTypes.object.isRequired
+        requestStatus: React.PropTypes.object.isRequired,
+        filter: React.PropTypes.string
     },
     getDefaultProps: function () {
         return {
             numNewMessages: 0,
-            filterOpen: false
+            filterOpen: false,
+            filter: ''
         };
     },
     render: function () {
@@ -270,6 +272,7 @@ var MessagesPresentation = injectIntl(React.createClass({
                                             value: 'forums'
                                         }
                                     ]}
+                                    value={this.props.filter}
                                 />
                             </Form>
                         </div>

--- a/src/views/messages/presentation.jsx
+++ b/src/views/messages/presentation.jsx
@@ -196,9 +196,9 @@ var SocialMessagesList = React.createClass({
                     </div>,
                     <ul className="messages-social-list" key="messages-social-list">
                         {this.renderSocialMessages(this.props.messages, (this.props.numNewMessages - 1))}
-                    </ul>,
-                    this.renderLoadMore(this.props.loadMore)
+                    </ul>
                 ] : []}
+                {this.renderLoadMore(this.props.loadMore)}
             </section>
         );
     }


### PR DESCRIPTION
This fixes #1546 by using the new optional `filter` keyword argument that will be added to the messages api endpoint.

### Test Cases ###
* If you change filters, the notifications that show up should only apply to that type of filter
* If you change filters and there are no notifications available for that filter, the load more button shouldn't show up
* If you change filters and there were no notifications of that type in the original list of 40 notifications, you should still see the most recent of that notification type