### PR TITLE
storage.js can use PROJECT_HOST env setting

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,6 +1,6 @@
 import ScratchStorage from 'scratch-storage';
 
-const PROJECT_SERVER = 'https://projects.scratch.mit.edu';
+const PROJECT_HOST = process.env.PROJECT_HOST || 'https://projects.scratch.mit.edu';
 
 /**
  * Wrapper for ScratchStorage which adds default web sources.
@@ -14,8 +14,8 @@ class Storage extends ScratchStorage {
             projectAsset => {
                 const [projectId, revision] = projectAsset.assetId.split('.');
                 return revision ?
-                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/${revision}` :
-                    `${PROJECT_SERVER}/internalapi/project/${projectId}/get/`;
+                    `${PROJECT_HOST}/internalapi/project/${projectId}/get/${revision}` :
+                    `${PROJECT_HOST}/internalapi/project/${projectId}/get/`;
             }
         );
     }


### PR DESCRIPTION
Instead of hardcoding the projects server host here, let's use the relevant env.variable if available.