### PR TITLE
made account menu have min-width, changed max-width to rem from px

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -9,7 +9,8 @@
     border-radius: 0 0 5px 5px;
     background-color: $ui-blue;
     padding: 10px;
-    max-width: 260px;
+    min-width: 9rem;
+    max-width: 16.25rem;
     overflow: visible;
     color: $type-white;
     font-size: .8125rem;
@@ -87,9 +88,5 @@
 
             content: "";
         }
-    }
-
-    @media only screen and (max-width: $tablet - 1) {
-        min-width: 160px;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-www/issues/1318

Maintains status of closed issue https://github.com/LLK/scratch-www/issues/1292

Note: hard to test on mobile widths because of https://github.com/LLK/scratch-www/issues/2180

Before: 
![screen shot 2018-10-12 at 9 23 00 am](https://user-images.githubusercontent.com/3431616/46872237-92eb8d80-ce01-11e8-8906-4d2806d3295e.png)


After:
![screen shot 2018-10-12 at 9 22 52 am](https://user-images.githubusercontent.com/3431616/46872250-9a129b80-ce01-11e8-9004-bb52dc8694b7.png)


Before: 
![screen shot 2018-10-12 at 9 24 40 am](https://user-images.githubusercontent.com/3431616/46872268-a3036d00-ce01-11e8-8854-ab502744f23c.png)

After:
(Note: this is slightly wider, and uglier, than a username this width would previously have)
![screen shot 2018-10-12 at 9 24 31 am](https://user-images.githubusercontent.com/3431616/46872274-a72f8a80-ce01-11e8-9d79-9f5a11a28e05.png)


Before and after, unchanged:
![screen shot 2018-10-12 at 9 24 19 am](https://user-images.githubusercontent.com/3431616/46872320-c1696880-ce01-11e8-9328-17f034addac4.png)

