### PR TITLE
Recongfigure docker external network usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,24 @@
 ESLINT=./node_modules/.bin/eslint
 NODE= NODE_OPTIONS=--max_old_space_size=8000 node
 SASSLINT=./node_modules/.bin/sass-lint -v
+SCRATCH_DOCKER_CONFIG=./node_modules/.bin/docker_config.sh
 S3CMD=s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600
 TAP=./node_modules/.bin/tap
 WATCH= NODE_OPTIONS=--max_old_space_size=8000 ./node_modules/.bin/watch
 WEBPACK= NODE_OPTIONS=--max_old_space_size=8000 ./node_modules/.bin/webpack
+
+
+# ------------------------------------
+
+$(SCRATCH_DOCKER_CONFIG):
+	npm install scratch-docker
+
+docker-up: $(SCRATCH_DOCKER_CONFIG)
+	$(SCRATCH_DOCKER_CONFIG) network create
+	docker-compose up
+
+docker-down:
+	docker-compose down
 
 # ------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ volumes:
   runtime_data:
 
 networks:
-  scratch-api_scratch_network:
-    external: true
+  default:
+    external:
+      name: scratchapi_scratch_network
 
 services:
   app:
@@ -13,7 +14,7 @@ services:
     hostname: scratch-www-app
     environment:
       - API_HOST=http://localhost:8491
-      - FALLBACK=http://localhost:8080
+      - FALLBACK=http://scratchr2-app:8080
       - USE_DOCKER_WATCHOPTIONS=true
     build:
       context: ./
@@ -35,5 +36,3 @@ services:
       - runtime_data:/runtime
     ports:
       - "8333:8333"
-    networks:
-      - scratch-api_scratch_network

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash.defaults": "4.0.1",
     "newrelic": "1.25.4",
     "raven": "0.10.0",
+    "scratch-docker": "^1.0.2",
     "scratch-parser": "^4.2.0",
     "scratch-storage": "^0.5.1"
   },


### PR DESCRIPTION
### Resolves:

Improves development ergonomics when working against docker based local development.

### Changes:

This moves the docker network handling to a separate tool that is part of a new npm module: `scratch-docker`. All other repos that depend on having docker network communication will also use this tool to converge on the named network.

This requires a step to run the network setup ahead of launching docker compose, this is accomplished by using:

```bash
$ make docker-up
and/or
$ make docker-down
```

Looks like I accidentally added this branch to LLK instead of my fork.
Related to: LLK/scratch-api/pull/538

### Test Coverage:

N/A