### PR TITLE
Add sort scheme dropdown to search results page

### DIFF
--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -1,7 +1,6 @@
 const keyMirror = require('keymirror');
 
 const Types = keyMirror({
-    SET_MODE: null,
     SET_SEARCH_TERM: null
 });
 
@@ -10,19 +9,12 @@ module.exports.navigationReducer = (state, action) => {
         state = '';
     }
     switch (action.type) {
-    case Types.SET_MODE:
-        return action.mode;
     case Types.SET_SEARCH_TERM:
         return action.searchTerm;
     default:
         return state;
     }
 };
-
-module.exports.setMode = mode => ({
-    type: Types.SET_MODE,
-    mode: mode
-});
 
 module.exports.setSearchTerm = searchTerm => ({
     type: Types.SET_SEARCH_TERM,

--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -1,6 +1,7 @@
 const keyMirror = require('keymirror');
 
 const Types = keyMirror({
+    SET_MODE: null,
     SET_SEARCH_TERM: null
 });
 
@@ -9,12 +10,19 @@ module.exports.navigationReducer = (state, action) => {
         state = '';
     }
     switch (action.type) {
+    case Types.SET_MODE:
+        return action.mode;
     case Types.SET_SEARCH_TERM:
         return action.searchTerm;
     default:
         return state;
     }
 };
+
+module.exports.setMode = mode => ({
+    type: Types.SET_MODE,
+    mode: mode
+});
 
 module.exports.setSearchTerm = searchTerm => ({
     type: Types.SET_SEARCH_TERM,

--- a/src/views/search/l10n.json
+++ b/src/views/search/l10n.json
@@ -1,5 +1,4 @@
 {
   "search.trending": "Trending",
-  "search.popular": "Popular",
-  "search.recent": "Recent"
+  "search.popular": "Popular"
 }

--- a/src/views/search/l10n.json
+++ b/src/views/search/l10n.json
@@ -1,0 +1,5 @@
+{
+  "search.trending": "Trending",
+  "search.popular": "Popular",
+  "search.recent": "Recent"
+}

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -18,6 +18,8 @@ const Tabs = require('../../components/tabs/tabs.jsx');
 const Page = require('../../components/page/www/page.jsx');
 const render = require('../../lib/render.jsx');
 
+const ACCEPTABLE_MODES = ['trending', 'popular', ''];
+
 require('./search.scss');
 
 class Search extends React.Component {
@@ -64,7 +66,7 @@ class Search extends React.Component {
             mode = mode.substring(0, term.indexOf('&'));
         }
         mode = decodeURIComponent(mode.split('+').join(' '));
-        this.props.dispatch(navigationActions.setMode(mode));
+        this.setState({mode: mode});
     }
     componentDidUpdate (prevProps) {
         if (this.props.searchTerm !== prevProps.searchTerm) {
@@ -78,15 +80,13 @@ class Search extends React.Component {
         }
         const start = pathname.lastIndexOf('/');
         const type = pathname.substring(start + 1, pathname.length);
-        const modeOptions = ['trending', 'popular', ''];
         return {
-            acceptableModes: modeOptions,
             tab: type,
             loadNumber: 16
         };
     }
     handleChangeSortMode (name, value) {
-        if (this.state.acceptableModes.indexOf(value) !== -1) {
+        if (ACCEPTABLE_MODES.indexOf(value) !== -1) {
             const term = this.props.searchTerm.split(' ').join('+');
             window.location =
                 `${window.location.origin}/search/${this.state.tab}?q=${term}&mode=${value}`;

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -11,6 +11,7 @@ const Button = require('../../components/forms/button.jsx');
 const Form = require('../../components/forms/form.jsx');
 const Grid = require('../../components/grid/grid.jsx');
 const navigationActions = require('../../redux/navigation.js');
+const Select = require('../../components/forms/select.jsx');
 const TitleBanner = require('../../components/title-banner/title-banner.jsx');
 const Tabs = require('../../components/tabs/tabs.jsx');
 
@@ -63,7 +64,9 @@ class Search extends React.Component {
             mode = mode.substring(0, term.indexOf('&'));
         }
         mode = decodeURIComponent(mode.split('+').join(' '));
-        this.state.mode = mode;
+        this.setState({
+            mode: mode
+        });
     }
     componentDidUpdate (prevProps) {
         if (this.props.searchTerm !== prevProps.searchTerm) {
@@ -227,7 +230,6 @@ class Search extends React.Component {
 Search.propTypes = {
     dispatch: PropTypes.func,
     intl: intlShape,
-    mode: PropTypes.string,
     searchTerm: PropTypes.string
 };
 

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -37,6 +37,20 @@ class Search extends React.Component {
         this.state.mode = '';
         this.state.offset = 0;
         this.state.loadMore = false;
+        
+        let mode = '';
+        const m = query.lastIndexOf('mode=');
+        if (m !== -1) {
+            mode = query.substring(m + 5, query.length).toLowerCase();
+        }
+        while (mode.indexOf('/') > -1) {
+            mode = mode.substring(0, term.indexOf('/'));
+        }
+        while (term.indexOf('&') > -1) {
+            mode = mode.substring(0, term.indexOf('&'));
+        }
+        mode = decodeURIComponent(mode.split('+').join(' '));
+        this.state.mode = mode;
     }
     componentDidMount () {
         const query = window.location.search;
@@ -53,20 +67,6 @@ class Search extends React.Component {
         }
         term = decodeURIComponent(term.split('+').join(' '));
         this.props.dispatch(navigationActions.setSearchTerm(term));
-        
-        let mode = '';
-        const m = query.lastIndexOf('mode=');
-        if (m !== -1) {
-            mode = query.substring(m + 5, query.length).toLowerCase();
-        }
-        while (mode.indexOf('/') > -1) {
-            mode = mode.substring(0, term.indexOf('/'));
-        }
-        while (term.indexOf('&') > -1) {
-            mode = mode.substring(0, term.indexOf('&'));
-        }
-        mode = decodeURIComponent(mode.split('+').join(' '));
-        this.setState({mode: mode});
     }
     componentDidUpdate (prevProps) {
         if (this.props.searchTerm !== prevProps.searchTerm) {

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -39,6 +39,8 @@ class Search extends React.Component {
         this.state.loadMore = false;
         
         let mode = '';
+        const query = window.location.search;
+        const q = query.lastIndexOf('q=');
         const m = query.lastIndexOf('mode=');
         if (m !== -1) {
             mode = query.substring(m + 5, query.length).toLowerCase();

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -64,9 +64,7 @@ class Search extends React.Component {
             mode = mode.substring(0, term.indexOf('&'));
         }
         mode = decodeURIComponent(mode.split('+').join(' '));
-        this.setState({
-            mode: mode
-        });
+        this.props.dispatch(navigationActions.setMode(mode));
     }
     componentDidUpdate (prevProps) {
         if (this.props.searchTerm !== prevProps.searchTerm) {

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -47,7 +47,7 @@ class Search extends React.Component {
         while (mode.indexOf('/') > -1) {
             mode = mode.substring(0, mode.indexOf('/'));
         }
-        while (term.indexOf('&') > -1) {
+        while (mode.indexOf('&') > -1) {
             mode = mode.substring(0, mode.indexOf('&'));
         }
         mode = decodeURIComponent(mode.split('+').join(' '));

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -78,7 +78,7 @@ class Search extends React.Component {
         }
         const start = pathname.lastIndexOf('/');
         const type = pathname.substring(start + 1, pathname.length);
-        const modeOptions = ['trending', 'popular', 'recent', ''];
+        const modeOptions = ['trending', 'popular', ''];
         return {
             acceptableModes: modeOptions,
             tab: type,
@@ -202,15 +202,11 @@ class Search extends React.Component {
                                 options={[
                                     {
                                         value: 'trending',
-                                        label: this.props.intl.formatMessage({id: 'explore.trending'})
+                                        label: this.props.intl.formatMessage({id: 'search.trending'})
                                     },
                                     {
                                         value: 'popular',
-                                        label: this.props.intl.formatMessage({id: 'explore.popular'})
-                                    },
-                                    {
-                                        value: 'recent',
-                                        label: this.props.intl.formatMessage({id: 'explore.recent'})
+                                        label: this.props.intl.formatMessage({id: 'search.popular'})
                                     }
                                 ]}
                                 value={this.state.mode}

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -40,16 +40,15 @@ class Search extends React.Component {
         
         let mode = '';
         const query = window.location.search;
-        const q = query.lastIndexOf('q=');
         const m = query.lastIndexOf('mode=');
         if (m !== -1) {
             mode = query.substring(m + 5, query.length).toLowerCase();
         }
         while (mode.indexOf('/') > -1) {
-            mode = mode.substring(0, term.indexOf('/'));
+            mode = mode.substring(0, mode.indexOf('/'));
         }
         while (term.indexOf('&') > -1) {
-            mode = mode.substring(0, term.indexOf('&'));
+            mode = mode.substring(0, mode.indexOf('&'));
         }
         mode = decodeURIComponent(mode.split('+').join(' '));
         this.state.mode = mode;

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -53,9 +53,9 @@ class Search extends React.Component {
         this.props.dispatch(navigationActions.setSearchTerm(term));
         
         let mode = '';
-        const m = query.lastIndexOf('m=');
+        const m = query.lastIndexOf('mode=');
         if (m !== -1) {
-            mode = query.substring(m + 2, query.length).toLowerCase();
+            mode = query.substring(m + 5, query.length).toLowerCase();
         }
         while (mode.indexOf('/') > -1) {
             mode = mode.substring(0, term.indexOf('/'));
@@ -89,7 +89,7 @@ class Search extends React.Component {
         if (this.state.acceptableModes.indexOf(value) !== -1) {
             const term = this.props.searchTerm.split(' ').join('+');
             window.location =
-                `${window.location.origin}/search/${this.state.tab}?q=${term}&m=${value}`;
+                `${window.location.origin}/search/${this.state.tab}?q=${term}&mode=${value}`;
         }
     }
     handleGetSearchMore () {

--- a/src/views/search/search.scss
+++ b/src/views/search/search.scss
@@ -105,7 +105,7 @@ $base-bg: $ui-white;
         }
     }
     
-        /* HACK: sort controls are terrible. There's some sort of magic formula for height of formsy components that I can't control. */
+    /* HACK: sort controls are terrible. There's some sort of magic formula for height of formsy components that I can't control. */
 
     .sort-controls {
         display: flex;

--- a/src/views/search/search.scss
+++ b/src/views/search/search.scss
@@ -104,15 +104,40 @@ $base-bg: $ui-white;
             }
         }
     }
+    
+        /* HACK: sort controls are terrible. There's some sort of magic formula for height of formsy components that I can't control. */
 
-    .select {
-        select {
-            margin-bottom: 0;
-            color: $header-gray;
-        }
+    .sort-controls {
+        display: flex;
+        margin: 0 auto;
+        border-bottom: 1px solid $ui-border;
+        padding: 8px 0;
+        width: 58.75rem;
+        justify-content: space-between;
+    }
 
-        .help-block {
-            display: none;
+    .sort-mode {
+        margin-top: -4px;
+        width: 13.75rem;
+
+        .select {
+
+            select {
+                margin-bottom: 0;
+                border: 0;
+                background-color: transparent;
+                height: 32px;
+                color: $header-gray;
+
+                &:focus,
+                &:active {
+                    background-color: transparent;
+                }
+            }
+
+            .help-block {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
### Resolves:

Resolves #1252 

### Changes:

> On the explore page, there is a dropdown for the sorting scheme ("Trending", "Popular", "Recent"). This component should be added to the search results page, defaulting to "Popular". Changing the choice should change the sort order of the results.

> The same design on the Explore page should be used for the dropdown, except that the tags should not appear in the row.

This PR adds this dropdown and its functionality, including a new `m` query parameter for filter mode. A new search URL could look like: `/search/projects/?q=cats&m=recent`
