### PR TITLE
[Master] Ignore querystring when routing conference page 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
 - '4.2'
 sudo: required
+group: deprecated-2017Q4
 cache:
   directories:
   - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages

--- a/src/routes.json
+++ b/src/routes.json
@@ -43,7 +43,7 @@
     },
     {
         "name": "conference-index",
-        "pattern": "^/conference/?$",
+        "pattern": "^/conference/?(\\?.*)?$",
         "routeAlias": "/conference(?!/201[4-5])",
         "view": "conference/2018/index/index",
         "title": "Scratch Conference",


### PR DESCRIPTION
Currently deployed for testing.

There was an issue building with the new Travis image, so that is what the `group:` in `.travis.yml` is for.