### PR TITLE
Fix gh-2160: Search with %

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -78,7 +78,7 @@ class Search extends React.Component {
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = decodeURIComponent(term.split('+').join(' '));
+        term = decodeURIComponent(term);
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -80,7 +80,7 @@ class Search extends React.Component {
         }
         try {
             term = decodeURIComponent(term);
-        } catch (e){
+        } catch (e) {
             // Error means that term was not URI encoded and decoding failed.
             // We can silence this error because not all query strings are intended to be decoded.
         }

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -78,7 +78,12 @@ class Search extends React.Component {
         while (term.indexOf('&') > -1) {
             term = term.substring(0, term.indexOf('&'));
         }
-        term = decodeURIComponent(term);
+        try {
+            term = decodeURIComponent(term);
+        } catch (e){
+            // Error means that term was not URI encoded and decoding failed.
+            // We can silence this error because not all query strings are intended to be decoded.
+        }
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {


### PR DESCRIPTION
### Resolves https://github.com/LLK/scratch-www/issues/2160

### Changes:

Because query terms only sometimes need to be decoded, we attempt URI decoding and silence the error if it fails. This lets us still search with queries like `cat%25cat` when we want to, but now falls back to no-decoding when an invalid string is presented (e.g. `100%pen`). 

