### PR TITLE
Upgrade compatibility to node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4.2'
+- '8'
 sudo: required
 cache:
   directories:

--- a/bin/get-localized-urls
+++ b/bin/get-localized-urls
@@ -36,7 +36,9 @@ https.get('https://resources.scratch.mit.edu/localized-urls.json', (res) => {
     res.on('end', () => {
         try {
             var urlJson = JSON.parse(urlData);
-            fs.writeFile(filename, JSON.stringify(urlJson, null, '  '));
+            fs.writeFile(filename, JSON.stringify(urlJson, null, '  '), (err) => {
+                if (err) process.stdout.write(`Failed writing file: ${err.message}\n`);
+            });
         } catch (e) {
             process.stdout.write(`Failed parsing url data: ${e.message}\n`);
             process.exit(1);

--- a/bin/get-localized-urls
+++ b/bin/get-localized-urls
@@ -36,9 +36,7 @@ https.get('https://resources.scratch.mit.edu/localized-urls.json', (res) => {
     res.on('end', () => {
         try {
             var urlJson = JSON.parse(urlData);
-            fs.writeFile(filename, JSON.stringify(urlJson, null, '  '), (err) => {
-                if (err) process.stdout.write(`Failed writing file: ${err.message}\n`);
-            });
+            fs.writeFileSync(filename, JSON.stringify(urlJson, null, '  '));
         } catch (e) {
             process.stdout.write(`Failed parsing url data: ${e.message}\n`);
             process.exit(1);

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "bunyan": "1.7.1",
     "compression": "1.6.1",
-    "express": "4.13.4",
-    "express-http-proxy": "0.6.0",
+    "express": "4.16.1",
+    "express-http-proxy": "1.1.0",
     "lodash.defaults": "4.0.1",
     "newrelic": "1.25.4",
     "raven": "0.10.0"
@@ -66,7 +66,7 @@
     "lodash.range": "3.0.1",
     "minilog": "2.0.8",
     "node-dir": "0.1.16",
-    "node-sass": "3.3.3",
+    "node-sass": "4.6.1",
     "pako": "0.2.8",
     "po2icu": "0.0.2",
     "postcss-loader": "0.8.2",


### PR DESCRIPTION
This fixes an issue in compilation by upgrading node-sass to v4.6, and also upgrades express in the process.

Callback added to `writeFile` in `get-localized-urls` in order to avoid a deprecation warning during `make translations`.