### PR TITLE
Add brycedtea to Credits page

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -176,6 +176,14 @@ const Credits = () => (
 
             <li>
                 <img
+                    alt="Bryce Avatar"
+                    src="//cdn.scratch.mit.edu/get_image/user/2029640_170x170.png"
+                />
+                <span className="name">Bryce Taylor</span>
+            </li>
+
+            <li>
+                <img
                     alt="Matthew Avatar"
                     src="//cdn.scratch.mit.edu/get_image/user/4373707_170x170.png"
                 />


### PR DESCRIPTION
### Resolves:

Closes #1978 

### Changes:

This adds an entry for Bryce Taylor, just before M. Taylor (since Taylor == Taylor; but B < M)

### Test Coverage:

`npm test` was weird because Windows is weird.

Manually tested by navigating to /info/credits and observing Bryce Taylor's avatar, their name, in the non-moderator category in their correct position.

![Screenshot of bottom half of list of developers, including Bryce Taylor](https://user-images.githubusercontent.com/18113170/42955700-c7b9650e-8b86-11e8-8575-b4ee08b075ee.png)

