### PR TITLE
Fixes #1674 - Add Learning Resource designer

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -54,6 +54,14 @@ var Jobs = React.createClass({
                                     MIT Media Lab, Cambridge, MA
                                 </span>
                             </li>
+                            <li>
+                                <a href="https://www.media.mit.edu/about/job-opportunities/learning-resources/">
+                                    Learning Resource Designer
+                                </a>
+                                <span>
+                                    MIT Media Lab, Cambridge, MA
+                                </span>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Adds:
 "Learning Resource Designer, MIT Media Lab, Cambridge, MA" to list of jobs
Link: https://www.media.mit.edu/about/job-opportunities/learning-resources/