### PR TITLE
Remove references to Linux for the Scratch 2.0 offline editor

### DIFF
--- a/src/components/news/news.json
+++ b/src/components/news/news.json
@@ -2,7 +2,7 @@
     {
         "id": 128283902498,
         "headline": "Update to Scratch Offline Editor",
-        "copy": "We’ve released an update to Offline Editor which fixed bugs affecting Linux users.",
+        "copy": "We’ve released an update to Offline Editor which fixed bugs affecting Windows users.",
         "url": "https://scratch.mit.edu/news#128283902498",
         "image": "https://33.media.tumblr.com/695b93f4ab74c68feaef1fe03baebdd5/tumblr_inline_n0xubtT0vU1szpavb.png"
     },

--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -55,8 +55,7 @@ class Download extends React.Component {
             downloadUrls = {
                 mac: `${downloadPath}${this.state.swfVersion}.dmg`,
                 mac105: `${downloadPath}${this.state.swfVersion}.air`,
-                windows: `${downloadPath}${this.state.swfVersion}.exe`,
-                linux: `${downloadPath}${this.state.swfVersion}.air`
+                windows: `${downloadPath}${this.state.swfVersion}.exe`
             };
         }
 
@@ -143,12 +142,6 @@ class Download extends React.Component {
                                                 <FormattedMessage id="download.download" />
                                             </a>
                                         </li>
-                                        <li className="installation-downloads-item">
-                                            <FormattedMessage id="download.linux" /> -
-                                            {' '}<a href="http://airdownload.adobe.com/air/lin/download/2.6/AdobeAIRInstaller.bin">
-                                                <FormattedMessage id="download.download" />
-                                            </a>
-                                        </li>
                                     </ul>
                                 </div>
                                 <div className="installation-column">
@@ -177,12 +170,6 @@ class Download extends React.Component {
                                             <li className="installation-downloads-item">
                                                 <FormattedMessage id="download.windows" /> -
                                                 {' '}<a href={downloadUrls.windows}>
-                                                    <FormattedMessage id="download.download" />
-                                                </a>
-                                            </li>
-                                            <li className="installation-downloads-item">
-                                                <FormattedMessage id="download.linux" /> -
-                                                {' '}<a href={downloadUrls.linux}>
                                                     <FormattedMessage id="download.download" />
                                                 </a>
                                             </li>

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -1,6 +1,6 @@
 {
   "download.title": "Scratch 2.0 Offline Editor",
-  "download.intro": "You can install the Scratch 2.0 editor to work on projects without an internet connection. This version will work on Mac, Windows, and some versions of Linux (32 bit).",
+  "download.intro": "You can install the Scratch 2.0 editor to work on projects without an internet connection. This version will work on Windows and MacOS.",
   "download.introMac": "<b>Note for Mac Users:</b> the latest version of Scratch 2.0 Offline requires Adobe AIR 20. To upgrade to Adobe AIR 20 manually, go <a href=\"https://get.adobe.com/air/\">here</a>.",
   "download.installation": "Installation",
   "download.airTitle": "Adobe AIR",
@@ -8,7 +8,6 @@
   "download.macOSX": "Mac OS X",
   "download.macOlder": "Mac OS 10.5 & Older",
   "download.windows": "Windows",
-  "download.linux": "Linux",
   "download.download": "Download",
   "download.offlineEditorTitle": "Scratch Offline Editor",
   "download.offlineEditorBody": "Next download and install the Scratch 2.0 Offline Editor",


### PR DESCRIPTION
### Resolves:
Resolves GH-1880

### Changes
- Removes references to Linux on the `/download` view
- Removes reference to Linux on the default metadata for the `news` component (used for testing)

### Details
Removes references to Linux for the Scratch 2.0 Offline Editor. Unfortunately [Adobe stopped supporting Adobe AIR on Linux platforms in 2011](https://helpx.adobe.com/air/kb/install-air-2-64-bit.html). We have continued to provide a version of the Scratch 2.0 Offline Editor since then, but unfortunately more recent versions of Ubuntu and other major distributions of Linux have completely broken AIR compatibility to the point where we need to drop support. Our hope is that the Scratch 3.0 Offline Editor will be able to more sustainably support Linux (via [Electron](https://electronjs.org/)) in the future.