### PR TITLE
Setup Selenium tests to be run with Sauce Labs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "start": "make start",
     "stop": "make stop",
     "test": "make test",
-    "smoke": "make smoke",
+    "smoke": "./node_modules/.bin/tap ./test/integration/smoke-testing/*.js --timeout=3600",
     "smoke-verbose": "make smoke-verbose",
+    "smoke-sauce": "./node_modules/.bin/tap ./test/integration/smoke-testing/*.js --timeout=60000",
     "watch": "make watch",
     "build": "make build",
     "dev": "make watch && make start &"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "start": "make start",
     "stop": "make stop",
     "test": "make test",
-    "smoke": "./node_modules/.bin/tap ./test/integration/smoke-testing/*.js --timeout=3600",
+    "smoke": "tap ./test/integration/smoke-testing/*.js --timeout=3600",
     "smoke-verbose": "make smoke-verbose",
-    "smoke-sauce": "./node_modules/.bin/tap ./test/integration/smoke-testing/*.js --timeout=60000",
+    "smoke-sauce": "tap ./test/integration/smoke-testing/*.js --timeout=60000",
     "watch": "make watch",
     "build": "make build",
     "dev": "make watch && make start &"

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,6 +1,8 @@
 var webdriver = require('selenium-webdriver');
 
 const headless = process.env.SMOKE_HEADLESS || false;
+const remote = process.env.SMOKE_REMOTE || false;
+const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 
 const getDriver = function () {
     const chromeCapabilities = webdriver.Capabilities.chrome();
@@ -18,7 +20,34 @@ const getDriver = function () {
     return newDriver;
 };
 
-const driver = getDriver();
+const getSauceDriver = function (username, accessKey, configs) {
+    let driver = new webdriver.Builder()
+        .withCapabilities({
+            browserName: configs.browserName,
+            platform: configs.platform,
+            version: configs.version,
+            username: username,
+            accessKey: accessKey,
+            name: 'smoke test scratch-www'
+        })
+        .usingServer(`http://${username}:${accessKey
+        }@ondemand.saucelabs.com:80/wd/hub`)
+        .build();
+    return driver;
+};
+// Driver configs can be generated with the Sauce Platform Configurator
+// https://wiki.saucelabs.com/display/DOCS/Platform+Configurator
+const driverConfig = {
+    browserName: 'chrome',
+    platform: 'macOS 10.13',
+    version: '67.0'
+};
+var driver;
+if (remote === 'true'){
+    driver = getSauceDriver(SAUCE_USERNAME, SAUCE_ACCESS_KEY, driverConfig);
+} else {
+    driver = getDriver();
+}
 
 const {By, until} = webdriver;
 
@@ -87,5 +116,6 @@ module.exports = {
     findByCss,
     clickCss,
     getLogs,
-    getDriver
+    getDriver,
+    getSauceDriver
 };

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,4 +1,4 @@
-var webdriver = require('selenium-webdriver');
+const webdriver = require('selenium-webdriver');
 
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
@@ -42,7 +42,7 @@ const driverConfig = {
     platform: 'macOS 10.13',
     version: '67.0'
 };
-var driver;
+let driver;
 if (remote === 'true'){
     driver = getSauceDriver(SAUCE_USERNAME, SAUCE_ACCESS_KEY, driverConfig);
 } else {

--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -11,8 +11,6 @@ const {
     webdriver
 } = require('../selenium-helpers.js');
 
-// Selenium's promise driver will be deprecated, so we should not rely on it
-webdriver.SELENIUM_PROMISE_MANAGER = 0;
 
 const rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 

--- a/test/integration/smoke-testing/test_navbar_links.js
+++ b/test/integration/smoke-testing/test_navbar_links.js
@@ -12,9 +12,6 @@ const {
 } = require('../selenium-helpers.js');
 var tap = require('tap');
 
-// Selenium's promise driver will be deprecated, so we should not rely on it
-webdriver.SELENIUM_PROMISE_MANAGER = 0;
-
 // Set test url through environment variable
 var rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 

--- a/test/integration/smoke-testing/test_project_rows.js
+++ b/test/integration/smoke-testing/test_project_rows.js
@@ -9,9 +9,6 @@ require('chromedriver');
 var tap = require('tap');
 var seleniumWebdriver = require('selenium-webdriver');
 
-// Selenium's promise driver will be deprecated, so we should not rely on it
-seleniumWebdriver.SELENIUM_PROMISE_MANAGER = 0;
-
 const {
     driver
 } = require('../selenium-helpers.js');


### PR DESCRIPTION
### Resolves:

Allows Smoke Tests to be run  with SauceLabs.  

### Changes:

Adds a second function for creating a driver so that it uses Sauce Labs and then checks the environment variable SMOKE_REMOTE to determine which type of driver to make.
Also sets up an package.json to have a smoke-sauce script that sets the timeout to be larger.
