### PR TITLE
Fix issue with error copy to match new teacher age limit.

### DIFF
--- a/src/views/teacherregistration/l10n.json
+++ b/src/views/teacherregistration/l10n.json
@@ -35,5 +35,5 @@
     "teacherRegistration.emailStepTitle": "Email Address",
     "teacherRegistration.emailStepDescription": "We will send you a confirmation email that will allow you to access your Scratch Teacher Account.",
     "teacherRegistration.validationEmailMatch": "The emails do not match",
-    "teacherRegistration.validationAge": "Sorry, teachers must be at least 13 years old"
+    "teacherRegistration.validationAge": "Sorry, teachers must be at least 16 years old"
 }


### PR DESCRIPTION
### Resolves:

Resolves GH-1929

### Changes:

Fix copy in Teacher Registration error message to match new GDPR policies.