### PR TITLE
Fix new message highlight

### DIFF
--- a/src/components/social-message/social-message.scss
+++ b/src/components/social-message/social-message.scss
@@ -13,7 +13,7 @@
 }
 
 .social-message.mod-unread {
-    background-color: lighten($ui-blue, 40);
+    background-color: $ui-blue-10percent;
 }
 
 .social-message.mod-unread .social-message-icon {


### PR DESCRIPTION
New messages should now have a blue backgroud (like they did previously).

### Resolves: https://github.com/LLK/scratch-www/issues/1989

/cc @thisandagain 