### PR TITLE
fixed smoke tests to use non-exclusive class locators

### DIFF
--- a/test/integration/smoke-testing/test-my-stuff.js
+++ b/test/integration/smoke-testing/test-my-stuff.js
@@ -52,7 +52,7 @@ test('Sign in to Scratch using scratchr2 navbar', t => {
 });
 
 test('Sign in to Scratch & verify My Stuff structure (tabs, title)', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => findByXpath('//div[@class="box-head"]/h2'))
         .then((element) => element.getText('h2'))
         .then((text) => t.equal('My Stuff', text, 'title should be My Stuff'))
@@ -75,7 +75,7 @@ test('Sign in to Scratch & verify My Stuff structure (tabs, title)', t => {
 });
 
 test('clicking See Inside should take you to the editor', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => findByXpath('//a[@data-control="edit"]'))
         .then((element) => element.getText('span'))
         .then((text) => t.equal(text, 'See inside', 'there should be a "See inside" button'))
@@ -89,7 +89,7 @@ test('clicking See Inside should take you to the editor', t => {
 });
 
 test('clicking a project title should take you to the project page', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => clickXpath('//a[@data-control="edit"]'))
         .then(() => driver.getCurrentUrl())
         .then(function (u) {
@@ -100,7 +100,7 @@ test('clicking a project title should take you to the project page', t => {
 });
 
 test('Add To button should bring up a list of studios', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => findByXpath('//div[@data-control="add-to"]'))
         .then((element) => element.getText('span'))
         .then((text) => t.equal(text, 'Add to', 'there should be an "Add to" button'))
@@ -115,7 +115,7 @@ test('Add To button should bring up a list of studios', t => {
 });
 
 test('+ New Studio button should take you to the studio page', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => clickXpath('//form[@id="new_studio"]/button[@type="submit"]'))
         .then(() => findByXpath('//div[@id="show-add-project"]'))
         .then((element) => element.getText('span'))
@@ -130,7 +130,7 @@ test('+ New Studio button should take you to the studio page', t => {
 });
 
 test('+ New Project button should open the editor', t => {
-    clickXpath('//a[@class="mystuff-icon"]')
+    clickXpath('//a[contains(@class, "mystuff-icon")]')
         .then(() => clickText('+ New Project'))
         .then(() => driver.getCurrentUrl())
         .then(function (u) {

--- a/test/integration/smoke-testing/test_project_rows.js
+++ b/test/integration/smoke-testing/test_project_rows.js
@@ -79,7 +79,8 @@ tap.test('checkFeaturedStudiosRowWhenSignedOut', function (t) {
 // checks that the link for a studio makes sense
 tap.test('checkFeaturedStudiosRowLinkWhenSignedOut', function (t) {
     var xPathLink = '//div[contains(@class, "thumbnail") and contains(@class, "gallery") ' +
-        'and contains(@class, "slick-slide") and contains(@class, "slick-active")]/a[@class="thumbnail-image"]';
+        'and contains(@class, "slick-slide") ' +
+        'and contains(@class, "slick-active")]/a[@class="thumbnail-image"]';
     driver.findElement(webdriver.By.xpath(xPathLink))
         .then(function (element) {
             element.getAttribute('href')

--- a/test/integration/smoke-testing/test_signing_in_and_out_discuss.js
+++ b/test/integration/smoke-testing/test_signing_in_and_out_discuss.js
@@ -54,7 +54,7 @@ test('Sign in to Scratch using scratchr2 navbar', t => {
 
 test('Sign out of Scratch using scratchr2 navbar', t => {
     clickXpath('//span[contains(@class, "user-name")' +
-        ' and contains(@class, "dropdown-toggle")]/img[@class="user-icon"]')
+        ' and contains(@class, "dropdown-toggle")]/img[contains(@class, "user-icon")]')
         .then(() => clickXpath('//input[@value="Sign out"]'))
         .then(() => findText('Sign in'))
         .then((element) => t.ok(element, 'Sign in reappeared on the page after signing out'))

--- a/test/integration/smoke-testing/test_signing_in_and_out_homepage.js
+++ b/test/integration/smoke-testing/test_signing_in_and_out_homepage.js
@@ -43,7 +43,7 @@ test('Sign in to Scratch using scratch-www navbar', t => {
         .then((element) => element.sendKeys(password))
         .then(() => clickXpath('//button[contains(@class, "button") and ' +
             'contains(@class, "submit-button") and contains(@class, "white")]'))
-        .then(() => findByXpath('//span[@class="profile-name"]'))
+        .then(() => findByXpath('//span[contains(@class, "profile-name")]'))
         .then((element) => element.getText())
         .then((text) => t.match(text.toLowerCase(), username.substring(0, 10).toLowerCase(),
             'first part of username should be displayed in navbar'))
@@ -51,7 +51,7 @@ test('Sign in to Scratch using scratch-www navbar', t => {
 });
 
 test('Sign out of Scratch using scratch-www navbar', t => {
-    clickXpath('//a[@class="user-info"]')
+    clickXpath('//a[contains(@class, "user-info")]')
         .then(() => clickText('Sign out'))
         .then(() => findText('Sign in'))
         .then((element) => t.ok(element, 'Sign in reappeared on the page after signing out'))


### PR DESCRIPTION
resolves broken smoke test from merging https://github.com/LLK/scratch-www/pull/2078

The issue was that the tests were targeting DOM elements by assuming they would *only* have one particular class, rather than allowing them to include that class among several.

Unfortunately, it's not easy to test all of these smoke tests before deploying them to staging, because they depend on seed data and server access that are not easy to replicate locally.