### PR TITLE
Hide intro modal in editor on new project page

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -329,6 +329,7 @@ class Preview extends React.Component {
                 </Page> :
                 <IntlGUI
                     enableCommunity
+                    hideIntro
                     basePath="/"
                     className="gui"
                     projectId={this.state.projectId}


### PR DESCRIPTION
### Resolves:
This PR is a continuation of llk/scratch-gui#2814.

### Changes:
This PR changes the project page view so it uses the `hideIntro` prop introduced in llk/scratch-gui#2831 to hide the intro modal in the editor.

### Test Coverage:

Tested manually by making sure the intro modal does not show up when clicking "See Inside" on project pages. Tested on macOS Firefox 63, Chrome 70, Safari 11.1.1
