### PR TITLE
[Master] Conference 2018 Livestream

### DIFF
--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -18,7 +18,7 @@ const ConferenceSplash = () => (
                 July 26-28, 2018 | Cambridge, MA, USA
             </h3>
             <h3>
-                <a href="http://web.media.mit.edu/events/medialabtalk/">
+                <a href="http://www.media.mit.edu/events/medialabtalk/">
                     Watch the keynotes live 7/26-7/28 at 9:30 a.m. EDT
                 </a>
             </h3>

--- a/src/views/conference/2018/index/index.jsx
+++ b/src/views/conference/2018/index/index.jsx
@@ -18,10 +18,9 @@ const ConferenceSplash = () => (
                 July 26-28, 2018 | Cambridge, MA, USA
             </h3>
             <h3>
-                (Opening Reception on Evening of July 25)
-            </h3>
-            <h3>
-                Scratch@MIT is sold out!
+                <a href="http://web.media.mit.edu/events/medialabtalk/">
+                    Watch the keynotes live 7/26-7/28 at 9:30 a.m. EDT
+                </a>
             </h3>
             <p>
                 <a href="/conference/2018/schedule">

--- a/src/views/conference/2018/index/index.scss
+++ b/src/views/conference/2018/index/index.scss
@@ -27,6 +27,13 @@
             font-size: 4rem;
         }
 
+        h3 {
+            a {
+                text-decoration: underline;
+                color: $type-white;
+            }
+        }
+
         p {
             margin-top: 1rem;
 


### PR DESCRIPTION
### Resolves:

#1812

### Changes:

Updated landing page header to include link to conference livestream (to be deployed on the 25th in prep for the beginning of the conference on the morning of the 26th)
