### PR TITLE
Change splash to use 30000000

### DIFF
--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -27,7 +27,7 @@ class Splash extends React.Component {
             'shouldShowEmailConfirmation'
         ]);
         this.state = {
-            projectCount: 20000000, // gets the shared project count
+            projectCount: 30000000, // gets the shared project count
             news: [], // gets news posts from the scratch Tumblr
             emailConfirmationModalOpen: false, // flag that determines whether to show banner to request email conf.
             refreshCacheStatus: 'notrequested'


### PR DESCRIPTION
It uses "30000000 projects" by default now!

### Resolves:
#1916 

### Changes:
Changed the default value.

### Test Coverage:
It's difficult to test it, because it has to be without api access.
