### PR TITLE
Updated link to Scratch Wiki - to new domain

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -67,7 +67,7 @@ const About = () => (
                         id="about.aroundTheWorldDescription"
                         values={{
                             translationLink: (
-                                <a href="http://wiki.scratch.mit.edu/wiki/How_to_Translate_Scratch">
+                                <a href="https://en.scratch-wiki.info/wiki/How_to_Translate_Scratch">
                                     <FormattedMessage id="about.translationLinkText" />
                                 </a>
                             )


### PR DESCRIPTION
### Resolves:

#1898 

### Changes:
Changes the link to old Scratch Wiki domain to new one
### Test Coverage:
See the /about/ page