### PR TITLE
Add a closing paren

### DIFF
--- a/src/views/about/l10n.json
+++ b/src/views/about/l10n.json
@@ -23,7 +23,7 @@
     "about.schoolsDescription": "Students are learning with Scratch at all levels (from elementary school to college) and across disciplines (such as math, computer science, language arts, social studies). Educators share stories, exchange resources, ask questions, and find people on the {scratchedLink}.",
     "about.scratchedLinkText": "ScratchEd website",
     "about.research": "Research",
-    "about.researchDescription": "The MIT Scratch Team and collaborators are researching how people use and learn with Scratch (for an introduction, see {spfaLink}. Find out more about Scratch {researchLink} and {statisticsLink} about Scratch.",
+    "about.researchDescription": "The MIT Scratch Team and collaborators are researching how people use and learn with Scratch (for an introduction, see {spfaLink}). Find out more about Scratch {researchLink} and {statisticsLink} about Scratch.",
     "about.spfaLinkText": "Scratch: Programming for All",
     "about.researchLinkText": "research",
     "about.statisticsLinkText": "statistics",


### PR DESCRIPTION
Translators can’t translate a string with unbalanced paren’s.

