### PR TITLE
Update to track changes in docker-compose behavior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: scratch-www-app
     environment:
       - API_HOST=http://localhost:8491
-      - FALLBACK=http://scratchr2-app:8080
+      - FALLBACK=http://localhost:8080
     build:  
       context: ./
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
   intl_data:
 
 networks:
-  scratchapi_scratch_network:
+  scratch-api_scratch_network:
     external: true
 
 services:
@@ -37,4 +37,4 @@ services:
     ports:
       - "8333:8333"
     networks:
-      - scratchapi_scratch_network
+      - scratch-api_scratch_network


### PR DESCRIPTION
docker-compose no longer strips `-` from the project name, which makes `scratchapi` now `scratch-api` when referencing the network.

### Resolves:

A change introduced by updates to `docker-compose`

### Changes:

Updates the named network when performing local development

### Test Coverage:

N/A