### PR TITLE
Changed link from /help to /tips

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -141,7 +141,7 @@ const About = () => (
                     <h3><FormattedMessage id="about.learnMore" /></h3>
                     <ul className="list">
                         <li>
-                            <a href="/help"><FormattedMessage id="about.learnMoreHelp" /></a>
+                            <a href="/tips"><FormattedMessage id="about.learnMoreHelp" /></a>
                         </li>
                         <li>
                             <a href="/info/faq"><FormattedMessage id="about.learnMoreFaq" /></a>


### PR DESCRIPTION
### Resolves:
#1909

### Changes:
Changed links from /help to /tips (It's moved in July 2017)

### Test Coverage:
See /about page