### PR TITLE
Fixes #1633 - Scratch Conference 2018 Website Phase 1

### DIFF
--- a/src/components/footer/conference/2018/footer.jsx
+++ b/src/components/footer/conference/2018/footer.jsx
@@ -1,0 +1,84 @@
+var React = require('react');
+var ReactIntl = require('react-intl');
+
+var injectIntl = ReactIntl.injectIntl;
+var FormattedMessage = ReactIntl.FormattedMessage;
+
+var FlexRow = require('../../../flex-row/flex-row.jsx');
+var FooterBox = require('../../container/footer.jsx');
+var LanguageChooser = require('../../../languagechooser/languagechooser.jsx');
+
+require('../footer.scss');
+
+var ConferenceFooter = React.createClass({
+    type: 'ConferenceFooter',
+    render: function () {
+        return (
+            <FooterBox>
+                <FlexRow className="scratch-links">
+                    <div className="family">
+                        <h4><FormattedMessage id='footer.scratchFamily' /></h4>
+                        <FlexRow>
+                            <FlexRow as="ul" className="column">
+                                <li>
+                                    <a href="https://scratch.mit.edu" target="_blank">Scratch</a>
+                                </li>
+                                <li>
+                                    <a href="http://www.scratchjr.org/" target="_blank">ScratchJr</a>
+                                </li>
+                            </FlexRow>
+                            <FlexRow as="ul" className="column">
+                                <li>
+                                    <a href="http://www.scratchfoundation.org/" target="_blank">Scratch Foundation</a>
+                                </li>
+                                <li>
+                                    <a href="http://scratched.gse.harvard.edu/" target="_blank">ScratchEd</a>
+                                </li>
+                            </FlexRow>
+                            <FlexRow as="ul" className="column">
+                                <li>
+                                    <a href="http://day.scratch.mit.edu" target="_blank">Scratch Day</a>
+                                </li>
+                            </FlexRow>
+                        </FlexRow>
+                        <p className="legal">
+                            <FormattedMessage id='general.copyright' />
+                        </p>
+                    </div>
+                    <div className="media">
+                        <div className="contact-us">
+                            <h4>Contact</h4>
+                            <p>
+                                <a href="mailto:conference@scratch.mit.edu" target="_blank">
+                                    Email Us
+                                </a>
+                            </p>
+                        </div>
+                        <div className="social">
+                            <FlexRow as="ul">
+                                <li>
+                                    <a href="//www.twitter.com/scratch" target="_blank">
+                                        <img src="/images/conference/footer/twitter.png" alt="scratch twitter" />
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="//www.facebook.com/scratchteam" target="_blank">
+                                        <img src="/images/conference/footer/facebook.png" alt="scratch facebook" />
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="http://medium.com/scratchfoundation-blog" target="_blank">
+                                        <img src="/images/conference/footer/medium.png" alt="scratch foundation blog" />
+                                    </a>
+                                </li>
+                            </FlexRow>
+                        </div>
+                    </div>
+                </FlexRow>
+                <LanguageChooser locale={this.props.intl.locale} />
+            </FooterBox>
+        );
+    }
+});
+
+module.exports = injectIntl(ConferenceFooter);

--- a/src/components/navigation/conference/2018/navigation.jsx
+++ b/src/components/navigation/conference/2018/navigation.jsx
@@ -1,0 +1,29 @@
+var React = require('react');
+
+var NavigationBox = require('../../base/navigation.jsx');
+
+require('./navigation.scss');
+
+var Navigation = React.createClass({
+    type: 'Navigation',
+    render: function () {
+        return (
+            <NavigationBox>
+                <ul className="ul mod-2018">
+                    <li className="li-left mod-logo mod-2018">
+                        <a href="/conference" className="logo-a">
+                            <img
+                                src="/images/logo_sm.png"
+                                alt="Scratch Logo"
+                                className="logo-a-image"
+                            />
+                            <p className="logo-a-title">Conferences</p>
+                        </a>
+                    </li>
+                </ul>
+            </NavigationBox>
+        );
+    }
+});
+
+module.exports = Navigation;

--- a/src/components/navigation/conference/2018/navigation.scss
+++ b/src/components/navigation/conference/2018/navigation.scss
@@ -1,0 +1,39 @@
+@import "../../../../colors";
+@import "../../../../frameless";
+
+#navigation {
+    .ul.mod-2018 {
+        display: flex;
+        justify-content: space-between;
+        flex-flow: row nowrap;
+        align-items: center;
+        list-style-type: none;
+    }
+
+    .li-left.mod-2018 {
+        margin-top: 0;
+        margin-right: 10px;
+        color: $type-white;
+    }
+
+    .logo-a {
+        display: flex;
+        height: 100%;
+        align-items: center;
+    }
+
+    .logo-a-image {
+        margin-right: 10px;
+        border-right: 2px solid $active-gray;
+        padding-right: 10px;
+        width: 80px;
+    }
+
+    .logo-a-title {
+        text-decoration: none;
+        white-space: nowrap;
+        color: $type-white;
+        font-size: .85rem;
+        font-weight: bold;
+    }
+}

--- a/src/components/page/conference/2018/page.jsx
+++ b/src/components/page/conference/2018/page.jsx
@@ -1,0 +1,27 @@
+var React = require('react');
+
+var Navigation = require('../../../navigation/conference/2017/navigation.jsx');
+var Footer = require('../../../footer/conference/2017/footer.jsx');
+
+require('../page.scss');
+
+var Page = React.createClass({
+    type: 'Page',
+    render: function () {
+        return (
+            <div className="page mod-conference">
+                <div id="navigation">
+                    <Navigation />
+                </div>
+                <div id="view">
+                    {this.props.children}
+                </div>
+                <div id="footer">
+                    <Footer />
+                </div>
+            </div>
+        );
+    }
+});
+
+module.exports = Page;

--- a/src/components/page/conference/2018/page.jsx
+++ b/src/components/page/conference/2018/page.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 
-var Navigation = require('../../../navigation/conference/2017/navigation.jsx');
-var Footer = require('../../../footer/conference/2017/footer.jsx');
+var Navigation = require('../../../navigation/conference/2018/navigation.jsx');
+var Footer = require('../../../footer/conference/2018/footer.jsx');
 
 require('../page.scss');
 

