### PR TITLE
Fix gh-1962: Update footer wiki link

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -108,7 +108,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="https://wiki.scratch.mit.edu/">
+                        <a href="https://en.scratch-wiki.info/">
                             <FormattedMessage id="general.wiki" />
                         </a>
                     </dd>


### PR DESCRIPTION
### Resolves: #1962 

### Changes:

Changed link in footer component from https://wiki.scratch.mit.edu to https://en.scratch-wiki.info/
