### PR TITLE
Added Community Moderator job listing

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -35,6 +35,14 @@ const Jobs = () => (
                             MIT Media Lab, Cambridge, MA
                         </span>
                     </li>
+                    <li>
+                        <a href="https://scratch.mit.edu/jobs/moderator">
+                            Community Moderator
+                        </a>
+                        <span>
+                            Remote
+                        </span>
+                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
### Resolves:

Resolves #1972 

### Changes:

Adds the "Community Moderator" job listing. The location is listed as "Remote".

### Test Coverage:

I tested it *in my miiiiiind*
