### PR TITLE
Positioning remix credit text correctly

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -263,7 +263,7 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         padding: .5rem;
         width: calc(100% - 1rem);
         flex-wrap: nowrap;
-        align-items: flex-start;
+        align-items: center;
     }
 
     .credit-text {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -264,6 +264,10 @@ $medium-and-small: "screen and (max-width : #{$tablet}-1)";
         width: calc(100% - 1rem);
         flex-wrap: nowrap;
         align-items: center;
+
+        @media #{$medium-and-small} {
+            flex-direction: row;
+        }
     }
 
     .credit-text {


### PR DESCRIPTION
### Resolves:
##2132

### Changes:
On mobile, remix credit is still a row so it looks nice and for single line remix credit it looks good because the text is vertically aligned.

### Test Coverage:
MacOS, Chrome, npm test passed