### PR TITLE
Fixes #1808 | Updates scratch press link to point to Scratch Foundation Media Kit.

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -88,7 +88,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="http://wiki.scratch.mit.edu/wiki/Scratch_Press">
+                        <a href="https://www.scratchfoundation.org/media-kit/">
                             <FormattedMessage id="general.press" />
                         </a>
                     </dd>


### PR DESCRIPTION
### Resolves:

Issue #1808 

### Changes:

This updates the link to:
https://www.scratchfoundation.org/media-kit/

Instead of:
https://wiki.scratch.mit.edu/wiki/Scratch_Press

### Test Coverage:
I don't think such a tiny change needs to be tested, but I can if necessary. 
