### PR TITLE
report project POSTs to scratchr2, displays modal reactively

### DIFF
--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -28,8 +28,8 @@ module.exports.validationHOCFactory = defaultValidationErrors => (Component => {
         <Component
             validationErrors={defaults(
                 {},
-                defaultValidationErrors,
-                props.validationErrors
+                props.validationErrors,
+                defaultValidationErrors
             )}
             {...omit(props, ['validationErrors'])}
         />

--- a/src/components/modal/addtostudio/modal.scss
+++ b/src/components/modal/addtostudio/modal.scss
@@ -35,7 +35,6 @@
 .addToStudio-modal-content {
     margin: 0 auto;
     width: 100%;
-    line-height: 1.5rem;
     font-size: .875rem;
 }
 

--- a/src/components/modal/base/modal.scss
+++ b/src/components/modal/base/modal.scss
@@ -64,9 +64,18 @@ $modal-close-size: 1rem;
 .action-buttons {
     display: flex;
     margin: 1.125rem .8275rem .9375rem .8275rem;
+    line-height: 1.5rem;
     justify-content: flex-end !important;
     align-items: flex-start;
     flex-wrap: nowrap;
+}
+
+/* setting overall modal to contain overflow looks good, but isn't
+compatible with elements (like validation popups) that need to bleed
+past modal boundary. This class can be used to force modal button
+row to appear to contain overflow. */
+.action-buttons-overflow-fix {
+    margin-bottom: .9375rem;
 }
 
 .action-button {
@@ -82,4 +91,20 @@ $modal-close-size: 1rem;
 
 .action-button-text {
     display: flex;
+}
+
+.action-button.disabled {
+    background-color: $active-dark-gray;
+}
+
+.error-text
+{
+    display: block;
+    border: 1px solid $active-gray;
+    border-radius: 5px;
+    background-color: $ui-orange;
+    padding: 1rem;
+    min-height: 1rem;
+    overflow: visible;
+    color: $type-white;
 }

--- a/src/components/modal/report/modal.scss
+++ b/src/components/modal/report/modal.scss
@@ -9,7 +9,7 @@
     margin: 100px auto;
     outline: none;
     padding: 0;
-    width: 30rem;
+    width: 36.25rem; /* 580px; */
     user-select: none;
 }
 
@@ -34,26 +34,45 @@
 .report-modal-content {
     margin: 1rem auto;
     width: 80%;
-    line-height: 1.5rem;
     font-size: .875rem;
+
+    .instructions {
+        line-height: 1.5rem;
+    }
+
+    .received {
+        margin: 0 auto;
+        width: 90%;
+        text-align: center;
+        line-height: 1.65rem;
+
+        .received-header {
+            font-weight: bold;
+        }
+    }
+
+    .error-text {
+        margin-top: .9375rem;
+    }
 
     .validation-message {
         $arrow-border-width: 1rem;
         display: block;
         position: absolute;
         top: 0;
-        left: 0;
-        transform: translate(23.5rem, 0);
+        left: 100%; /* position to the right of parent */
         margin-left: $arrow-border-width;
         border: 1px solid $active-gray;
         border-radius: 5px;
         background-color: $ui-orange;
         padding: 1rem;
+        min-width: 12rem;
         max-width: 18.75rem;
         min-height: 1rem;
         overflow: visible;
         color: $type-white;
 
+        /* arrow on box that points to the left */
         &:before {
             display: block;
             position: absolute;
@@ -77,4 +96,14 @@
 
 .report-modal-field {
     position: relative;
+}
+
+.form-group.has-error {
+    .textarea, select {
+        border: 1px solid $ui-orange;
+    }
+}
+
+.report-text .textarea {
+    margin-bottom: 0;
 }

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -172,6 +172,7 @@
     "registration.welcomeStepTitle": "Hurray! Welcome to Scratch!",
 
     "thumbnail.by": "by",
+    "report.error": "Something went wrong when trying to send your message. Please try again.",
     "report.project": "Report Project",
     "report.projectInstructions": "From the dropdown below, please select the reason why you feel this project is disrespectful or inappropriate or otherwise breaks the {CommunityGuidelinesLink}.",
     "report.CommunityGuidelinesLinkText": "Scratch Community Guidelines",
@@ -181,8 +182,11 @@
     "report.reasonScary": "Too Violent or Scary",
     "report.reasonLanguage": "Inappropriate Language",
     "report.reasonMusic": "Inappropriate Music",
+    "report.reasonMissing": "Please select a reason",
     "report.reasonImage": "Inappropriate Images",
     "report.reasonPersonal": "Sharing Personal Contact Information",
+    "report.receivedHeader": "We have received your report!",
+    "report.receivedBody": "The Scratch Team will review the project based on the Scratch community guidelines.",
     "report.promptPlaceholder": "Select a reason why above.",
     "report.promptCopy": "Please provide a link to the original project",
     "report.promptUncredited": "Please provide links to the uncredited content",
@@ -194,5 +198,7 @@
     "report.promptImage": "Please say the name of the sprite or the backdrop with the inappropriate image",
     "report.tooLongError": "That's too long! Please find a way to shorten your text.",
     "report.tooShortError": "That's too short. Please describe in detail what's inappropriate or disrespectful about the project.",
-    "report.send": "Send"
+    "report.send": "Send",
+    "report.sending": "Sending...",
+    "report.textMissing": "Please tell us why you are reporting this project"
 }

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -43,7 +43,7 @@ const PreviewPresentation = ({
     projectId,
     projectInfo,
     remixes,
-    report,
+    reportOpen,
     replies,
     addToStudioOpen,
     projectStudios,
@@ -278,8 +278,8 @@ const PreviewPresentation = ({
                                                 Report
                                             </Button>,
                                             <ReportModal
+                                                isOpen={reportOpen}
                                                 key="report-modal"
-                                                report={report}
                                                 type="project"
                                                 onReport={onReportSubmit}
                                                 onRequestClose={onReportClose}
@@ -377,12 +377,7 @@ PreviewPresentation.propTypes = {
     projectStudios: PropTypes.arrayOf(PropTypes.object),
     remixes: PropTypes.arrayOf(PropTypes.object),
     replies: PropTypes.objectOf(PropTypes.array),
-    report: PropTypes.shape({
-        category: PropTypes.string,
-        notes: PropTypes.string,
-        open: PropTypes.bool,
-        waiting: PropTypes.bool
-    }),
+    reportOpen: PropTypes.bool,
     studios: PropTypes.arrayOf(PropTypes.object),
     userOwnsProject: PropTypes.bool
 };


### PR DESCRIPTION
Resolves #1957.

When tested using Docker, depends on https://github.com/LLK/scratchr2/pull/5133 .

Looks like:

![screen shot 2018-08-06 at 12 31 54 pm](https://user-images.githubusercontent.com/3431616/43729058-1058d0aa-9975-11e8-9683-66e98af9e2ea.png)

![screen shot 2018-08-06 at 12 32 14 pm](https://user-images.githubusercontent.com/3431616/43729078-221fe332-9975-11e8-929b-4229a6c4877c.png)

![screen shot 2018-08-06 at 12 32 32 pm](https://user-images.githubusercontent.com/3431616/43729087-275a7736-9975-11e8-8b19-9f72e149a281.png)

![screen shot 2018-08-06 at 2 48 49 pm](https://user-images.githubusercontent.com/3431616/43735172-fdbd1a74-9987-11e8-940c-89869a28710e.png)


![screen shot 2018-08-06 at 12 32 41 pm 2](https://user-images.githubusercontent.com/3431616/43729105-36e5929e-9975-11e8-8a4c-cc278c726509.png)

![screen shot 2018-08-06 at 12 31 40 pm](https://user-images.githubusercontent.com/3431616/43729098-31e597ee-9975-11e8-858d-a962c2996eec.png)



Note that this does NOT use a scratch-api endpoint at all; it just uses the existing scratchr2 endpoint.

We ran into difficulties getting scratch-api to read the cookie from scratch-www, in the process of sending a proxy request from scratch-api to scratchr2. We decided to come back to this at a a later time.
 
Why setting headers in www doesn’t work:
* Currently can get csrf token from cookie fine; but can’t get sessionid token that way, because it’s set as http only by scratchr2. So it’s unreadable!

Why sending whole cookie from www to api doesn’t work:
* So, it CAN, it’s just tricky.
* To send cookie, you have xhr options include withCredentials: true. That will send cookie.
* But Chrome won’t show you the response from api, because it wants api to set Access-Control-Allow-Credentials header, and we’re not.
    * But we could! BUT, restifycors will complain and error if you set that header while allowing wildcard incoming domains...