### PR TITLE
Hide Firefox focus ring on <select> elements (language selector)

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -12,6 +12,7 @@
         border: 1px solid $active-gray;
         border-radius: 5px;
         background: $ui-light-gray url("../../../static/svgs/forms/carot.svg") no-repeat right center;
+        color: $type-gray;
         padding-right: 4rem;
         width: 100%;
         height: 3rem;
@@ -32,6 +33,11 @@
         &:focus {
             outline: none;
             border: 1px solid $ui-blue;
+        }
+
+        &:-moz-focusring {
+            color: transparent;
+            text-shadow: 0 0 0 $type-gray;
         }
 
         &:focus,

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -7,7 +7,7 @@
     }
 
     select {
-        transition: all .5s ease;
+        transition: border .5s ease;
         margin-bottom: .75rem;
         border: 1px solid $active-gray;
         border-radius: 5px;
@@ -30,7 +30,6 @@
         }
 
         &:focus {
-            transition: all .5s ease;
             outline: none;
             border: 1px solid $ui-blue;
         }

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -12,11 +12,11 @@
         border: 1px solid $active-gray;
         border-radius: 5px;
         background: $ui-light-gray url("../../../static/svgs/forms/carot.svg") no-repeat right center;
-        color: $type-gray;
         padding-right: 4rem;
         width: 100%;
         height: 3rem;
         text-indent: 1rem;
+        color: $type-gray;
         font-size: .875rem;
         appearance: none;
 
@@ -36,8 +36,8 @@
         }
 
         &:-moz-focusring {
-            color: transparent;
             text-shadow: 0 0 0 $type-gray;
+            color: transparent;
         }
 
         &:focus,


### PR DESCRIPTION
### Resolves:

Fixes the old issue #711.

### Changes:

I don't know why commit 007bb54bf17d62577e85317778db48af4b023656 is in this PR, but it doesn't make any changes.

Quoting the two commit messages:

> Only transition border property since it's the only property which actually animates. (The background image also changes on hover/focus, but that isn't visually effected by transition, so we [don't transition] it.) This is for the next commit. Without this, the focus ring slowly disappears, and the text slowly becomes the color it's meant to be; neither of those are good.

> Hide Firefox focus ring, per [this StackOverflow answer](https://stackoverflow.com/a/18853002/4633828). This isn't a perfect fix - we have to set `color` explicitly, rather than use `inherit`, because we want the text color to be the same when the select element is focused. That means both `color` and `text-shadow`'s color have to be explicitly set to the same thing (otherwise they might not match). Yay, hacks!

### Test Coverage:

Tested locally. The language selector in the site footer appears as expected (no focus ring). Strangely, the "explore" page's selector isn't affected this at all (even though it's also a `<Select>` element).
