### PR TITLE
Update wiki link in footer

### DIFF
--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -147,7 +147,7 @@ tap.test('clickDiscussionForumsLink', options, function (t) {
 // SCRATCH WIKI
 tap.test('clickScratchWikiLink', options, function (t) {
     var linkText = 'Scratch Wiki';
-    var expectedUrl = 'https://wiki.scratch.mit.edu/wiki/Scratch_Wiki_Home';
+    var expectedUrl = 'https://en.scratch-wiki.info/wiki/Scratch_Wiki_Home';
     clickFooterLinks(linkText).then( function (url) {
         t.equal(url, expectedUrl);
         t.end();


### PR DESCRIPTION
(Feel free to close if not needed. : ) )

### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/1814.

### Changes:

The URL `https://wiki.scratch.mit.edu/wiki/Scratch_Wiki_Home` was changed to `https://en.scratch-wiki.info/wiki/Scratch_Wiki_Home` (in https://github.com/LLK/scratch-www/blob/develop/test/integration/smoke-testing/test_footer_links.js#L148).

### Test Coverage:

I ran the file and the other footer link tests still pass. There is one failure, which is this test, because the link in the footer has not yet been updated to the new URL. In the reporting for the test failure, you can see that the old URL was the one found, and the new URL is the one the test is now looking for. (The other tests in this file pass, and I did not make any changes to any other files.)
<img width="840" alt="screen shot 2018-02-18 at 9 29 04 am" src="https://user-images.githubusercontent.com/1320456/36353061-86d9b048-148f-11e8-9d40-e02e09f3d85a.png">

