### PR TITLE
watchOptions required for use in docker environment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ intl/*
 locales/*
 **/*.min.js
 **/node_modules/*
+scratch-gui/*

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test:
 	@make tap
 
 lint:
-	$(ESLINT) . --ext .js,.jsx,.json
+	$(ESLINT) --ignore-pattern scratch-gui --ignore-pattern node_modules . --ext .js,.jsx,.json
 	$(SASSLINT) ./src/*.scss
 	$(SASSLINT) ./src/**/*.scss
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test:
 	@make tap
 
 lint:
-	$(ESLINT) --ignore-pattern scratch-gui --ignore-pattern node_modules . --ext .js,.jsx,.json
+	$(ESLINT) . --ext .js,.jsx,.json
 	$(SASSLINT) ./src/*.scss
 	$(SASSLINT) ./src/**/*.scss
 

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -21,15 +21,18 @@ routes.forEach(route => {
     app.get(route.pattern, handler(route));
 });
 
-app.use(webpackDevMiddleware(compiler,
-    {
+var middlewareOptions = {};
+if (process.env.USE_DOCKER_WATCHOPTIONS) {
+    middlewareOptions = {
         watchOptions: {
             aggregateTimeout: 500,
             poll: 2500,
             ignored: ['node_modules','build']
         }
-    }
-));
+    };
+}
+
+app.use(webpackDevMiddleware(compiler, middlewareOptions));
 
 var proxyHost = process.env.FALLBACK || '';
 if (proxyHost !== '') {

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -27,7 +27,7 @@ if (process.env.USE_DOCKER_WATCHOPTIONS) {
         watchOptions: {
             aggregateTimeout: 500,
             poll: 2500,
-            ignored: ['node_modules','build']
+            ignored: ['node_modules', 'build']
         }
     };
 }

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -21,7 +21,15 @@ routes.forEach(route => {
     app.get(route.pattern, handler(route));
 });
 
-app.use(webpackDevMiddleware(compiler));
+app.use(webpackDevMiddleware(compiler,
+    {
+        watchOptions: {
+            aggregateTimeout: 500,
+            poll: 2500,
+            ignored: ['node_modules','build']
+        }
+    }
+));
 
 var proxyHost = process.env.FALLBACK || '';
 if (proxyHost !== '') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - API_HOST=http://localhost:8491
       - FALLBACK=http://localhost:8080
+      - USE_DOCKER_WATCHOPTIONS=true
     build:  
       context: ./
       dockerfile: Dockerfile


### PR DESCRIPTION
By default, webpack-dev-middleware is supposed to be watching for changes in the local source files, but in practice this seems to not be the case in docker containers, as fsevents are not passed through the NFS mount into a container and it requires explicit polling to enable watching for changes.

This will work in both docker and outside of docker, and tunes the load on a docker container running webpack to not overly burden a local host’s cpu watching for changes. 

### Resolves:

#1974 - Docker does not re-compile on changes

### Changes:

This updates `dev-server/index.js` to specify `watchOptions`. These options include a polling interval of 2500ms and aggregate changes in a 500ms window.  See also: https://webpack.js.org/configuration/watch/

### Test Coverage:

N/A