### PR TITLE
Thumbnailcolumns appear at bottom on mobile

### DIFF
--- a/src/components/thumbnailcolumn/thumbnailcolumn.scss
+++ b/src/components/thumbnailcolumn/thumbnailcolumn.scss
@@ -45,6 +45,7 @@
                 float: left;
                 max-width: 164px;
                 overflow: hidden;
+                text-align: left;
 
                 .thumbnail-creator a {
                     color: $type-gray;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -537,7 +537,7 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
             display: inline-block;
             width: 100%;
 
-            /* the following can be transferred to
+            /* TODO: the following can be transferred to
             src/components/thumbnailcolumn/thumbnailcolumn.scss
             after testing */
             @media #{$medium-and-small} {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -536,6 +536,21 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         .thumbnail-column {
             display: inline-block;
             width: 100%;
+
+            /* the following can be transferred to
+            src/components/thumbnailcolumn/thumbnailcolumn.scss
+            after testing */
+            @media #{$medium-and-small} {
+                flex-direction: row;
+
+                .thumbnail {
+                    display: inline-block;
+                }
+            }
+        }
+
+        @media #{$medium-and-small} {
+            margin-top: 1rem;
         }
     }
 }


### PR DESCRIPTION
### Resolves:
Part of #2086. On mobile the thumbnailcolumns like remixes and studios should appear below comments and also be in a row or so (design not finalized, looking for a meantime-solution here)

### Test Coverage:
npm test passed
MacOS, Chrome