--- a/src/routes.json
+++ b/src/routes.json
@@ -58,6 +58,14 @@
         "viewportWidth": "device-width"
     },
     {
+        "name": "conference-index-2016",
+        "pattern": "^/conference/2016/?$",
+        "routeAlias": "/conference(?!/201[4-5])",
+        "view": "conference/2016/index/index",
+        "title": "Scratch Conference",
+        "viewportWidth": "device-width"
+    },
+    {
         "name": "conference-plan-2016",
         "pattern": "^/conference/2016/plan/?$",
         "routeAlias": "/conference(?!/201[4-5])",

--- a/src/routes.json
+++ b/src/routes.json
@@ -44,16 +44,16 @@
     {
         "name": "conference-index",
         "pattern": "^/conference/?$",
-        "routeAlias": "/conference(?!/201[4-5])",
-        "view": "conference/2017/index/index",
+        "routeAlias": "/conference(?!/201[4-7])",
+        "view": "conference/2018/index/index",
         "title": "Scratch Conference",
         "viewportWidth": "device-width"
     },
     {
-        "name": "conference-index-2016",
-        "pattern": "^/conference/2016/?$",
-        "routeAlias": "/conference(?!/201[4-5])",
-        "view": "conference/2016/index/index",
+        "name": "conference-index-2017",
+        "pattern": "^/conference/2017/?$",
+        "routeAlias": "/conference(?!/201[4-6])",
+        "view": "conference/2017/index/index",
         "title": "Scratch Conference",
         "viewportWidth": "device-width"
     },

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -1,5 +1,5 @@
 var FormattedDate = require('react-intl').FormattedDate;
-var FormattedMessage = require('react-intl').FormattedMessage;
+var FormattedHTMLMessage = require('react-intl').FormattedHTMLMessage;
 var React = require('react');
 var render = require('../../../../lib/render.jsx');
 
@@ -19,7 +19,9 @@ var ConferenceSplash = React.createClass({
                 <TitleBanner className='mod-conference mod-2018'>
                     <div className='title-banner-image mod-2018'></div>
                     <h1 className='title-banner-h1 mod-2018'>
-                        <FormattedMessage id='conference-2018.title' />
+                        <center>
+                          <FormattedMessage id='conference-2018.title' />
+                        </center>
                     </h1>
                     <h3 className='title-banner-h3 mod-2018'>
                         <FormattedMessage id='conference-2018.dateDesc' />
@@ -28,7 +30,7 @@ var ConferenceSplash = React.createClass({
                 <div className='inner'>
                     <section className='conf2018-panel mod-desc'>
                         <p className='conf2018-panel-desc'>
-                            <FormattedMessage id='conference-2018.desc' />
+                            <FormattedHTMLMessage id='conference-2018.desc' />
                         </p>
                         <table className='conf2018-panel-details'>
                             <tbody>
@@ -55,7 +57,7 @@ var ConferenceSplash = React.createClass({
                                             month='long'
                                             day='2-digit'
                                         />
-                                        {' (with opening reception the evening of July 25)'}
+                                        <FormattedMessage id='conference-2018.dateDescMore' />
                                     </td>
                                 </tr>
                                 <tr className='conf2018-panel-row'>
@@ -67,7 +69,7 @@ var ConferenceSplash = React.createClass({
                                         />
                                     </td>
                                     <td><FormattedMessage id='conference-2018.location' /></td>
-                                    <td>{'MIT Media Lab, Cambridge, MA'}</td>
+                                    <td><FormattedMessage id='conference-2018.locationDetails' /></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -4,7 +4,7 @@ var React = require('react');
 var render = require('../../../../lib/render.jsx');
 
 var FlexRow = require('../../../../components/flex-row/flex-row.jsx');
-var Page = require('../../../../components/page/conference/2017/page.jsx');
+var Page = require('../../../../components/page/conference/2018/page.jsx');
 var TitleBanner = require('../../../../components/title-banner/title-banner.jsx');
 
 require('../../../../components/forms/button.scss');
@@ -15,495 +15,92 @@ var ConferenceSplash = React.createClass({
 
     render: function () {
         return (
-            <div className='index mod-2017'>
-                <TitleBanner className='mod-conference mod-2017'>
-                    <div className='title-banner-image mod-2017'></div>
-                    <h1 className='title-banner-h1 mod-2017'>
-                        <FormattedMessage id='conference-2017.title' />
+            <div className='index mod-2018'>
+                <TitleBanner className='mod-conference mod-2018'>
+                    <div className='title-banner-image mod-2018'></div>
+                    <h1 className='title-banner-h1 mod-2018'>
+                        <FormattedMessage id='conference-2018.title' />
                     </h1>
-                    <h3 className='title-banner-h3 mod-2017'>
-                        <FormattedMessage id='conference-2017.desc' />
+                    <h3 className='title-banner-h3 mod-2018'>
+                        <FormattedMessage id='conference-2018.desc' />
                     </h3>
                 </TitleBanner>
-                <h3 className='conf2017-title-band'>
-                    <FormattedMessage id='conference-2017.seeBelow' />
-                </h3>
                 <div className='inner'>
-                    <section className='conf2017-panel mod-france'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/fr.svg'
-                                alt='France Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.franceTitle' /></h3>
-                                <h4><FormattedMessage id='conference-2017.franceSubTitle' /></h4>
-                            </div>
-                        </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.franceDesc' />
+                    <section className='conf2018-panel mod-desc'>
+                        <p className='conf2018-panel-desc'>
+                            <FormattedMessage id='conference-2018.desc' />
                         </p>
-                        <table className='conf2017-panel-details'>
+                        <table className='conf2018-panel-details'>
                             <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
+                                <tr className='conf2018-panel-row'>
+                                    <td className='conf2018-panel-row-icon'>
                                         <img
-                                            className='conf2017-panel-row-icon-image'
+                                            className='conf2018-panel-row-icon-image'
                                             src='/svgs/conference/index/calendar-icon.svg'
                                             alt='Calendar Icon'
                                         />
                                     </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td><FormattedMessage id='conference-2018.date' /></td>
                                     <td>
                                         <FormattedDate
-                                            value={new Date(2017, 6, 18)}
+                                            value={new Date(2018, 6, 26)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'
                                         />
                                         {' - '}
                                         <FormattedDate
-                                            value={new Date(2017, 6, 21)}
+                                            value={new Date(2018, 6, 28)}
                                             year='numeric'
                                             month='long'
                                             day='2-digit'
                                         />
+                                        {' (with opening reception the evening of July 25)'}
                                     </td>
                                 </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
+                                <tr className='conf2018-panel-row'>
+                                    <td className='conf2018-panel-row-icon'>
                                         <img
-                                            className='conf2017-panel-row-icon-image'
+                                            className='conf2018-panel-row-icon-image'
                                             src='/svgs/conference/index/map-icon.svg'
                                             alt='Map Icon'
                                         />
                                     </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'Bordeaux, France'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.franceAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'English'}</td>
+                                    <td><FormattedMessage id='conference-2018.location' /></td>
+                                    <td>{'MIT Media Lab, Cambridge, MA'}</td>
                                 </tr>
                             </tbody>
                         </table>
-                        <a className='button mod-2017-panel' href='http://scratch2017bdx.org'>
-                            <FormattedMessage id='conference-2017.website' />
+                    </section>
+                    <section className='conf2018-panel'>
+                        <p className='conf2018-panel-desc'>
+                            <FormattedMessage id='conference-2018.sessionDesc' />
+                        </p>
+                        <p className='conf2018-panel-session'>
+                            <FormattedMessage id='conference-2018.sessionItem1' />
+                            <FormattedMessage id='conference-2018.sessionItem2' />
+                            <FormattedMessage id='conference-2018.sessionItem3' />
+                            <FormattedMessage id='conference-2018.sessionItem4' />
+                        </p>
+                        <a className='button mod-2018-panel' href='https://docs.google.com/forms/d/e/1FAIpQLSd7SkuQ-dfW-P3aArSQokK9GkKAUKufTVBHod_ElNIiFE9iBQ/viewform?usp=sf_link'>
+                            <FormattedMessage id='conference-2018.proposal' />
                         </a>
                     </section>
-                    <section className='conf2017-panel mod-hungary'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/hu.svg'
-                                alt='Hungary Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.hungaryTitle' /></h3>
+                    <section className='conf2018-panel mod-registration'>
+                        <FlexRow className='conf2018-panel-title'>
+                            <div className='conf2018-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2018.registrationTitle' /></h3>
                             </div>
                         </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.hungaryDesc' />
+                        <p className='conf2018-panel-desc'>
+                            <FormattedMessage id='conference-2018.registrationEarly' />
+                            <FormattedMessage id='conference-2018.registrationStandard' />
                         </p>
-                        <table className='conf2017-panel-details'>
-                            <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/calendar-icon.svg'
-                                            alt='Calendar Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
-                                    <td>
-                                        <FormattedDate
-                                            value={new Date(2017, 7, 24)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                        {' - '}
-                                        <FormattedDate
-                                            value={new Date(2017, 7, 25)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                    </td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/map-icon.svg'
-                                            alt='Map Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'Budapest, Hungary'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.hungaryAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'English'}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <a className='button mod-2017-panel' href='https://events.epam.com/events/scratch-2017'>
-                            <FormattedMessage id='conference-2017.website' />
-                        </a>
                     </section>
-                    <section className='conf2017-panel mod-costarica'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/cr.svg'
-                                alt='Costa Rica Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.costaricaTitle' /></h3>
-                                <h4><FormattedMessage id='conference-2017.costaricaSubTitle' /></h4>
-                            </div>
-                        </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.costaricaDesc' />
+                    <section className='conf2018-panel mod-questions'>
+                        <p className='conf2018-panel-desc'>
+                            <FormattedMessage id='conference-2018.questions' />
                         </p>
-                        <table className='conf2017-panel-details'>
-                            <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/calendar-icon.svg'
-                                            alt='Calendar Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
-                                    <td>
-                                        <FormattedDate
-                                            value={new Date(2017, 10, 12)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                    </td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/map-icon.svg'
-                                            alt='Map Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'San José, Costa Rica'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.costaricaAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'Español (Spanish)'}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <a className='button mod-2017-panel' href='https://scratchcostarica.com/'>
-                            <FormattedMessage id='conference-2017.website' />
-                        </a>
-                    </section>
-                    <section className='conf2017-panel mod-chile'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/cl.svg'
-                                alt='Chile Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.chileTitle' /></h3>
-                                <h4><FormattedMessage id='conference-2017.chileSubTitle' /></h4>
-                            </div>
-                        </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.chileDesc' />
-                        </p>
-                        <table className='conf2017-panel-details'>
-                            <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/calendar-icon.svg'
-                                            alt='Calendar Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
-                                    <td>
-                                        <FormattedDate
-                                            value={new Date(2017, 7, 31)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                        {' - '}
-                                        <FormattedDate
-                                            value={new Date(2017, 8, 1)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                    </td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/map-icon.svg'
-                                            alt='Map Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'Santiago, Chile'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.chileAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'Español (Spanish) - simultaneous translation during plenary sessions'}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <a className='button mod-2017-panel' href='http://www.scratchalsur.org'>
-                            <FormattedMessage id='conference-2017.website' />
-                        </a>
-                    </section>
-                    <section className='conf2017-panel mod-brasil'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/br.svg'
-                                alt='Brasil Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.brasilTitle' /></h3>
-                            </div>
-                        </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.brasilDesc' />
-                        </p>
-                        <table className='conf2017-panel-details'>
-                            <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/calendar-icon.svg'
-                                            alt='Calendar Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
-                                    <td>
-                                        <FormattedDate
-                                            value={new Date(2017, 9, 5)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                        {' - '}
-                                        <FormattedDate
-                                            value={new Date(2017, 9, 7)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                    </td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/map-icon.svg'
-                                            alt='Map Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'São Paulo, Brasil'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.brasilAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'Português (Portuguese)'}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <a className='button mod-2017-panel' href='http://scratchbrasil.org/'>
-                            <FormattedMessage id='conference-2017.website' />
-                        </a>
-                    </section>
-                    <section className='conf2017-panel mod-china mod-last'>
-                        <FlexRow className='conf2017-panel-title'>
-                            <img
-                                className='conf2017-panel-flag'
-                                src='/svgs/conference/flags/cn.svg'
-                                alt='China Flag'
-                            />
-                            <div className='conf2017-panel-title-text'>
-                                <h3><FormattedMessage id='conference-2017.chinaTitle' /></h3>
-                            </div>
-                        </FlexRow>
-                        <p className='conf2017-panel-desc'>
-                            <FormattedMessage id='conference-2017.chinaDesc' />
-                        </p>
-                        <table className='conf2017-panel-details'>
-                            <tbody>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/calendar-icon.svg'
-                                            alt='Calendar Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.date' /></td>
-                                    <td>
-                                        <FormattedDate
-                                            value={new Date(2017, 4, 20)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                        {' - '}
-                                        <FormattedDate
-                                            value={new Date(2017, 4, 21)}
-                                            year='numeric'
-                                            month='long'
-                                            day='2-digit'
-                                        />
-                                    </td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/map-icon.svg'
-                                            alt='Map Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.location' /></td>
-                                    <td>{'Shanghai, China'}</td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/audience-icon.svg'
-                                            alt='Audience Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.audience' /></td>
-                                    <td><FormattedMessage id='conference-2017.chinaAudience' /></td>
-                                </tr>
-                                <tr className='conf2017-panel-row'>
-                                    <td className='conf2017-panel-row-icon'>
-                                        <img
-                                            className='conf2017-panel-row-icon-image'
-                                            src='/svgs/conference/index/language-icon.svg'
-                                            alt='Language Icon'
-                                        />
-                                    </td>
-                                    <td><FormattedMessage id='conference-2017.language' /></td>
-                                    <td>{'中文 (Chinese)'}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <a className='button mod-2017-panel' href='http://scratchconference2017.sxl.cn/'>
-                            <FormattedMessage id='conference-2017.website' />
-                        </a>
                     </section>
                 </div>
             </div>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -20,7 +20,7 @@ var ConferenceSplash = React.createClass({
                     <div className='title-banner-image mod-2018'></div>
                     <h1 className='title-banner-h1 mod-2018'>
                         <center>
-                          <FormattedMessage id='conference-2018.title' />
+                          <FormattedHTMLMessage id='conference-2018.title' />
                         </center>
                     </h1>
                     <h3 className='title-banner-h3 mod-2018'>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -76,7 +76,7 @@ var ConferenceSplash = React.createClass({
                     </section>
                     <section className='conf2018-panel'>
                         <p className='conf2018-panel-desc'>
-                            <FormattedMessage id='conference-2018.sessionDesc' />
+                            <FormattedHTMLMessage id='conference-2018.sessionDesc' />
                         </p>
                         <p className='conf2018-panel-session'>
                             <FormattedMessage id='conference-2018.sessionItem1' />
@@ -96,12 +96,13 @@ var ConferenceSplash = React.createClass({
                         </FlexRow>
                         <p className='conf2018-panel-desc'>
                             <FormattedMessage id='conference-2018.registrationEarly' />
+                            <br/>
                             <FormattedMessage id='conference-2018.registrationStandard' />
                         </p>
                     </section>
                     <section className='conf2018-panel mod-questions'>
                         <p className='conf2018-panel-desc'>
-                            <FormattedMessage id='conference-2018.questions' />
+                            <FormattedHTMLMessage id='conference-2018.questions' />
                         </p>
                     </section>
                 </div>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -1,4 +1,5 @@
 var FormattedDate = require('react-intl').FormattedDate;
+var FormattedMessage = require('react-intl').FormattedMessage;
 var FormattedHTMLMessage = require('react-intl').FormattedHTMLMessage;
 var React = require('react');
 var render = require('../../../../lib/render.jsx');

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -22,7 +22,7 @@ var ConferenceSplash = React.createClass({
                         <FormattedMessage id='conference-2018.title' />
                     </h1>
                     <h3 className='title-banner-h3 mod-2018'>
-                        <FormattedMessage id='conference-2018.desc' />
+                        <FormattedMessage id='conference-2018.dateDesc' />
                     </h3>
                 </TitleBanner>
                 <div className='inner'>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -80,10 +80,18 @@ var ConferenceSplash = React.createClass({
                             <FormattedHTMLMessage id='conference-2018.sessionDesc' />
                         </p>
                         <p className='conf2018-panel-session'>
-                            <FormattedMessage id='conference-2018.sessionItem1' />
-                            <FormattedMessage id='conference-2018.sessionItem2' />
-                            <FormattedMessage id='conference-2018.sessionItem3' />
-                            <FormattedMessage id='conference-2018.sessionItem4' />
+                            <p className='conf2018-panel-session'>
+                                <FormattedHTMLMessage id='conference-2018.sessionItem1' />
+                            </p>
+                            <p className='conf2018-panel-session'>
+                                <FormattedHTMLMessage id='conference-2018.sessionItem2' />
+                            </p>
+                            <p className='conf2018-panel-session'>
+                                <FormattedHTMLMessage id='conference-2018.sessionItem3' />
+                            </p>
+                            <p className='conf2018-panel-session'>
+                                <FormattedHTMLMessage id='conference-2018.sessionItem4' />
+                            </p>
                         </p>
                         <a className='button mod-2018-panel' href='https://docs.google.com/forms/d/e/1FAIpQLSd7SkuQ-dfW-P3aArSQokK9GkKAUKufTVBHod_ElNIiFE9iBQ/viewform?usp=sf_link'>
                             <FormattedMessage id='conference-2018.proposal' />

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -1,0 +1,514 @@
+var FormattedDate = require('react-intl').FormattedDate;
+var FormattedMessage = require('react-intl').FormattedMessage;
+var React = require('react');
+var render = require('../../../../lib/render.jsx');
+
+var FlexRow = require('../../../../components/flex-row/flex-row.jsx');
+var Page = require('../../../../components/page/conference/2017/page.jsx');
+var TitleBanner = require('../../../../components/title-banner/title-banner.jsx');
+
+require('../../../../components/forms/button.scss');
+require('./index.scss');
+
+var ConferenceSplash = React.createClass({
+    type: 'ConferenceSplash',
+
+    render: function () {
+        return (
+            <div className='index mod-2017'>
+                <TitleBanner className='mod-conference mod-2017'>
+                    <div className='title-banner-image mod-2017'></div>
+                    <h1 className='title-banner-h1 mod-2017'>
+                        <FormattedMessage id='conference-2017.title' />
+                    </h1>
+                    <h3 className='title-banner-h3 mod-2017'>
+                        <FormattedMessage id='conference-2017.desc' />
+                    </h3>
+                </TitleBanner>
+                <h3 className='conf2017-title-band'>
+                    <FormattedMessage id='conference-2017.seeBelow' />
+                </h3>
+                <div className='inner'>
+                    <section className='conf2017-panel mod-france'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/fr.svg'
+                                alt='France Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.franceTitle' /></h3>
+                                <h4><FormattedMessage id='conference-2017.franceSubTitle' /></h4>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.franceDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 6, 18)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                        {' - '}
+                                        <FormattedDate
+                                            value={new Date(2017, 6, 21)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'Bordeaux, France'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.franceAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'English'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='http://scratch2017bdx.org'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                    <section className='conf2017-panel mod-hungary'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/hu.svg'
+                                alt='Hungary Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.hungaryTitle' /></h3>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.hungaryDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 7, 24)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                        {' - '}
+                                        <FormattedDate
+                                            value={new Date(2017, 7, 25)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'Budapest, Hungary'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.hungaryAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'English'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='https://events.epam.com/events/scratch-2017'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                    <section className='conf2017-panel mod-costarica'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/cr.svg'
+                                alt='Costa Rica Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.costaricaTitle' /></h3>
+                                <h4><FormattedMessage id='conference-2017.costaricaSubTitle' /></h4>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.costaricaDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 10, 12)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'San José, Costa Rica'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.costaricaAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'Español (Spanish)'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='https://scratchcostarica.com/'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                    <section className='conf2017-panel mod-chile'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/cl.svg'
+                                alt='Chile Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.chileTitle' /></h3>
+                                <h4><FormattedMessage id='conference-2017.chileSubTitle' /></h4>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.chileDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 7, 31)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                        {' - '}
+                                        <FormattedDate
+                                            value={new Date(2017, 8, 1)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'Santiago, Chile'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.chileAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'Español (Spanish) - simultaneous translation during plenary sessions'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='http://www.scratchalsur.org'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                    <section className='conf2017-panel mod-brasil'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/br.svg'
+                                alt='Brasil Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.brasilTitle' /></h3>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.brasilDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 9, 5)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                        {' - '}
+                                        <FormattedDate
+                                            value={new Date(2017, 9, 7)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'São Paulo, Brasil'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.brasilAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'Português (Portuguese)'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='http://scratchbrasil.org/'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                    <section className='conf2017-panel mod-china mod-last'>
+                        <FlexRow className='conf2017-panel-title'>
+                            <img
+                                className='conf2017-panel-flag'
+                                src='/svgs/conference/flags/cn.svg'
+                                alt='China Flag'
+                            />
+                            <div className='conf2017-panel-title-text'>
+                                <h3><FormattedMessage id='conference-2017.chinaTitle' /></h3>
+                            </div>
+                        </FlexRow>
+                        <p className='conf2017-panel-desc'>
+                            <FormattedMessage id='conference-2017.chinaDesc' />
+                        </p>
+                        <table className='conf2017-panel-details'>
+                            <tbody>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/calendar-icon.svg'
+                                            alt='Calendar Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.date' /></td>
+                                    <td>
+                                        <FormattedDate
+                                            value={new Date(2017, 4, 20)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                        {' - '}
+                                        <FormattedDate
+                                            value={new Date(2017, 4, 21)}
+                                            year='numeric'
+                                            month='long'
+                                            day='2-digit'
+                                        />
+                                    </td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/map-icon.svg'
+                                            alt='Map Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.location' /></td>
+                                    <td>{'Shanghai, China'}</td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/audience-icon.svg'
+                                            alt='Audience Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.audience' /></td>
+                                    <td><FormattedMessage id='conference-2017.chinaAudience' /></td>
+                                </tr>
+                                <tr className='conf2017-panel-row'>
+                                    <td className='conf2017-panel-row-icon'>
+                                        <img
+                                            className='conf2017-panel-row-icon-image'
+                                            src='/svgs/conference/index/language-icon.svg'
+                                            alt='Language Icon'
+                                        />
+                                    </td>
+                                    <td><FormattedMessage id='conference-2017.language' /></td>
+                                    <td>{'中文 (Chinese)'}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <a className='button mod-2017-panel' href='http://scratchconference2017.sxl.cn/'>
+                            <FormattedMessage id='conference-2017.website' />
+                        </a>
+                    </section>
+                </div>
+            </div>
+        );
+    }
+});
+
+render(<Page><ConferenceSplash /></Page>, document.getElementById('app'));

--- a/src/views/conference/2018/index/index.scss
+++ b/src/views/conference/2018/index/index.scss
@@ -8,7 +8,7 @@
 .title-banner-image.mod-2018 {
     opacity: .75;
     margin-bottom: 1.75rem;
-    background-image: url("/images/conference/index/2018/title-banner.jpg");
+    background-image: url("/images/conference/index/2017/title-banner.jpg");
     background-position: center;
     background-size: cover;
     width: 100%;
@@ -22,7 +22,7 @@
 }
 
 .title-banner-h3.mod-2018 {
-    text-align: left;
+    text-align: center;
     color: $type-white;
 }
 

--- a/src/views/conference/2018/index/index.scss
+++ b/src/views/conference/2018/index/index.scss
@@ -1,0 +1,184 @@
+@import "../../../../colors";
+@import "../../../../frameless";
+
+.title-banner.mod-conference.mod-2017 {
+    padding-top: 0;
+}
+
+.title-banner-image.mod-2017 {
+    opacity: .75;
+    margin-bottom: 1.75rem;
+    background-image: url("/images/conference/index/2017/title-banner.jpg");
+    background-position: center;
+    background-size: cover;
+    width: 100%;
+    height: 20rem;
+}
+
+.conf2017-panel,
+.title-banner-h3.mod-2017 {
+    margin: auto;
+    width: 48.75rem;
+}
+
+.title-banner-h3.mod-2017 {
+    text-align: left;
+    color: $type-white;
+}
+
+.conf2017-title-band {
+    background-color: lighten($ui-blue, 10%);
+    padding: 1.5rem;
+    text-align: center;
+    color: $type-white;
+}
+
+.conf2017-panel {
+    border-bottom: 1px solid $ui-border;
+}
+
+.conf2017-panel.mod-last {
+    border-bottom: 0;
+}
+
+.flex-row.conf2017-panel-title {
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.conf2017-panel-flag {
+    margin-right: 6.25rem;
+    border: 1px solid $ui-border;
+    border-radius: 1px;
+    background-color: $ui-border;
+    width: 3.75rem;
+}
+
+.conf2017-panel-desc {
+    margin: 2rem 0;
+}
+
+td {
+    padding: .75rem 1.25rem;
+    vertical-align: top;
+}
+
+.conf2017-panel-row-icon-image {
+    margin-top: .125rem;
+    width: 1rem;
+    height: 1rem;
+}
+
+.button.mod-2017-panel {
+    display: block;
+    margin: 2rem auto 0;
+    background-color: $ui-orange;
+    padding: 1rem 0;
+    width: 13.75rem;
+    text-align: center;
+    color: $type-white;
+}
+
+@media only screen and (max-width: $mobile - 1) {
+    .index.mod-2017 {
+        text-align: left;
+    }
+
+    .title-banner-image.mod-2017 {
+        height: 10rem;
+    }
+
+    .title-banner-h1.mod-2017 {
+        line-height: 1.25em;
+    }
+
+    .conf2017-panel,
+    .title-banner-h3.mod-2017 {
+        width: initial;
+    }
+
+    .conf2017-panel {
+        margin: auto .5rem;
+    }
+
+    .title-banner-h3.mod-2017 {
+        margin: 1rem .5rem .5rem;
+        font-size: 1.1rem;
+    }
+
+    .flex-row.conf2017-panel-title {
+        flex-direction: row;
+    }
+
+    .conf2017-panel-flag {
+        margin-right: 1.25rem;
+    }
+
+    .conf2017-panel-title-text {
+        max-width: 14rem;
+    }
+
+    .conf2017-panel-row > td {
+        padding: .75rem .375rem .75rem 0;
+    }
+}
+
+@media only screen and (min-width: $mobile) and (max-width: $tablet - 1) {
+    .index.mod-2017 {
+        text-align: left;
+    }
+
+    .title-banner-image.mod-2017 {
+        height: 10rem;
+    }
+
+    .conf2017-panel,
+    .title-banner-h3.mod-2017 {
+        margin: auto .5rem ;
+        width: initial;
+    }
+
+    .title-banner-h3.mod-2017 {
+        font-size: 1.1rem;
+    }
+
+    .flex-row.conf2017-panel-title {
+        flex-direction: row;
+    }
+
+    .conf2017-panel-flag {
+        margin-right: 5rem;
+    }
+
+    .conf2017-panel-title-text {
+        max-width: 18.75rem;
+    }
+
+    .button.mod-2017-panel {
+        width: 5.75rem;
+    }
+}
+
+@media only screen and (min-width: $tablet) and (max-width: $desktop - 1) {
+    .index.mod-2017 {
+        text-align: left;
+    }
+
+    .title-banner-image.mod-2017 {
+        height: 15rem;
+    }
+
+    .conf2017-panel,
+    .title-banner-h3.mod-2017 {
+        margin: auto;
+        width: 38.75rem;
+    }
+
+    .title-banner-h3.mod-2017 {
+        font-size: 1.1rem;
+    }
+
+    .button.mod-2017-panel {
+        width: 8.75rem;
+    }
+}

--- a/src/views/conference/2018/index/index.scss
+++ b/src/views/conference/2018/index/index.scss
@@ -1,60 +1,45 @@
 @import "../../../../colors";
 @import "../../../../frameless";
 
-.title-banner.mod-conference.mod-2017 {
+.title-banner.mod-conference.mod-2018 {
     padding-top: 0;
 }
 
-.title-banner-image.mod-2017 {
+.title-banner-image.mod-2018 {
     opacity: .75;
     margin-bottom: 1.75rem;
-    background-image: url("/images/conference/index/2017/title-banner.jpg");
+    background-image: url("/images/conference/index/2018/title-banner.jpg");
     background-position: center;
     background-size: cover;
     width: 100%;
     height: 20rem;
 }
 
-.conf2017-panel,
-.title-banner-h3.mod-2017 {
+.conf2018-panel,
+.title-banner-h3.mod-2018 {
     margin: auto;
     width: 48.75rem;
 }
 
-.title-banner-h3.mod-2017 {
+.title-banner-h3.mod-2018 {
     text-align: left;
     color: $type-white;
 }
 
-.conf2017-title-band {
-    background-color: lighten($ui-blue, 10%);
-    padding: 1.5rem;
-    text-align: center;
-    color: $type-white;
-}
-
-.conf2017-panel {
+.conf2018-panel {
     border-bottom: 1px solid $ui-border;
 }
 
-.conf2017-panel.mod-last {
+.conf2018-panel.mod-last {
     border-bottom: 0;
 }
 
-.flex-row.conf2017-panel-title {
+.flex-row.conf2018-panel-title {
     justify-content: flex-start;
     align-items: center;
 }
 
-.conf2017-panel-flag {
-    margin-right: 6.25rem;
-    border: 1px solid $ui-border;
-    border-radius: 1px;
-    background-color: $ui-border;
-    width: 3.75rem;
-}
-
-.conf2017-panel-desc {
+.conf2018-panel-desc {
     margin: 2rem 0;
 }
 
@@ -63,13 +48,13 @@ td {
     vertical-align: top;
 }
 
-.conf2017-panel-row-icon-image {
+.conf2018-panel-row-icon-image {
     margin-top: .125rem;
     width: 1rem;
     height: 1rem;
 }
 
-.button.mod-2017-panel {
+.button.mod-2018-panel {
     display: block;
     margin: 2rem auto 0;
     background-color: $ui-orange;
@@ -80,105 +65,97 @@ td {
 }
 
 @media only screen and (max-width: $mobile - 1) {
-    .index.mod-2017 {
+    .index.mod-2018 {
         text-align: left;
     }
 
-    .title-banner-image.mod-2017 {
+    .title-banner-image.mod-2018 {
         height: 10rem;
     }
 
-    .title-banner-h1.mod-2017 {
+    .title-banner-h1.mod-2018 {
         line-height: 1.25em;
     }
 
-    .conf2017-panel,
-    .title-banner-h3.mod-2017 {
+    .conf2018-panel,
+    .title-banner-h3.mod-2018 {
         width: initial;
     }
 
-    .conf2017-panel {
+    .conf2018-panel {
         margin: auto .5rem;
     }
 
-    .title-banner-h3.mod-2017 {
+    .title-banner-h3.mod-2018 {
         margin: 1rem .5rem .5rem;
         font-size: 1.1rem;
     }
 
-    .flex-row.conf2017-panel-title {
+    .flex-row.conf2018-panel-title {
         flex-direction: row;
     }
 
-    .conf2017-panel-flag {
-        margin-right: 1.25rem;
-    }
-
-    .conf2017-panel-title-text {
+    .conf2018-panel-title-text {
         max-width: 14rem;
     }
 
-    .conf2017-panel-row > td {
+    .conf2018-panel-row > td {
         padding: .75rem .375rem .75rem 0;
     }
 }
 
 @media only screen and (min-width: $mobile) and (max-width: $tablet - 1) {
-    .index.mod-2017 {
+    .index.mod-2018 {
         text-align: left;
     }
 
-    .title-banner-image.mod-2017 {
+    .title-banner-image.mod-2018 {
         height: 10rem;
     }
 
-    .conf2017-panel,
-    .title-banner-h3.mod-2017 {
+    .conf2018-panel,
+    .title-banner-h3.mod-2018 {
         margin: auto .5rem ;
         width: initial;
     }
 
-    .title-banner-h3.mod-2017 {
+    .title-banner-h3.mod-2018 {
         font-size: 1.1rem;
     }
 
-    .flex-row.conf2017-panel-title {
+    .flex-row.conf2018-panel-title {
         flex-direction: row;
     }
 
-    .conf2017-panel-flag {
-        margin-right: 5rem;
-    }
-
-    .conf2017-panel-title-text {
+    .conf2018-panel-title-text {
         max-width: 18.75rem;
     }
 
-    .button.mod-2017-panel {
+    .button.mod-2018-panel {
         width: 5.75rem;
     }
 }
 
 @media only screen and (min-width: $tablet) and (max-width: $desktop - 1) {
-    .index.mod-2017 {
+    .index.mod-2018 {
         text-align: left;
     }
 
-    .title-banner-image.mod-2017 {
+    .title-banner-image.mod-2018 {
         height: 15rem;
     }
 
-    .conf2017-panel,
-    .title-banner-h3.mod-2017 {
+    .conf2018-panel,
+    .title-banner-h3.mod-2018 {
         margin: auto;
         width: 38.75rem;
     }
 
-    .title-banner-h3.mod-2017 {
+    .title-banner-h3.mod-2018 {
         font-size: 1.1rem;
     }
 
-    .button.mod-2017-panel {
+    .button.mod-2018-panel {
         width: 8.75rem;
     }
 }

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -1,0 +1,38 @@
+{
+    "conference-2017.title": "Scratch Conferences 2017",
+    "conference-2017.desc": "This year, in celebration of Scratch’s 10th anniversary, the global Scratch community will host regional Scratch conferences in many cities around the world.",
+    "conference-2017.seeBelow": "Learn more about conference dates and locations below.",
+
+    "conference-2017.date": "Date",
+    "conference-2017.location": "Location",
+    "conference-2017.audience": "Audience",
+    "conference-2017.language": "Language",
+    "conference-2017.website": "Visit Website",
+    
+    "conference-2017.franceTitle": "Scratch2017BDX",
+    "conference-2017.franceSubTitle": "Opening, Inspiring, Connecting",
+    "conference-2017.franceDesc": "Scratch2017BDX is an opportunity to meet people and share ideas, and to be inspired and inspiring. It's a global fest to celebrate creativity and enjoy discoveries and understanding about Scratch and beyond.",
+    "conference-2017.franceAudience": "Global Scratch family",
+    
+    "conference-2017.brasilTitle": "Conferência Scratch Brasil 2017",
+    "conference-2017.brasilDesc": "The Scratch Brazil Conference 2017 will be a meeting point for Brazilian educators, researchers, developers and makers who are interested in creating, sharing and learning with Scratch. The conference will foster discussions about the use of Scratch in and out of the classroom, creative computing, Scratch extensions, and other important themes related to Scratch's adoption in Brazil. We are planning something very participatory, with lots of hands-on workshops, poster sessions and opportunities for collaboration.",
+    "conference-2017.brasilAudience": "Educators, researchers, developers, and makers",
+    
+    "conference-2017.hungaryTitle": "Scratch 2017 @ Budapest",
+    "conference-2017.hungaryDesc": "The Scratch Conference in Budapest is a unique opportunity to meet our extended Scratch family and grow and inspire each other. It is a space to revel in creative thinking and coding, to dive in and share in all the diverse possibilities we have found. We are change agents — tried and true geeks in our genes — and we look forward to rolling up our shirt sleeves and having some “hard-fun”. Truly in this sphere, the outlook for the future is bright and we are excited. Come, meet, and collaborate with other members of the Scratch community.",
+    "conference-2017.hungaryAudience": "Teachers, educators, foundations",
+    
+    "conference-2017.chileTitle": "Scratch al Sur 2017",
+    "conference-2017.chileSubTitle": "Imaginando, creando, compartiendo",
+    "conference-2017.chileDesc": "Scratch al Sur 2017 is an opportunity to learn about the importance of introducing programming languages in schools. All lectures and workshops will provide an opportunity to share different experiences, from higher levels to those who are beginning to participate in Scratch's global community.",
+    "conference-2017.chileAudience": "School teachers, principals, education administrators, researchers, and information technology professionals",
+    
+    "conference-2017.chinaTitle": "Scratch Conference: China*Love",
+    "conference-2017.chinaDesc": "Join us for a gathering to support creative expression with Scratch in China. Share ways to promote learning with passion for programming, animation, community, and life.",
+    "conference-2017.chinaAudience": "Educators, parents, developers, makers",
+
+    "conference-2017.costaricaTitle": "Scratch Conference Costa Rica",
+    "conference-2017.costaricaSubTitle": "People, Projects, and Places",
+    "conference-2017.costaricaDesc": "Scratch Conference Costa Rica is a global event taking place at a community level that unites teachers, students, businesses, and leaders, so that coding and design is part of every child's education, starting with Scratch.",
+    "conference-2017.costaricaAudience": "Scratch users, teachers, college professors, potential Scratchers, university students (future teachers and software developers) in Costa Rica and Spanish-speaking Latin America"
+}

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -1,6 +1,8 @@
 {
     "conference-2018.title": "Scratch Conference 2018: The Next Generation",
     "conference-2018.dateDesc": "July 26-28, 2018 | Cambridge, MA, USA",
+    "conference-2018.dateDescMore": " (with opening reception the evening of July 25)",
+    "conference-2018.locationDetails": "MIT Media Lab, Cambridge, MA",
     "conference-2018.seeBelow": "Learn more about conference dates and locations below.",
 
     "conference-2018.date": "When:",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -1,6 +1,6 @@
 {
     "conference-2018.title": "Scratch Conference 2018: The Next Generation",
-    "conference-2018.desc": "July 26-28, 2018 | Cambridge, MA, USA",
+    "conference-2018.dateDesc": "July 26-28, 2018 | Cambridge, MA, USA",
     "conference-2018.seeBelow": "Learn more about conference dates and locations below.",
 
     "conference-2018.date": "When:",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -21,5 +21,5 @@
     "conference-2018.registrationEarly": "Early Bird Registration (March 1-May 1): $200",
     "conference-2018.registrationStandard": "Standard Registration (after May 1): $300",
 
-    "conference-2018.questions": "Questions? Contact the Scratch Team at <a href="mailto:conference@scratch.mit.edu">conference@scratch.mit.edu</a>"
+    "conference-2018.questions": "Questions? Contact the Scratch Team at <a href='mailto:conference@scratch.mit.edu'>conference@scratch.mit.edu</a>"
 }

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -1,5 +1,5 @@
 {
-    "conference-2018.title": "Scratch Conference 2018: The Next Generation",
+    "conference-2018.title": "Scratch Conference 2018 <br/> The Next Generation",
     "conference-2018.dateDesc": "July 26-28, 2018 | Cambridge, MA, USA",
     "conference-2018.dateDescMore": " (with opening reception the evening of July 25)",
     "conference-2018.locationDetails": "MIT Media Lab, Cambridge, MA",
@@ -11,11 +11,12 @@
     "conference-2018.desc": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.<br /> <br />We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
-    "conference-2018.sessionItem1": "Poster/demonstration (90 minutes). Show off your project in an exhibition setting, alongside other presenters. You will be provided with display space for a poster and table space for a computer or handouts.",
-    "conference-2018.sessionItem2": "Hands-on workshop (90 minutes). Engage participants in hands-on activities, highlighting new ways of creating and collaborating with Scratch.",
-    "conference-2018.sessionItem3": "Interactive panel (60 minutes). Discuss a Scratch-related topic in a panel with three or more people. Your proposal should describe how you will engage the audience during the session.",
-    "conference-2018.sessionItem4": "Ignite talk (5 minutes). Share what you've been doing in a short, lively presentation.",
+    "conference-2018.sessionItem1": "<b>Poster/demonstration (90 minutes)</b>. Show off your project in an exhibition setting, alongside other presenters. You will be provided with display space for a poster and table space for a computer or handouts.",
+    "conference-2018.sessionItem2": "<b>Hands-on workshop (90 minutes)</b>. Engage participants in hands-on activities, highlighting new ways of creating and collaborating with Scratch.",
+    "conference-2018.sessionItem3": "<b>Interactive panel (60 minutes)</b>. Discuss a Scratch-related topic in a panel with three or more people. Your proposal should describe how you will engage the audience during the session.",
+    "conference-2018.sessionItem4": "<b>Ignite talk (5 minutes)</b>. Share what you've been doing in a short, lively presentation.",
 
+    "conference-2018.proposal": " Submit Your Proposal",
     "conference-2018.proposalDeadline": "Deadline for proposals: February 5",
     "conference-2018.proposalAccept": "Notification of acceptance: March 1",
 

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -1,38 +1,25 @@
 {
-    "conference-2017.title": "Scratch Conferences 2017",
-    "conference-2017.desc": "This year, in celebration of Scratch’s 10th anniversary, the global Scratch community will host regional Scratch conferences in many cities around the world.",
-    "conference-2017.seeBelow": "Learn more about conference dates and locations below.",
+    "conference-2018.title": "Scratch Conference 2018: The Next Generation",
+    "conference-2018.desc": "July 26-28, 2018 | Cambridge, MA, USA",
+    "conference-2018.seeBelow": "Learn more about conference dates and locations below.",
 
-    "conference-2017.date": "Date",
-    "conference-2017.location": "Location",
-    "conference-2017.audience": "Audience",
-    "conference-2017.language": "Language",
-    "conference-2017.website": "Visit Website",
-    
-    "conference-2017.franceTitle": "Scratch2017BDX",
-    "conference-2017.franceSubTitle": "Opening, Inspiring, Connecting",
-    "conference-2017.franceDesc": "Scratch2017BDX is an opportunity to meet people and share ideas, and to be inspired and inspiring. It's a global fest to celebrate creativity and enjoy discoveries and understanding about Scratch and beyond.",
-    "conference-2017.franceAudience": "Global Scratch family",
-    
-    "conference-2017.brasilTitle": "Conferência Scratch Brasil 2017",
-    "conference-2017.brasilDesc": "The Scratch Brazil Conference 2017 will be a meeting point for Brazilian educators, researchers, developers and makers who are interested in creating, sharing and learning with Scratch. The conference will foster discussions about the use of Scratch in and out of the classroom, creative computing, Scratch extensions, and other important themes related to Scratch's adoption in Brazil. We are planning something very participatory, with lots of hands-on workshops, poster sessions and opportunities for collaboration.",
-    "conference-2017.brasilAudience": "Educators, researchers, developers, and makers",
-    
-    "conference-2017.hungaryTitle": "Scratch 2017 @ Budapest",
-    "conference-2017.hungaryDesc": "The Scratch Conference in Budapest is a unique opportunity to meet our extended Scratch family and grow and inspire each other. It is a space to revel in creative thinking and coding, to dive in and share in all the diverse possibilities we have found. We are change agents — tried and true geeks in our genes — and we look forward to rolling up our shirt sleeves and having some “hard-fun”. Truly in this sphere, the outlook for the future is bright and we are excited. Come, meet, and collaborate with other members of the Scratch community.",
-    "conference-2017.hungaryAudience": "Teachers, educators, foundations",
-    
-    "conference-2017.chileTitle": "Scratch al Sur 2017",
-    "conference-2017.chileSubTitle": "Imaginando, creando, compartiendo",
-    "conference-2017.chileDesc": "Scratch al Sur 2017 is an opportunity to learn about the importance of introducing programming languages in schools. All lectures and workshops will provide an opportunity to share different experiences, from higher levels to those who are beginning to participate in Scratch's global community.",
-    "conference-2017.chileAudience": "School teachers, principals, education administrators, researchers, and information technology professionals",
-    
-    "conference-2017.chinaTitle": "Scratch Conference: China*Love",
-    "conference-2017.chinaDesc": "Join us for a gathering to support creative expression with Scratch in China. Share ways to promote learning with passion for programming, animation, community, and life.",
-    "conference-2017.chinaAudience": "Educators, parents, developers, makers",
+    "conference-2018.date": "When:",
+    "conference-2018.location": "Where:",
 
-    "conference-2017.costaricaTitle": "Scratch Conference Costa Rica",
-    "conference-2017.costaricaSubTitle": "People, Projects, and Places",
-    "conference-2017.costaricaDesc": "Scratch Conference Costa Rica is a global event taking place at a community level that unites teachers, students, businesses, and leaders, so that coding and design is part of every child's education, starting with Scratch.",
-    "conference-2017.costaricaAudience": "Scratch users, teachers, college professors, potential Scratchers, university students (future teachers and software developers) in Costa Rica and Spanish-speaking Latin America"
+    "conference-2018.desc": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.<br /> <br />We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration.",
+
+    "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
+    "conference-2018.sessionItem1": "Poster/demonstration (90 minutes). Show off your project in an exhibition setting, alongside other presenters. You will be provided with display space for a poster and table space for a computer or handouts.",
+    "conference-2018.sessionItem2": "Hands-on workshop (90 minutes). Engage participants in hands-on activities, highlighting new ways of creating and collaborating with Scratch.",
+    "conference-2018.sessionItem3": "Interactive panel (60 minutes). Discuss a Scratch-related topic in a panel with three or more people. Your proposal should describe how you will engage the audience during the session.",
+    "conference-2018.sessionItem4": "Ignite talk (5 minutes). Share what you've been doing in a short, lively presentation.",
+
+    "conference-2018.proposalDeadline": "Deadline for proposals: February 5",
+    "conference-2018.proposalAccept": "Notification of acceptance: March 1",
+
+    "conference-2018.registrationTitle": "Registration:",
+    "conference-2018.registrationEarly": "Early Bird Registration (March 1-May 1): $200",
+    "conference-2018.registrationStandard": "Standard Registration (after May 1): $300",
+
+    "conference-2018.questions": "Questions? Contact the Scratch Team at <a href="mailto:conference@scratch.mit.edu">conference@scratch.mit.edu</a>"
 }


### PR DESCRIPTION
Fixes #1633 
Adds the following:
New Copy (italics = instructions not copy):

Title: Scratch Conference 2018: The Next Generation (replaces Scratch Conferences 2017)
Sub-title: July 26-28, 2018 | Cambridge, MA, USA (replaces 'This year, in celebration...')

[Drop the lighter blue banner 'Learn more about conference dates and locations below.']

Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.

We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration.

[use date and location styling from current site:]
When: July 26-28, 2018 (with opening reception the evening of July 25)
Where: MIT Media Lab, Cambridge, MA

Interested in offering a session? We invite four types of proposals:

Poster/demonstration (90 minutes). Show off your project in an exhibition setting, alongside other presenters. You will be provided with display space for a poster and table space for a computer or handouts.

Hands-on workshop (90 minutes). Engage participants in hands-on activities, highlighting new ways of creating and collaborating with Scratch.

Interactive panel (60 minutes). Discuss a Scratch-related topic in a panel with three or more people. Your proposal should describe how you will engage the audience during the session.

Ignite talk (5 minutes). Share what you've been doing in a short, lively presentation.

Button: Submit Your Proposal
[link to https://docs.google.com/forms/d/e/1FAIpQLSd7SkuQ-dfW-P3aArSQokK9GkKAUKufTVBHod_ElNIiFE9iBQ/viewform?usp=sf_link]

Deadline for proposals: February 5
Notification of acceptance: March 1

Registration:
Early Bird Registration (March 1-May 1): $200
Standard Registration (after May 1): $300

Questions? Contact the Scratch Team at conference@scratch.mit.edu

to the page.