### PR TITLE
Make Selenium Helper function to click element by CSS

### DIFF
--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -30,6 +30,10 @@ const findByCss = (css) => {
     return driver.wait(until.elementLocated(By.css(css), 1000 * 5));
 };
 
+const clickCss = (css) => {
+    return findByCss(css).then(el => el.click());
+};
+
 const getLogs = (whitelist) => {
     return driver.manage()
         .logs()
@@ -65,5 +69,6 @@ module.exports = {
     findText,
     clickButton,
     findByCss,
+    clickCss,
     getLogs
 };


### PR DESCRIPTION
### Resolves:

Sets the helpers up to use Css selectors to locate and click elements in the Selenium tests

### Changes:

Adds a ClickCss function so selenium tests can locate an item by css and then click it in one line
