### PR TITLE
Use the proper API route for reporting projects

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -660,7 +660,7 @@ module.exports.reportComment = (projectId, commentId, topLevelCommentId, token) 
     });
 });
 
-module.exports.reportProject = (id, jsonData) => (dispatch => {
+module.exports.reportProject = (id, jsonData, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('report', module.exports.Status.FETCHING));
     // scratchr2 will fail if no thumbnail base64 string provided. We don't yet have
     // a way to get the actual project thumbnail in www/gui, so for now just submit
@@ -670,11 +670,12 @@ module.exports.reportProject = (id, jsonData) => (dispatch => {
             '0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
     });
     api({
-        host: '',
-        uri: `/site-api/projects/all/${id}/report/`,
+        uri: `/proxy/projects/${id}/report`,
+        authentication: token,
+        withCredentials: true,
         method: 'POST',
-        json: jsonData,
-        useCsrf: true
+        useCsrf: true,
+        json: jsonData
     }, (err, body, res) => {
         if (err || res.statusCode !== 200) {
             dispatch(module.exports.setFetchStatus('report', module.exports.Status.ERROR));

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -199,7 +199,7 @@ class Preview extends React.Component {
         this.setState({addToStudioOpen: false});
     }
     handleReportSubmit (formData) {
-        this.props.reportProject(this.state.projectId, formData);
+        this.props.reportProject(this.state.projectId, formData, this.props.user.token);
     }
     handlePopState () {
         const path = window.location.pathname.toLowerCase();
@@ -612,8 +612,8 @@ const mapDispatchToProps = dispatch => ({
     setLovedStatus: (loved, id, username, token) => {
         dispatch(previewActions.setLovedStatus(loved, id, username, token));
     },
-    reportProject: (id, formData) => {
-        dispatch(previewActions.reportProject(id, formData));
+    reportProject: (id, formData, token) => {
+        dispatch(previewActions.reportProject(id, formData, token));
     },
     setOriginalInfo: info => {
         dispatch(previewActions.setOriginalInfo(info));


### PR DESCRIPTION
/cc @benjiwheeler @colbygk this PR moves the last request from preview that was hitting `/site-api` directly to hitting the correct proxy route. I also added the token so that the API accepts the request, and I think because of fixes colby made to `/proxy` it now goes through correctly. This worked on my local setup, but once it is deployed we should just double check that it works on staging (i don't see why it wouldn't, but these proxy routes are finnicky. 

/cc @rschamp This closes the card we discussed today about "API used for all proxy routes"