### PR TITLE
Fix the /about research page link

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -119,7 +119,7 @@ const About = () => (
                         id="about.researchDescription"
                         values={{
                             researchLink: (
-                                <a href="/info/research">
+                                <a href="/research">
                                     <FormattedMessage id="about.researchLinkText" />
                                 </a>
                             ),


### PR DESCRIPTION
### Resolves:

Fixes #1895

### Changes:

Changes the research page link in the /about view from /info/research to /research
