### PR TITLE
Remove extra characters from preview faq routeAlias

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -214,7 +214,7 @@
     {
         "name": "preview-faq-redirect",
         "pattern": "^/preview-faq/?$",
-        "routeAlias": "/preview-faq/?$",
+        "routeAlias": "/preview-faq",
         "redirect": "/3faq"
     },
     {


### PR DESCRIPTION
This PR fixes an issue with the /preview-faq -> /3faq redirect by removing `/?$` from the end of the routeAlias for the preview faq redirect route.