### PR TITLE
Run smoke tests with Travis after deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - ROOT_URL_VAR=ROOT_URL_$TRAVIS_BRANCH
   - ROOT_URL=${!ROOT_URL_VAR}
   - ROOT_URL=${ROOT_URL:-$ROOT_URL_STAGING}
+  - PATH=$PATH:$PWD/test/integration/node_modules/chromedriver/bin
   # EB_AWS_ACCESS_KEY_ID
   - secure: A138rYuXDsOmpEwYxZ31WyXEeq5fgr9qyqsQh1nTFsjBKpFtNM+CN9e0QJQFT3PLs4wH/lWTRSyHxakxKQS1sxq828f9gHed+f15REKk/fRUplcCYIexT9xKVtU3D8CRNn/KBFWk75fZyZt20eyOVIv4h3pInKQz7y84J6PWzB1BCrAFvADrzS1X68Z3NJJLyxnz0YEurzz8mC2v4D0s/XifKTWvRtefD4QM6pE0C2iYyk+ThrLwg7i9FDHVfo0MrkgcdX7mz37SnTr7p7mHWnGXrGngi/NiDRQ+Uwwq/sr2UIww0rCwS1xsOcS//dC4NNqrrt1kUTsoC1Yt87Ny+gI0nUplsfEpdKajAkOYdANC5bJUGqPdSlOds1v9aJs9Hx48uGamWkm/3cFmoJ5uA2ZzUwbSGjTkWbnhwzT0YRvcLGhP1WE/EswaIyK5qMp522E79mP1yH6M750iUvi4N39+QW1BNX3ADkOwyAI67ArX5on5gWP83RXcJ15im7XsBpsmVn/KXi6AouWPb8jmSmKCj0QZCzfLY7ivM42IugYpK2NV7kFB38DpXQamJ5eskgwYa3elRmednIFUuwb1QDnONvJogVjk4CLmoSxssC2mJnnrUItM7l8G6As81GMI+6lTtl86hAuXBjUk60FMbgTAQDX9ll26LgpBy8jHSx8=
   # EB_AWS_SECRET_ACCESS_KEY
@@ -63,6 +64,7 @@ env:
   - NODE_ENV=production
   - WWW_VERSION=${TRAVIS_COMMIT:0:5}
 addons:
+  chrome: stable
   apt:
     sources:
       - ubuntu-toolchain-r-test
@@ -93,8 +95,9 @@ jobs:
         - master
   - stage: smoke
     install:
-    - cd test/intergration
+    - cd test/integration
     - npm install
+    - cd -
     script: npm run smoke
 stages:
 - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,4 +102,4 @@ jobs:
 stages:
 - test
 - name: smoke
-  if: branch IN (master, develop, travis) and type != pull_request
+  if: branch IN (travis) and type != pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ env:
   - API_HOST_VAR=API_HOST_$TRAVIS_BRANCH
   - API_HOST=${!API_HOST_VAR}
   - API_HOST=${API_HOST:-$API_HOST_STAGING}
+  - ROOT_URL_master=https://scratch.mit.edu
+  - ROOT_URL_STAGING=https://scratch.ly
+  - ROOT_URL_VAR=ROOT_URL_$TRAVIS_BRANCH
+  - ROOT_URL=${!ROOT_URL_VAR}
+  - ROOT_URL=${ROOT_URL:-$ROOT_URL_STAGING}
   # EB_AWS_ACCESS_KEY_ID
   - secure: A138rYuXDsOmpEwYxZ31WyXEeq5fgr9qyqsQh1nTFsjBKpFtNM+CN9e0QJQFT3PLs4wH/lWTRSyHxakxKQS1sxq828f9gHed+f15REKk/fRUplcCYIexT9xKVtU3D8CRNn/KBFWk75fZyZt20eyOVIv4h3pInKQz7y84J6PWzB1BCrAFvADrzS1X68Z3NJJLyxnz0YEurzz8mC2v4D0s/XifKTWvRtefD4QM6pE0C2iYyk+ThrLwg7i9FDHVfo0MrkgcdX7mz37SnTr7p7mHWnGXrGngi/NiDRQ+Uwwq/sr2UIww0rCwS1xsOcS//dC4NNqrrt1kUTsoC1Yt87Ny+gI0nUplsfEpdKajAkOYdANC5bJUGqPdSlOds1v9aJs9Hx48uGamWkm/3cFmoJ5uA2ZzUwbSGjTkWbnhwzT0YRvcLGhP1WE/EswaIyK5qMp522E79mP1yH6M750iUvi4N39+QW1BNX3ADkOwyAI67ArX5on5gWP83RXcJ15im7XsBpsmVn/KXi6AouWPb8jmSmKCj0QZCzfLY7ivM42IugYpK2NV7kFB38DpXQamJ5eskgwYa3elRmednIFUuwb1QDnONvJogVjk4CLmoSxssC2mJnnrUItM7l8G6As81GMI+6lTtl86hAuXBjUk60FMbgTAQDX9ll26LgpBy8jHSx8=
   # EB_AWS_SECRET_ACCESS_KEY
