### PR TITLE
Fix gh-1825: Remove filled jobs

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -28,40 +28,8 @@ const Jobs = () => (
                 <h3><FormattedMessage id="jobs.openings" /></h3>
                 <ul>
                     <li>
-                        <a href="https://www.media.mit.edu/about/job-opportunities/web-designer-scratch/">
-                            Designer
-                        </a>
-                        <span>
-                            MIT Media Lab, Cambridge, MA
-                        </span>
-                    </li>
-                    <li>
                         <a href="https://www.media.mit.edu/about/job-opportunities/full-stack-engineer-lifelong-kindergarten/">
                             Full Stack Engineer
-                        </a>
-                        <span>
-                            MIT Media Lab, Cambridge, MA
-                        </span>
-                    </li>
-                    <li>
-                        <a href="https://www.media.mit.edu/about/job-opportunities/learning-resources/">
-                            Learning Resource Designer
-                        </a>
-                        <span>
-                            MIT Media Lab, Cambridge, MA
-                        </span>
-                    </li>
-                    <li>
-                        <a href="https://www.media.mit.edu/about/job-opportunities/qa-engineer-scratch/">
-                            QA Engineer
-                        </a>
-                        <span>
-                            MIT Media Lab, Cambridge, MA
-                        </span>
-                    </li>
-                    <li>
-                        <a href="https://www.media.mit.edu/about/job-opportunities/senior-backend-engineer-scratch-1/">
-                            Senior Backend Engineer
                         </a>
                         <span>
                             MIT Media Lab, Cambridge, MA


### PR DESCRIPTION
### Resolves:
#1825 - Remove filled listings from `/jobs/`

### Changes:

Removed: Designer, Learning Resource Designer, QA Engineer, Senior Backend Engineer

### Test Coverage:

- [ ] The job listings for Designer, Learning Resource Designer, QA Engineer, Senior Backend Engineer should now all be removed from the `/jobs/` page.
