### PR TITLE
Add comment toggling for the preview page

### DIFF
--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -6,5 +6,7 @@
     "preview.penExtensionChip": "Pen",
     "preview.speechExtensionChip": "Google Speech",
     "preview.translateExtensionChip": "Google Translate",
-    "preview.videoMotionChip": "Video Motion"
+    "preview.videoMotionChip": "Video Motion",
+    "preview.comments.turnOff": "Turn off commenting",
+    "preview.comments.turnedOff": "Sorry, comment posting has been turned off for this project."
 }

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -1,6 +1,8 @@
 const injectIntl = require('react-intl').injectIntl;
 const PropTypes = require('prop-types');
 const intlShape = require('react-intl').intlShape;
+const FormattedMessage = require('react-intl').FormattedMessage;
+
 const MediaQuery = require('react-responsive').default;
 const React = require('react');
 const Formsy = require('formsy-react').default;
@@ -76,6 +78,7 @@ const PreviewPresentation = ({
     onAddToStudioClicked,
     onAddToStudioClosed,
     onToggleStudio,
+    onToggleComments,
     onSeeInside,
     onUpdate
 }) => {
@@ -317,16 +320,37 @@ const PreviewPresentation = ({
                                 <div className="comments-container">
                                     <FlexRow className="comments-header">
                                         <h4>Comments</h4>
-                                        {/* TODO: Add toggle comments component and logic*/}
+                                        {userOwnsProject ? (
+                                            <div>
+                                                <label>
+                                                    <input
+                                                        checked={!projectInfo.comments_allowed}
+                                                        className="comments-allowed-input"
+                                                        type="checkbox"
+                                                        onChange={onToggleComments}
+                                                    />
+                                                    <FormattedMessage id="preview.comments.turnOff" />
+                                                </label>
+                                            </div>
+                                        ) : null}
                                     </FlexRow>
 
                                     <FlexRow className="comments-root-reply">
-                                        {isLoggedIn &&
-                                            <ComposeComment
-                                                projectId={projectId}
-                                                onAddComment={onAddComment}
-                                            />
-                                        }
+                                        {projectInfo.comments_allowed ? (
+                                            isLoggedIn ? (
+                                                <ComposeComment
+                                                    projectId={projectId}
+                                                    onAddComment={onAddComment}
+                                                />
+                                            ) : (
+                                                /* TODO add box for signing in to leave a comment */
+                                                null
+                                            )
+                                        ) : (
+                                            <div className="comments-turned-off">
+                                                <FormattedMessage id="preview.comments.turnedOff" />
+                                            </div>
+                                        )}
                                     </FlexRow>
 
                                     <FlexRow className="comments-list">
@@ -399,6 +423,7 @@ PreviewPresentation.propTypes = {
     onReportClose: PropTypes.func.isRequired,
     onReportSubmit: PropTypes.func.isRequired,
     onSeeInside: PropTypes.func,
+    onToggleComments: PropTypes.func,
     onToggleStudio: PropTypes.func,
     onUpdate: PropTypes.func,
     originalInfo: projectShape,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -48,6 +48,7 @@ class Preview extends React.Component {
             'handleSeeInside',
             'handleUpdateProjectTitle',
             'handleUpdate',
+            'handleToggleComments',
             'initCounts',
             'pushHistory',
             'renderLogin',
@@ -166,6 +167,14 @@ class Preview extends React.Component {
                     });
                 });
             });
+    }
+    handleToggleComments () {
+        this.props.updateProject(
+            this.props.projectInfo.id,
+            {comments_allowed: !this.props.projectInfo.comments_allowed},
+            this.props.user.username,
+            this.props.user.token
+        );
     }
     handleAddComment (comment, topLevelCommentId) {
         this.props.handleAddComment(comment, topLevelCommentId);
@@ -356,6 +365,7 @@ class Preview extends React.Component {
                         onReportClose={this.handleReportClose}
                         onReportSubmit={this.handleReportSubmit}
                         onSeeInside={this.handleSeeInside}
+                        onToggleComments={this.handleToggleComments}
                         onToggleStudio={this.handleToggleStudio}
                         onUpdate={this.handleUpdate}
                     />

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -189,6 +189,19 @@ $stage-width: 480px;
         .comment-bubble {
             text-align: left;
         }
+
+        .comments-turned-off {
+            border: 1px solid $ui-blue-25percent;
+            border-radius: .5rem;
+            padding: 1.5rem 0;
+            background: $ui-blue-10percent;
+            width: 100%;
+            text-align: center;
+        }
+
+        .comments-allowed-input {
+            margin-right: 3px;
+        }
     }
 
     .remix-button,

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -193,8 +193,8 @@ $stage-width: 480px;
         .comments-turned-off {
             border: 1px solid $ui-blue-25percent;
             border-radius: .5rem;
-            padding: 1.5rem 0;
             background: $ui-blue-10percent;
+            padding: 1.5rem 0;
             width: 100%;
             text-align: center;
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/654102/46760069-fc06c000-cc9e-11e8-9e2a-f34fdd2d071d.png)

![image](https://user-images.githubusercontent.com/654102/46760070-fdd08380-cc9e-11e8-8d81-13fa320aafab.png)

This uses the project update route using `comments_allowed` as a boolean property. This requires https://github.com/LLK/scratch-api/pull/590

For testing:
- As the project owner, you should see the comment toggling checkbox. When it is toggled, it should show the "sorry comments disabled" and should remain that way when the project is refreshed.
- If you are not the project owner, you should not see the toggle, but should see the "sorry comments disabled" message 