### PR TITLE
Don't use eval devtool in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ routes.forEach(function (route) {
 // Config
 module.exports = {
     entry: entry,
-    devtool: 'eval',
+    devtool: process.env.NODE_ENV === 'production' ? 'none' : 'eval',
     output: {
         path: path.resolve(__dirname, 'build'),
         filename: 'js/[name].bundle.js'


### PR DESCRIPTION
#1684 

This will save *[an alot](http://4.bp.blogspot.com/_D_Z-D2tzi14/S8TRIo4br3I/AAAAAAAACv4/Zh7_GcMlRKo/s1600/ALOT.png)* of bandwidth and parsing time. Also Uglify works much better on code that isn't in strings.

Before:
<img width="480" alt="image" src="https://user-images.githubusercontent.com/3819625/33286600-e1031db8-d383-11e7-8777-8c65a1643284.png">
After:
<img width="659" alt="image" src="https://user-images.githubusercontent.com/3819625/33286914-e9b27660-d384-11e7-9169-64b4c82ee328.png">

This should be tagged "performance," but I don't have the permissions to do so.