### PR TITLE
Pin scratch-gui to `latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20180605163331",
+    "scratch-gui": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
Now that GUI deploys "stable" builds to the `latest` tag, we can pin to latest, so rebuilds pull in the latest stable GUI.
