### PR TITLE
Fix search bar's handling of special characters

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -45,7 +45,7 @@ class Search extends React.Component {
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = decodeURI(term.split('+').join(' '));
+        term = decodeURIComponent(term.split('+').join(' '));
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {


### PR DESCRIPTION
### Resolves:

Resolves #1224 

### Changes:

`decodeURI` will **only** decode escape sequences that could've been added with `encodeURI`.

`decodeURIComponent` will decode everything it can, even if it's just ASCII punctuation encodings.

That means that when you now search for `cats?`, you will then see the feedback saying `cats?` -- and not `cats%3f`, which can be a little confusing.

### Test Coverage:
The below should test everything

- [X] `?q=%D0%9A%D0%BE%D0%BC%D0%B0%D1%80` should still appear as `Комар`
- [X] **`?q=cat%3Fcat` should now appear as `cat?cat`**
- [X] `?q=cat%20cat` should still appear as `cat cat`
- [X] `?q=CATCAT` should still appear as `cat cat`

All of these manual tests worked.