### PR TITLE
Fix Select Menu in Messages Section

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -16,7 +16,6 @@
         width: 100%;
         height: 3rem;
         margin:0px;
-        list-style-position:outside;
         padding-left: 1rem;
         color: $type-gray;
         font-size: .875rem;

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -15,7 +15,9 @@
         padding-right: 4rem;
         width: 100%;
         height: 3rem;
-        text-indent: 1rem;
+        margin:0px;
+        list-style-position:outside;
+        padding-left: 1rem;
         color: $type-gray;
         font-size: .875rem;
         appearance: none;

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -13,9 +13,9 @@
         border-radius: 5px;
         background: $ui-light-gray url("../../../static/svgs/forms/carot.svg") no-repeat right center;
         padding-right: 4rem;
+        padding-left: 1rem;
         width: 100%;
         height: 3rem;
-        padding-left: 1rem;
         color: $type-gray;
         font-size: .875rem;
         appearance: none;

--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -15,7 +15,6 @@
         padding-right: 4rem;
         width: 100%;
         height: 3rem;
-        margin:0px;
         padding-left: 1rem;
         color: $type-gray;
         font-size: .875rem;


### PR DESCRIPTION
### Resolves:

Resolves #1643

### Changes:

Fixes the text slicing in the select menu of the Messages section. Potential reason can be due to different indentation spacing/styles across different browsers. This PR changes the text-indent property to left-padding potentially fixing it for all the browsers (Chrome, IE and Mozilla tested)

### Test Coverage:

Chrome (Desktop):
![image](https://user-images.githubusercontent.com/10993808/46852363-533a9b00-ce2d-11e8-8b3a-7cfcc093b009.png)

Chrome (Mobile):
![image](https://user-images.githubusercontent.com/10993808/46852339-3aca8080-ce2d-11e8-9a5d-f1e5c280a3c4.png)

Firefox(Desktop):
![image](https://user-images.githubusercontent.com/10993808/46852409-71a09680-ce2d-11e8-8924-a85f068ce068.png)

Firefox(Mobile):
![image](https://user-images.githubusercontent.com/10993808/46852393-69e0f200-ce2d-11e8-9857-509ccbce8d7b.png)

IE (Desktop):
![image](https://user-images.githubusercontent.com/10993808/46852496-c8a66b80-ce2d-11e8-9741-682fdf554a57.png)


IE (Responsive):

![image](https://user-images.githubusercontent.com/10993808/46852476-b75d5f00-ce2d-11e8-8e8d-fc9e28eb44e9.png)

