### PR TITLE
Thumbnail Fix

### DIFF
--- a/src/views/microworld/fashion/fashion.json
+++ b/src/views/microworld/fashion/fashion.json
@@ -8,7 +8,7 @@
    ],
    "videos":[
       {
-         "image":"https://i.vimeocdn.com/video/528845372.webp?mw=900&amp;mh=583&amp;q=70",
+         "image":"https://i.vimeocdn.com/video/528845372.png?mw=900&amp;mh=583&amp;q=70",
          "link":"//player.vimeo.com/video/134864477?title=0&byline=0&portrait=0"
       }
    ],

--- a/src/views/microworld/hiphop/hiphop.json
+++ b/src/views/microworld/hiphop/hiphop.json
@@ -8,7 +8,7 @@
    ],
    "videos":[
       {
-         "image":"https://i.vimeocdn.com/video/521248373.webp?mw=900&mh=583&q=70",
+         "image":"https://i.vimeocdn.com/video/521248373.png?mw=900&mh=583&q=70",
          "link":"//player.vimeo.com/video/124055657?title=0&byline=0&portrait=0"
       }
    ],


### PR DESCRIPTION
### Resolves:

Resolves #998.

### Changes:

Firefox and IE are not able to load the WebP image on the hip-hop page. Changing the extension of the image from .webp to .png fixes the problem. Not sure if this the desired solution, Firefox is currently incorporating WebP support.

### Test Coverage:

Firefox before fix:
![image](https://user-images.githubusercontent.com/10993808/46914969-d8a38400-cfc2-11e8-92db-e39362b65bc8.png)

Firefox after fix:
![image](https://user-images.githubusercontent.com/10993808/46914983-0688c880-cfc3-11e8-8215-7d96fe570ef3.png)

Edge after fix:
![image](https://user-images.githubusercontent.com/10993808/46914979-f4a72580-cfc2-11e8-881b-85c3503d3400.png)


