### PR TITLE
Initial GUI embed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 ESLINT=./node_modules/.bin/eslint
-NODE=node
+NODE= NODE_OPTIONS=--max_old_space_size=8000 node
 SASSLINT=./node_modules/.bin/sass-lint -v
 S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600
 TAP=./node_modules/.bin/tap
-WATCH=./node_modules/.bin/watch
-WEBPACK=./node_modules/.bin/webpack
+WATCH= NODE_OPTIONS=--max_old_space_size=8000 ./node_modules/.bin/watch
+WEBPACK= NODE_OPTIONS=--max_old_space_size=8000 ./node_modules/.bin/webpack
 
 # ------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
+    "scratch-gui": "0.1.0-prerelease.20180413202757",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20180413202757",
+    "scratch-gui": "0.1.0-prerelease.20180427201459",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",

--- a/src/routes.json
+++ b/src/routes.json
@@ -193,7 +193,7 @@
     },
     {
         "name": "preview",
-        "pattern": "^/preview/?(\\d+)?/?$",
+        "pattern": "^/preview/(*)/?$",
         "routeAlias": "/preview/?$",
         "view": "preview/preview",
         "title": "Scratch 3.0 Preview"

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -6,6 +6,9 @@ const React = require('react');
 const Formsy = require('formsy-react').default;
 const classNames = require('classnames');
 
+const GUI = require('scratch-gui').default;
+const IntlGUI = injectIntl(GUI);
+
 const sessionActions = require('../../redux/session.js');
 const decorateText = require('../../lib/decorate-text.jsx');
 const FlexRow = require('../../components/flex-row/flex-row.jsx');
@@ -25,8 +28,10 @@ const PreviewPresentation = props => {
         faved,
         favoriteCount,
         intl,
+        isFullScreen,
         loved,
         loveCount,
+        projectId,
         projectInfo,
         remixes,
         sessionStatus,
@@ -34,6 +39,7 @@ const PreviewPresentation = props => {
         user,
         onFavoriteClicked,
         onLoveClicked,
+        onSeeInside,
         onUpdate
         // ...otherProps TBD
     } = props;
@@ -93,15 +99,23 @@ const PreviewPresentation = props => {
                                         Remix
                                     </button>
                                 }
-                                <button className="button see-inside-button">
+                                <button 
+                                    className="button see-inside-button"
+                                    onClick={onSeeInside}
+                                >
                                     See Inside
                                 </button>
                             </div>
                         </FlexRow>
                         <FlexRow className="preview-row">
-                            <div className="placeholder">
-                                <img src={placeholder} />
-                            </div>
+                            <IntlGUI
+                                basePath="/"
+                                className="guiPlayer"
+                                isFullScreen={isFullScreen}
+                                isPlayerOnly={true}
+                                previewInfoVisible="false"
+                                projectId={projectId}
+                            />
                             <FlexRow className="project-notes">
                                 {shareDate && (
                                     <div className="share-date">
@@ -286,10 +300,12 @@ PreviewPresentation.propTypes = {
     faved: PropTypes.bool,
     favoriteCount: PropTypes.number,
     intl: intlShape,
+    isFullScreen: PropTypes.bool,
     loveCount: PropTypes.number,
     loved: PropTypes.bool,
     onFavoriteClicked: PropTypes.func,
     onLoveClicked: PropTypes.func,
+    onSeeInside: PropTypes.func,
     onUpdate: PropTypes.func,
     projectInfo: PropTypes.shape({
         id: PropTypes.number,

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -14,7 +14,6 @@ const decorateText = require('../../lib/decorate-text.jsx');
 const FlexRow = require('../../components/flex-row/flex-row.jsx');
 const Avatar = require('../../components/avatar/avatar.jsx');
 const CappedNumber = require('../../components/cappednumber/cappednumber.jsx');
-const placeholder = require('./gui-placeholder.png');
 const ShareBanner = require('../../components/share-banner/share-banner.jsx');
 const ThumbnailColumn = require('../../components/thumbnailcolumn/thumbnailcolumn.jsx');
 const InplaceInput = require('../../components/forms/inplace-input.jsx');
@@ -99,7 +98,7 @@ const PreviewPresentation = props => {
                                         Remix
                                     </button>
                                 }
-                                <button 
+                                <button
                                     className="button see-inside-button"
                                     onClick={onSeeInside}
                                 >
@@ -109,10 +108,10 @@ const PreviewPresentation = props => {
                         </FlexRow>
                         <FlexRow className="preview-row">
                             <IntlGUI
+                                isPlayerOnly
                                 basePath="/"
                                 className="guiPlayer"
                                 isFullScreen={isFullScreen}
-                                isPlayerOnly={true}
                                 previewInfoVisible="false"
                                 projectId={projectId}
                             />
@@ -307,6 +306,7 @@ PreviewPresentation.propTypes = {
     onLoveClicked: PropTypes.func,
     onSeeInside: PropTypes.func,
     onUpdate: PropTypes.func,
+    projectId: PropTypes.number,
     projectInfo: PropTypes.shape({
         id: PropTypes.number,
         title: PropTypes.string,

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -1,21 +1,21 @@
 @import "../../colors";
 @import "../../frameless";
 
-html,
-body,
-#app,
-.gui {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-}
-
 /* override view padding for share banner */
 #view {
     padding: 0 0 20px 0;
 }
 
-.gui * { box-sizing: border-box; }
+.gui {
+    margin: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 11;
+}
+
+// .gui * { box-sizing: border-box; }
 
 .preview {
     
@@ -162,13 +162,9 @@ body,
         align-items: flex-start;
     }
 
-    .placeholder {
+    .guiPlayer {
         display: inline-block;
         width: 480px;
-    }
-
-    .placeholder img {
-        width: 100%;
     }
 
     .project-notes {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -7,18 +7,18 @@
 }
 
 .gui {
-    margin: 0;
     position: absolute;
     top: 0;
+    z-index: 11;
+    margin: 0;
     width: 100%;
     height: 100%;
-    z-index: 11;
 }
 
 // .gui * { box-sizing: border-box; }
 
 .preview {
-    
+
     .project-title {
         font-size: 1.75rem;
         font-weight: 500;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,21 @@ module.exports = {
         new CopyWebpackPlugin([
             {from: 'static'},
             {from: 'intl', to: 'js'}
-        ])
+        ]),
+        new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-gui/dist/static/blocks-media',
+            to: 'static/blocks-media'
+        }]),
+        new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-gui/dist/extension-worker.js'
+        }]),
+        new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-gui/dist/extension-worker.js.map'
+        }]),
+        new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-gui/dist/static/assets',
+            to: 'static/assets'
+        }])
     ])
         .concat(process.env.NODE_ENV === 'production' ? [
             new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
### Resolves:

Fixes #1773, and most of #1799 

### Changes:

- `/preview/editor` will load GUI with an empty project
- `/preview/:id/editor` will load GUI with a project from the projects server (not local data)
- `/preview/:id` loads a Scratch 2 project with just the player from GUI
- can switch in/out of full screen mode for both player and editor
- passes intl object to GUI


