### PR TITLE
Point at GulpTea’s avatar in credits page

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -157,7 +157,7 @@ var Credits = React.createClass({
                     </li>
 
                     <li>
-                        <img src="//cdn2.scratch.mit.edu/get_image/user/default_60x60.png" alt="Joel Avatar" />
+                        <img src="//cdn2.scratch.mit.edu/get_image/user/26249744_60x60.png" alt="Joel Avatar" />
                         <span className="name">Joel Gritter</span>
                     </li>
 


### PR DESCRIPTION
I noticed while doing qa for #1616 that @TheGrits avatar was pointing at the default avatar – I changed it to point at `GulpTea`'s avatar instead.