### PR TITLE
Fix spacing in message title

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -249,7 +249,7 @@ class Navigation extends React.Component {
                                             'message-count': true,
                                             'show': this.props.unreadMessageCount > 0
                                         })}
-                                    >{this.props.unreadMessageCount}</span>
+                                    >{this.props.unreadMessageCount} </span>
                                     <FormattedMessage id="general.messages" />
                                 </a>
                             </li>,


### PR DESCRIPTION
### Resolves:

#2029

### Changes:

> The link incorrectly displays the text. Instead of just "Messages" or "1 Message" or "2 Messages" it displays it as messagecount+Messages (example 0Messages or 1Messages)

This PR adds a space between the message count and the word "messages", ex. 0 Messages or 1 Message.

### Test Coverage:

![image](https://user-images.githubusercontent.com/31634240/44462898-fddbcd80-a5e3-11e8-8eb4-c6816b8cc693.png)

