### PR TITLE
Japanese Character Fix

### DIFF
--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -16,7 +16,7 @@
     #{$extras} {
         overflow: hidden;
         text-overflow: ellipsis;
-        line-height: normal;
+        line-height: 1.2em;
         white-space: nowrap;
         word-wrap: break-word;
     }


### PR DESCRIPTION
### Resolves:

Resolves #1191

### Changes:

 Japanese characters in the title were increasing the height of the line by 4 pixels. As mentioned the line-height has been changed from 'normal' to 1.2em. This has fixed the alignment issues.

### Test Coverage:
Before Fix:
![image](https://user-images.githubusercontent.com/10993808/46914120-fe2a9080-cfb6-11e8-8648-5a50c31a8526.png)

After Fix:
![image](https://user-images.githubusercontent.com/10993808/46914063-f4ecf400-cfb5-11e8-8918-0406f03eceb6.png)

Tested in browsers : Chrome, Mozilla and IE

Mozilla:
![image](https://user-images.githubusercontent.com/10993808/46914189-52357500-cfb7-11e8-9730-280ee31729f6.png)

IE:
![image](https://user-images.githubusercontent.com/10993808/46914192-65484500-cfb7-11e8-9e79-832a747e36a8.png)

