### PR TITLE
Make container smaller for mobile to allow for space left and right

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -36,8 +36,8 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         }
 
         @media #{$intermediate} {
-            min-width: 640px;
             width: 90%;
+            min-width: 640px;
         }
     }
 

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -9,7 +9,7 @@ $stage-width: 480px;
 /* screen sizes */
 $small: "screen and (max-width : #{$mobile}-1)";
 $medium: "screen and (min-width : #{$mobile}) and (max-width : #{$tablet}-1)";
-$big: "screen and (min-width : #{$tablet})";
+$intermediate: "screen and (min-width : #{$tablet}) and (max-width : 941px)"; /* 941 because currently breakpoint of .inner in www is 941 */
 $medium-and-small: "screen and (max-width : #{$tablet}-1)";
 
 /* override view padding for share banner */
@@ -27,6 +27,19 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
 }
 
 .preview {
+
+    .inner {
+      @media #{$medium-and-small} {
+          max-width: 90%;
+          margin: 0 auto;
+      }
+
+      @media #{$intermediate} {
+          min-width: 640px;
+          width: 90%;
+          margin: 0 auto;
+      }
+    }
 
     .project-title {
         font-size: 1.75rem;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -32,11 +32,12 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         margin: 0 auto;
 
         @media #{$medium-and-small} {
-            padding: 0 1rem;
+            max-width: 90%;
         }
 
         @media #{$intermediate} {
             min-width: 640px;
+            width: 90%;
         }
     }
 

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -14,6 +14,7 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
 /* override view padding for share banner */
 #view {
     padding: 0;
+    width: 100%;
 }
 
 .gui {
@@ -74,6 +75,10 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         @media #{$medium-and-small} {
             flex-direction: row;
         }
+
+        @media #{$small} {
+            margin-right: 0;
+        }
     }
 
     img {
@@ -98,10 +103,6 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         text-align: left;
         font-size: .8rem;
         flex-grow: 1;
-
-        @media #{$medium-and-small} {
-            min-width: 100%;
-        }
     }
 
     .validation-message {
@@ -244,10 +245,6 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
 
         @media #{$small} {
             width: 100%;
-
-            .stage-wrapper {
-                max-width: 100%;
-            }
         }
     }
 

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -29,16 +29,16 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
 .preview {
 
     .inner {
-      @media #{$medium-and-small} {
-          max-width: 90%;
-          margin: 0 auto;
-      }
+        @media #{$medium-and-small} {
+            margin: 0 auto;
+            max-width: 90%;
+        }
 
-      @media #{$intermediate} {
-          min-width: 640px;
-          width: 90%;
-          margin: 0 auto;
-      }
+        @media #{$intermediate} {
+            margin: 0 auto;
+            width: 90%;
+            min-width: 640px;
+        }
     }
 
     .project-title {


### PR DESCRIPTION
### Resolves:
Part of #2086: According to the design, left and right of page content should be some space on mobile. This is what this pull request does. It will not take full effect unless some of the page content is actually adapted to fit in the page container.

### Test Coverage:
MacOS, Chrome
npm test passed
