### PR TITLE
[Master] Add wedo troubleshooting item about updating scratch link

### DIFF
--- a/src/views/wedo2/l10n.json
+++ b/src/views/wedo2/l10n.json
@@ -21,6 +21,8 @@
     "wedo2.closeScratchCopiesText": "Only one copy of Scratch can connect with the WeDo 2.0 at a time. If you have Scratch open in other browser tabs, close it and try again.",
     "wedo2.otherComputerConnectedTitle": "Make sure no other computer is connected to your WeDo 2.0",
     "wedo2.otherComputerConnectedText": "Only one computer can be connected to an WeDo 2.0 at a time. If you have another computer connected to your WeDo 2.0, disconnect the WeDo 2.0 or close Scratch on that computer and try again.",
+    "wedo2.updateLinkTitle": "Update Scratch Link",
+    "wedo2.updateLinkText": "Make sure you have installed the latest version of Scratch Link.",
     "wedo2.legacyInfoTitle": "Using Scratch 2.0?",
     "wedo2.legacyInfoText": "Visit our page about {wedoLegacyLink}.",
     "wedo2.legacyLinkText": "using LEGO WeDo with Scratch 2.0"

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -180,6 +180,10 @@ class Wedo2 extends ExtensionLanding {
                     <p>
                         <FormattedMessage id="wedo2.otherComputerConnectedText" />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="wedo2.updateLinkTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="wedo2.updateLinkText" />
+                    </p>
                     <h3 className="faq-title"><FormattedMessage id="wedo2.legacyInfoTitle" /></h3>
                     <p>
                         <FormattedMessage


### PR DESCRIPTION
Due to a version compatibility issue with Scratch Link, people who have installed it before the upcoming update will not be able to use the WeDo 2.0 extension. I've added an entry to the troubleshooting section of the WeDo landing page that suggests updating it.  