### PR TITLE
fix modal prop

### DIFF
--- a/src/components/modal/base/modal.jsx
+++ b/src/components/modal/base/modal.jsx
@@ -23,15 +23,14 @@ class Modal extends React.Component {
         return this.modal.portal.requestClose();
     }
     render () {
-        // only set bodyOpenClassName prop if this.props.useStandardSizes is true.
-        // (careful -- setting bodyOpenClassName to null here causes an error, because
-        // ReactModal does not correctly handle the case of a null bodyOpenClassName)
-        const bodyOpenClassNameProp = this.props.useStandardSizes ?
-            {bodyOpenClassName: classNames('overflow-hidden')} : {};
         return (
             <ReactModal
                 appElement={document.getElementById('app')}
-                {...bodyOpenClassNameProp}
+                // bodyOpenClassName can be blank string, but must not be null here; a null value causes
+                // an error, because ReactModal does not correctly handle the case of a null bodyOpenClassName
+                bodyOpenClassName={classNames({
+                    'overflow-hidden': this.props.useStandardSizes
+                })}
                 className={{
                     base: classNames('modal-content', this.props.className, {
                         'modal-sizes': this.props.useStandardSizes

--- a/src/components/modal/base/modal.jsx
+++ b/src/components/modal/base/modal.jsx
@@ -23,13 +23,16 @@ class Modal extends React.Component {
         return this.modal.portal.requestClose();
     }
     render () {
+        // only set bodyOpenClassName prop if this.props.useStandardSizes is true.
+        // (careful -- setting bodyOpenClassName to null here causes an error, because
+        // ReactModal does not correctly handle the case of a null bodyOpenClassName)
+        const bodyOpenClassName = {
+            ...(this.props.useStandardSizes ? {bodyOpenClassName: classNames('overflow-hidden')} : {})
+        };
         return (
             <ReactModal
                 appElement={document.getElementById('app')}
-                // only set bodyOpenClassName prop if this.props.useStandardSizes is true.
-                // (careful -- setting bodyOpenClassName to null here causes an error, because ReactModal
-                // does not correctly handle the case of a null bodyOpenClassName)
-                {...(this.props.useStandardSizes ? {bodyOpenClassName: classNames('overflow-hidden')} : {})}
+                {...bodyOpenClassName}
                 className={{
                     base: classNames('modal-content', this.props.className, {
                         'modal-sizes': this.props.useStandardSizes

--- a/src/components/modal/base/modal.jsx
+++ b/src/components/modal/base/modal.jsx
@@ -26,13 +26,12 @@ class Modal extends React.Component {
         // only set bodyOpenClassName prop if this.props.useStandardSizes is true.
         // (careful -- setting bodyOpenClassName to null here causes an error, because
         // ReactModal does not correctly handle the case of a null bodyOpenClassName)
-        const bodyOpenClassName = {
-            ...(this.props.useStandardSizes ? {bodyOpenClassName: classNames('overflow-hidden')} : {})
-        };
+        const bodyOpenClassNameProp = this.props.useStandardSizes ?
+            {bodyOpenClassName: classNames('overflow-hidden')} : {};
         return (
             <ReactModal
                 appElement={document.getElementById('app')}
-                {...bodyOpenClassName}
+                {...bodyOpenClassNameProp}
                 className={{
                     base: classNames('modal-content', this.props.className, {
                         'modal-sizes': this.props.useStandardSizes

--- a/src/components/modal/base/modal.jsx
+++ b/src/components/modal/base/modal.jsx
@@ -26,7 +26,10 @@ class Modal extends React.Component {
         return (
             <ReactModal
                 appElement={document.getElementById('app')}
-                bodyOpenClassName={this.props.useStandardSizes ? classNames('overflow-hidden') : null}
+                // only set bodyOpenClassName prop if this.props.useStandardSizes is true.
+                // (careful -- setting bodyOpenClassName to null here causes an error, because ReactModal
+                // does not correctly handle the case of a null bodyOpenClassName)
+                {...(this.props.useStandardSizes ? {bodyOpenClassName: classNames('overflow-hidden')} : {})}
                 className={{
                     base: classNames('modal-content', this.props.className, {
                         'modal-sizes': this.props.useStandardSizes


### PR DESCRIPTION
### Resolves:

An issue with react-modal (https://github.com/reactjs/react-modal/issues/697) was causing errors when we passed the prop `bodyOpenClassName` a value of `null`. It works when the value is `undefined` or the prop is omitted.

### Changes:

Now, when we are not setting `bodyOpenClassName` to a custom value, we simply omit the prop entirely.