### PR TITLE
Fix notes/instructions layout on Firefox 

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -220,6 +220,7 @@ $stage-height: 404px;
     .description-block {
         display: flex;
         width: 100%;
+        min-height: 0;
         flex-direction: column;
         align-items: flex-start;
         flex: 1;


### PR DESCRIPTION
### Resolves:
This PR resolves #1935.

### Changes:
Firefox implements flexboxes in a way that prevents them from shrinking smaller than their content unless `min-height` is set to 0. This PR adds `min-height: 0` to the `description-block` class to allow the notes and instruction containers to scroll. This change does not affect the behavior on Chrome or Safari.