### PR TITLE
Fix gh-1899: Add Console Warning

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -36,3 +36,23 @@ const Raven = require('raven-js');
 
     window._locale = updateLocale();
 })();
+
+/**
+ * -----------------------------------------------------------------------------
+ * Console warning
+ * -----------------------------------------------------------------------------
+ */
+(() => {
+    window.onload = function () {
+        console.log('%cStop!', 'color: #F00; font-size: 30px; -webkit-text-stroke: 1px black; font-weight:bold');
+        console.log(
+            'This is part of your browser intended for developers. ' +
+            'If someone told you to copy-and-paste something here, ' +
+            'don\'t do it! It could allow them to take over your ' +
+            'Scratch account, delete all of your projects, or do many ' +
+            'other harmful things. If you don\'t understand what exactly ' +
+            'you are doing here, you should close this window without doing ' +
+            'anything.'
+        );
+    };
+})();

--- a/src/init.js
+++ b/src/init.js
@@ -44,6 +44,7 @@ const Raven = require('raven-js');
  */
 (() => {
     window.onload = function () {
+        /* eslint-disable no-console */
         console.log('%cStop!', 'color: #F00; font-size: 30px; -webkit-text-stroke: 1px black; font-weight:bold');
         console.log(
             'This is part of your browser intended for developers. ' +
@@ -54,5 +55,6 @@ const Raven = require('raven-js');
             'you are doing here, you should close this window without doing ' +
             'anything.'
         );
+        /* eslint-enable no-console */
     };
 })();


### PR DESCRIPTION
### Resolves: #1899 

### Changes:

Added `console.log()` calls to be executed on the `window.onload` event, in `init.js`.

### Test Coverage:
Tested on MacOS 10.13.5

Chrome 67.0.3396.87:
<img width="1440" alt="screen shot 2018-06-29 at 09 34 44" src="https://user-images.githubusercontent.com/13542746/42095525-dd3e32c6-7b80-11e8-843c-b740fbed1fc1.png">

Firefox 59.0.2:
<img width="1440" alt="screen shot 2018-06-29 at 09 35 12" src="https://user-images.githubusercontent.com/13542746/42095554-f0aa47c8-7b80-11e8-945a-b81b74d8afdb.png">

Safari 11.1.1:
<img width="1440" alt="screen shot 2018-06-29 at 09 37 40" src="https://user-images.githubusercontent.com/13542746/42095593-04fd1606-7b81-11e8-9fa3-cef2790cca46.png">
