### PR TITLE
[DEVELOP] Fix top banner centering on android chrome

### DIFF
--- a/src/views/splash/beta/top-banner.scss
+++ b/src/views/splash/beta/top-banner.scss
@@ -15,7 +15,9 @@
     .beta-top-container {
         position: absolute;
         top: 0;
+        right: 0;
         bottom: 0;
+        left: 0;
         margin: auto;
         height: 15rem;
     }


### PR DESCRIPTION
### Changes:
This PR fixes an issue on Android Chrome 50 where the text in the top banner was not centered. This was done by adding `left: 0;` and `right: 0;` on the container for the text in the top banner.

**Before:**
<img width="400" alt="An improperly centered banner on Android Chrome" src="https://user-images.githubusercontent.com/3019167/43528130-3ed27f10-9576-11e8-9d8c-8815b7be4d32.png">

**After:**
<img width="400" alt="The top banner with fixed centering" src="https://user-images.githubusercontent.com/3019167/43528172-54ba8f7a-9576-11e8-8c1a-f85a02b35f16.png">

Tested on Android Chrome 50, macOS Firefox 63, Chrome 68, and Safari 11.1.

