### PR TITLE
Made comments fade out look nice in Safari too

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -28,6 +28,7 @@ $ui-coral-dark: hsla(350, 100, 60, 1); // #FF3355 More Blocks tertiary
 $ui-white: hsla(0, 100%, 100%, 1); //#FFF
 $ui-white-15percent: hsla(0, 100%, 100%, .15); //#FFF
 $ui-light-primary: hsl(215, 100, 95);
+$ui-light-primary-transparent: hsla(215, 100, 95, 0);
 
 $ui-border: hsla(0, 0, 85, 1); //#D9D9D9
 

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -1,7 +1,5 @@
 @import "../../../colors";
 
-$cross-browser-transparent: hsla(0, 0, 100%, 0);
-
 .compose-comment {
     width: 100%;
 
@@ -174,7 +172,7 @@ $cross-browser-transparent: hsla(0, 0, 100%, 0);
                 position: absolute;
                 bottom: 0;
                 background: linear-gradient(
-                    $cross-browser-transparent,
+                    $ui-light-primary-transparent,
                     $ui-light-primary
                 );
                 width: 100%;

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -1,6 +1,6 @@
 @import "../../../colors";
 
-$cross-browser-transparent: hsla(0, 0, 100, 0);
+$cross-browser-transparent: hsla(0, 0, 100%, 0);
 
 .compose-comment {
     width: 100%;

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -1,5 +1,7 @@
 @import "../../../colors";
 
+$cross-browser-transparent: hsla(0, 0, 100, 0);
+
 .compose-comment {
     width: 100%;
 
@@ -172,7 +174,7 @@
                 position: absolute;
                 bottom: 0;
                 background: linear-gradient(
-                    transparent,
+                    $cross-browser-transparent,
                     $ui-light-primary
                 );
                 width: 100%;
@@ -188,7 +190,7 @@
     margin-bottom: 24px;
     width: 100%;
     overflow: hidden;
-    text-align: center; 
+    text-align: center;
 
     &:before,
     &:after {
@@ -211,4 +213,3 @@
         margin-right: -50%;
     }
 }
-


### PR DESCRIPTION
### Resolves:
#2067 

### Changes:
transparent in safari gets a greyish look. fix is to use a white base and set to 0 opacity.
<img width="632" alt="screen shot 2018-09-21 at 10 00 53 am" src="https://user-images.githubusercontent.com/5471273/45885748-44f4e400-bd85-11e8-9b71-1342ff7c9a91.png">

### Test Coverage:
MacOS, Chrome, Firefox, Safari
npm test passed