### PR TITLE
Fix gh-1899: Create Console Warning

### DIFF
--- a/src/components/consolewarning/consolewarning.jsx
+++ b/src/components/consolewarning/consolewarning.jsx
@@ -1,0 +1,16 @@
+const React = require('react');
+
+class ConsoleWarning extends React.Component {
+    constructor (reactIntl) {
+        super();
+        console.log(
+            '%c' + reactIntl.formatMessage({id: 'general.consoleWarningTitle'}),
+            'color: #F00; font-size: 30px; -webkit-text-stroke: 1px black; font-weight:bold'
+        );
+        console.log(reactIntl.formatMessage({id: 'general.consoleWarningDescription'}));
+    }
+
+    render () {
+        return false;
+    }
+}

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -8,6 +8,8 @@
     "general.collaborators": "Collaborators",
     "general.community": "Community",
     "general.confirmEmail": "Confirm Email",
+    "general.consoleWarningTitle": "Stop!",
+    "general.consoleWarningDescription": "This is part of your browser intended for developers. If someone told you to copy-and-paste something here, don't do it! It could allow them to take over your Scratch account, delete all of your projects, or do many other harmful things. If you don't understand what exactly you are doing here, you should close this window without doing anything.",
     "general.contactUs": "Contact Us",
     "general.copyright": "Scratch is a project of the Lifelong Kindergarten Group at the MIT Media Lab",
     "general.country": "Country",


### PR DESCRIPTION
### Resolves: #1899 

### Changes:

Created new component for the console warning. The console warning has localized strings in the general l10n.json file, and uses console.log() to write to the console. (console.log() is currently not permitted in the lint rules, so this may need to be changed)

The resulting console warning should look like this:
![image](https://user-images.githubusercontent.com/13542746/41935274-14ea0a96-7957-11e8-8c22-c3af1d6f09b2.png)
