### PR TITLE
Keep title on preview project page from overflowing or otherwise messing up the layout

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -99,7 +99,10 @@ const PreviewPresentation = ({
                                             value={projectInfo.title}
                                         /> :
                                         <React.Fragment>
-                                            <div className="project-title">{projectInfo.title}</div>
+                                            <div
+                                                className="project-title no-edit"
+                                                title={projectInfo.title}
+                                            >{projectInfo.title}</div>
                                             {'by '}
                                             <a href={`/users/${projectInfo.author.username}`}>
                                                 {projectInfo.author.username}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -32,6 +32,14 @@ $stage-width: 480px;
                 transform: translate(22rem, 0);
             }
         }
+
+        &.no-edit {
+            /* titles of projects you don't own should not
+            show the full title if this is too long */
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     }
 
     .project-header {
@@ -39,6 +47,8 @@ $stage-width: 480px;
         flex-grow: 1;
         justify-content: flex-start;
         align-items: flex-start;
+        flex-wrap: nowrap;
+        width: 65%; /* Setting a width to the header will keep it from flowing over the usual content of the page */
 
         .inplace-input {
             height: calc(3rem - 4px);
@@ -66,9 +76,10 @@ $stage-width: 480px;
         text-align: left;
         font-size: .8rem;
         flex-grow: 1;
+        width: inherit; /* Inherits the width of whatever this is in. This works well for the preview page and might need to change if used in a different context*/
     }
 
-    .validation-message {
+    .validation-message { 
         $arrow-border-width: 1rem;
         display: block;
         position: absolute;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -44,7 +44,7 @@ $stage-width: 480px;
 
     .project-header {
         margin-right: 2rem;
-        width: 65%; /* Setting a width to the header will keep it from flowing over the usual content of the page */
+        min-width: 0;
         flex-grow: 1;
         justify-content: flex-start;
         align-items: flex-start;
@@ -73,7 +73,8 @@ $stage-width: 480px;
 
     .title {
         margin-left: 1rem;
-        width: inherit; /* Inherits the width of whatever this is in. This works well for the preview page and might need to change if used in a different context*/
+        /* width: inherit;  Inherits the width of whatever this is in. This works well for the preview page and might need to change if used in a different context*/
+        min-width: 0;
         text-align: left;
         font-size: .8rem;
         flex-grow: 1;
@@ -128,6 +129,10 @@ $stage-width: 480px;
         .col-sm-9 {
             position: relative;
         }
+    }
+
+    .project-buttons {
+      flex-shrink: 0;
     }
 
     .button {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -44,11 +44,11 @@ $stage-width: 480px;
 
     .project-header {
         margin-right: 2rem;
+        width: 65%; /* Setting a width to the header will keep it from flowing over the usual content of the page */
         flex-grow: 1;
         justify-content: flex-start;
         align-items: flex-start;
         flex-wrap: nowrap;
-        width: 65%; /* Setting a width to the header will keep it from flowing over the usual content of the page */
 
         .inplace-input {
             height: calc(3rem - 4px);
@@ -73,13 +73,13 @@ $stage-width: 480px;
 
     .title {
         margin-left: 1rem;
+        width: inherit; /* Inherits the width of whatever this is in. This works well for the preview page and might need to change if used in a different context*/
         text-align: left;
         font-size: .8rem;
         flex-grow: 1;
-        width: inherit; /* Inherits the width of whatever this is in. This works well for the preview page and might need to change if used in a different context*/
     }
 
-    .validation-message { 
+    .validation-message {
         $arrow-border-width: 1rem;
         display: block;
         position: absolute;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -132,7 +132,7 @@ $stage-width: 480px;
     }
 
     .project-buttons {
-      flex-shrink: 0;
+        flex-shrink: 0;
     }
 
     .button {
@@ -458,6 +458,7 @@ $stage-width: 480px;
             content: "";
         }
     }
+    
     .studio-button {
         &:before {
             background-image: url("/svgs/project/studio-add-white.svg");


### PR DESCRIPTION
### Resolves:

Part of #1986 

### Changes:

* added a title attribute to project title so you can see the whole title even when it is not completely displayed on the website
* made it so long titles don't get displayed completely, see comments in scss file

### Test Coverage:
npm test passed
Tested in MacOS Chrome & Safari, looks good for screen with min-width 640px

<img width="697" alt="screen shot 2018-08-23 at 2 32 50 pm" src="https://user-images.githubusercontent.com/5471273/44544861-73799380-a6e1-11e8-8ac1-f28c4882434d.png">

<img width="1010" alt="screen shot 2018-08-23 at 2 32 09 pm" src="https://user-images.githubusercontent.com/5471273/44544824-56dd5b80-a6e1-11e8-8d09-a97133729d11.png">