@@ -66,20 +71,32 @@ addons:
 install:
   - sudo -H pip install -r requirements.txt
   - npm --production=false install
-deploy:
-- provider: script
-  skip_cleanup: $SKIP_CLEANUP
-  script: env make sync
-  on:
-    repo: LLK/scratch-www
-    branch:
-    - develop
-    - hotfix/*
-    - release/*
-- provider: script
-  skip_cleanup: $SKIP_CLEANUP
-  script: env make sync
-  on:
-    repo: LLK/scratch-www
-    branch:
-    - master
+jobs:
+  include:
+  - stage: test
+    deploy:
+    - provider: script
+      skip_cleanup: $SKIP_CLEANUP
+      script: env make sync
+      on:
+        repo: LLK/scratch-www
+        branch:
+        - develop
+        - hotfix/*
+        - release/*
+    - provider: script
+      skip_cleanup: $SKIP_CLEANUP
+      script: env make sync
+      on:
+        repo: LLK/scratch-www
+        branch:
+        - master
+  - stage: smoke
+    install:
+    - cd test/intergration
+    - npm install
+    script: npm run smoke
+stages:
+- test
+- name: smoke
+  if: branch IN (master, develop, travis) and type != pull_request

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,5 +1,5 @@
 {
-    "devDependencies": {
+    "dependencies": {
         "selenium-webdriver": "3.6.0",
         "chromedriver": "2.37.0"
     }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,8 +1,24 @@
 var webdriver = require('selenium-webdriver');
 
-const driver = new webdriver.Builder()
-    .forBrowser('chrome')
-    .build();
+const headless = process.env.SMOKE_HEADLESS || false;
+
+const getDriver = function () {
+    const chromeCapabilities = webdriver.Capabilities.chrome();
+    let args = [];
+    if (headless) {
+        args.push('--headless');
+        args.push('window-size=1024,1680');
+        args.push('--no-sandbox');
+    }
+    chromeCapabilities.set('chromeOptions', {args});
+    const newDriver = new webdriver.Builder()
+        .forBrowser('chrome')
+        .withCapabilities(chromeCapabilities)
+        .build();
+    return newDriver;
+};
+
+const driver = getDriver();
 
 const {By, until} = webdriver;
 
@@ -70,5 +86,6 @@ module.exports = {
     clickButton,
     findByCss,
     clickCss,
-    getLogs
+    getLogs,
+    getDriver
 };

--- a/test/integration/smoke-testing/test_project_rows.js
+++ b/test/integration/smoke-testing/test_project_rows.js
@@ -12,9 +12,9 @@ var seleniumWebdriver = require('selenium-webdriver');
 // Selenium's promise driver will be deprecated, so we should not rely on it
 seleniumWebdriver.SELENIUM_PROMISE_MANAGER = 0;
 
-// chrome driver
-var driver = new seleniumWebdriver.Builder().withCapabilities(seleniumWebdriver.Capabilities.chrome())
-    .build();
+const {
+    driver
+} = require('../selenium-helpers.js');
 
 var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 


### PR DESCRIPTION
Sets up Travis to run Selenium smoke tests on the branch Travis.  This includes modifying the selenium helpers to be able to run headless and adding a stage to Travis to run the tests after it builds.

The tests will currently only run on the Travis build as they fail intermittently and shouldn't run on everything until they pass more consistently.  

