### PR TITLE
Fix width of message select

### DIFF
--- a/src/views/messages/messages.scss
+++ b/src/views/messages/messages.scss
@@ -24,7 +24,7 @@
     color: $type-gray;
 }
 
-select {
+.messages-title-filter {
     width: 110%;
 }
 
@@ -172,7 +172,7 @@ select {
         width: $cols8;
     }
     
-    select {
+    .messages-title-filter {
         width: 100%;
     }
 }

--- a/src/views/messages/messages.scss
+++ b/src/views/messages/messages.scss
@@ -24,6 +24,10 @@
     color: $type-gray;
 }
 
+select {
+    width: 110%;
+}
+
 .help-block {
     display: none;
 }
@@ -166,5 +170,9 @@
 
     .messages-social-loadmore {
         width: $cols8;
+    }
+    
+    select {
+        width: 100%;
     }
 }


### PR DESCRIPTION
### Resolves:

Resolves #1643 

### Changes:

When "Comment Activity" is selected, it gets too big for the menu. On mobile and desktop (but not tablet, because there isn't enough room,) this PR changes the width to `110%` to fit the text better.

### Test Coverage:

Desktop Size Chrome:

![image](https://user-images.githubusercontent.com/31634240/43261137-b301ee6a-90a9-11e8-8999-b3106a964ae6.png)
Mobile Size Chrome:

![image](https://user-images.githubusercontent.com/31634240/43261180-d365520a-90a9-11e8-8f05-d30a46f03092.png)

