### PR TITLE
Fix gh-1934: Search bar special chars

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -57,19 +57,28 @@ class Search extends React.Component {
 
     }
     componentDidMount () {
-        const query = window.location.search;
-        const q = query.lastIndexOf('q=');
-        let term = '';
-        if (q !== -1) {
-            term = query.substring(q + 2, query.length).toLowerCase();
-        }
+        const query = decodeURIComponent(window.location.search);
+        let term = query;
+
+        const stripQueryValue = function (queryTerm) {
+            const queryIndex = query.indexOf('q=');
+            if (queryIndex !== -1) {
+                queryTerm = query.substring(queryIndex + 2, query.length).toLowerCase();
+            }
+            return queryTerm;
+        };
+        // Strip off the initial "?q="
+        term = stripQueryValue(term);
+        // Strip off user entered "?q="
+        term = stripQueryValue(term);
+
         while (term.indexOf('/') > -1) {
             term = term.substring(0, term.indexOf('/'));
         }
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = decodeURIComponent(decodeURIComponent(term.split('+').join(' ')));
+        term = decodeURIComponent(term.split('+').join(' '));
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -37,7 +37,7 @@ class Search extends React.Component {
         this.state.mode = 'popular';
         this.state.offset = 0;
         this.state.loadMore = false;
-        
+
         let mode = '';
         const query = window.location.search;
         const m = query.lastIndexOf('mode=');
@@ -54,7 +54,7 @@ class Search extends React.Component {
         if (ACCEPTABLE_MODES.indexOf(mode) !== -1) {
             this.state.mode = mode;
         }
-        
+
     }
     componentDidMount () {
         const query = window.location.search;
@@ -69,7 +69,7 @@ class Search extends React.Component {
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = decodeURIComponent(term.split('+').join(' '));
+        term = decodeURIComponent(decodeURIComponent(term.split('+').join(' ')));
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {


### PR DESCRIPTION


### Resolves:

Resolves #1934 

The text was encoded once already by the search bar. That means we need to decode it twice in order to decode special characters.

### Test Coverage:

?q=cat%3Fcat (should now appear as cat?cat)
?q=cat%20cat (should still appear as cat cat)
