### PR TITLE
Add Changes to scratch conf website (#1746)

### DIFF
--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -79,7 +79,7 @@ var ConferenceSplash = React.createClass({
                             </tbody>
                         </table>
                         <p>
-                        <FormattedMessage id='conference-2018.registrationDate' />
+                            <FormattedMessage id='conference-2018.registrationDate' />
                         </p>
                     </section>
                     <section className='conf2018-panel'>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -78,7 +78,9 @@ var ConferenceSplash = React.createClass({
                                 </tr>
                             </tbody>
                         </table>
+                        <p>
                         <FormattedMessage id='conference-2018.registrationDate' />
+                        </p>
                     </section>
                     <section className='conf2018-panel'>
                         <p className='conf2018-panel-desc'>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -78,6 +78,7 @@ var ConferenceSplash = React.createClass({
                                 </tr>
                             </tbody>
                         </table>
+                        <FormattedMessage id='conference-2018.registrationDate' />
                     </section>
                     <section className='conf2018-panel'>
                         <p className='conf2018-panel-desc'>

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -10,9 +10,8 @@
     "conference-2018.location": "Where:",
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
-    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.",
-  		  
-     "conference-2018.registrationTime": "Registration opens March 1, 2018.",
+    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.
+    "conference-2018.registrationTime": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
     "conference-2018.sessionItem1Title": "Poster/demonstration (90 minutes).",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -11,7 +11,7 @@
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
     "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.",
-    "conference-2018.registrationdate": "Registration opens March 1, 2018.",
+    "conference-2018.registrationDate": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
     "conference-2018.sessionItem1Title": "Poster/demonstration (90 minutes).",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -11,6 +11,7 @@
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
     "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration.",
+    "conference-2018.desc3": "The conference is intended primarily for adults who support young people learning Scratch."
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
     "conference-2018.sessionItem1Title": "Poster/demonstration (90 minutes).",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -10,8 +10,7 @@
     "conference-2018.location": "Where:",
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
-    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.
-    
+    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.,"
     "conference-2018.registrationTime": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -11,6 +11,7 @@
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
     "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.
+    
     "conference-2018.registrationTime": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -10,8 +10,9 @@
     "conference-2018.location": "Where:",
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
-    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration.",
-    "conference-2018.desc3": "The conference is intended primarily for adults who support young people learning Scratch."
+    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.",
+  		  
+     "conference-2018.registrationTime": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
     "conference-2018.sessionItem1Title": "Poster/demonstration (90 minutes).",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -10,7 +10,7 @@
     "conference-2018.location": "Where:",
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
-    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.,"
+    "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.",
     "conference-2018.registrationTime": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",

--- a/src/views/conference/2018/index/l10n.json
+++ b/src/views/conference/2018/index/l10n.json
@@ -11,7 +11,7 @@
 
     "conference-2018.desc1": "Join us for the Scratch@MIT conference, a playful gathering of educators, researchers, developers, and other members of the worldwide Scratch community.",
     "conference-2018.desc2": "We're planning a very participatory conference, with an entire day of hands-on workshops and lots of opportunities for peer-to-peer discussion and collaboration. The conference is intended primarily for adults who support young people learning Scratch.",
-    "conference-2018.registrationTime": "Registration opens March 1, 2018.",
+    "conference-2018.registrationdate": "Registration opens March 1, 2018.",
 
     "conference-2018.sessionDesc": "Interested in offering a session? We invite four types of proposals:",
     "conference-2018.sessionItem1Title": "Poster/demonstration (90 minutes).",


### PR DESCRIPTION
### Resolves:

Fixes The Changes Requsted In issue #1746 

### Changes:


*/ Add  extra desc   to desc2 `The conference is intended primarily for adults who support young people learning Scratch.` in #L13 <br>
*/ Adding a new section in jsx, a new corresponding section to the l10n file with the Registration opens March 1, 2018. text.

### Test Coverage:

I used NPM start and test, i can't show a screenshot, because my screenshot is not working. I used it today 
(december 23th 2017) and used my freind coumpter, who lives far away from me! )
I used NPM because @thisandagain Told me! :D

# Notes

[![Build Status](https://travis-ci.org/LLK/scratch-www.svg?branch=develop)](https://travis-ci.org/LLK/scratch-www)