### PR TITLE
Pass to and receive from GUI info about project creation lifecycle; handle url changes

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -46,6 +46,8 @@ module.exports.previewReducer = (state, action) => {
     }
 
     switch (action.type) {
+    case 'RESET_TO_INTIAL_STATE':
+        return module.exports.getInitialState();
     case 'SET_PROJECT_INFO':
         return Object.assign({}, state, {
             projectInfo: action.info
@@ -162,6 +164,10 @@ module.exports.previewReducer = (state, action) => {
 module.exports.setError = error => ({
     type: 'ERROR',
     error: error
+});
+
+module.exports.resetProject = () => ({
+    type: 'RESET_TO_INTIAL_STATE'
 });
 
 module.exports.setProjectInfo = info => ({

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -403,6 +403,7 @@ class Preview extends React.Component {
                         canRemix={this.props.canRemix}
                         canSave={this.props.canSave}
                         canSaveAsCopy={this.props.canSaveAsCopy}
+                        canSaveNew={this.props.canSaveNew}
                         canShare={this.props.canShare}
                         className="gui"
                         projectHost={this.props.projectHost}
@@ -430,11 +431,12 @@ Preview.propTypes = {
         visible: PropTypes.bool
     }),
     canAddToStudio: PropTypes.bool,
-    canCreateNew: PropTypes.bool,
+    canCreateNew: PropTypes.bool, // NOTE: rename these?
     canRemix: PropTypes.bool,
     canReport: PropTypes.bool,
     canSave: PropTypes.bool,
     canSaveAsCopy: PropTypes.bool,
+    canSaveNew: PropTypes.bool,
     canShare: PropTypes.bool,
     comments: PropTypes.arrayOf(PropTypes.object),
     faved: PropTypes.bool,
@@ -550,11 +552,12 @@ const mapStateToProps = state => {
 
     return {
         canAddToStudio: isLoggedIn && userOwnsProject,
-        canCreateNew: false,
+        canCreateNew: isLoggedIn && userOwnsProject,
         canRemix: false,
         canReport: isLoggedIn && !userOwnsProject,
         canSave: userOwnsProject,
         canSaveAsCopy: false,
+        canSaveNew: isLoggedIn,
         canShare: userOwnsProject && state.permissions.social,
         comments: state.preview.comments,
         faved: state.preview.faved,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -126,7 +126,7 @@ class Preview extends React.Component {
             const username = this.props.user.username;
             const token = this.props.user.token;
             this.props.getTopLevelComments(this.state.projectId, this.props.comments.length,
-                 this.props.isAdmin, token);
+                this.props.isAdmin, token);
             this.props.getProjectInfo(this.state.projectId, token);
             this.props.getRemixes(this.state.projectId, token);
             this.props.getProjectStudios(this.state.projectId, token);
@@ -335,8 +335,6 @@ class Preview extends React.Component {
         });
     }
     handleUpdateProjectId (projectId, callback) {
-        // NOTE: this needs more work
-        // NOTE: need to load everything for new project that is loaded in componentDidUpdate
         this.setState({projectId: projectId}, () => {
             const parts = window.location.pathname.toLowerCase()
                 .split('/')

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -77,11 +77,15 @@ class Preview extends React.Component {
         /* In the beginning, if user is on mobile and landscape, go to fullscreen */
         this.setScreenFromOrientation();
     }
-    componentDidUpdate (prevProps) {
-        if (this.props.sessionStatus !== prevProps.sessionStatus &&
-            this.props.sessionStatus === sessionActions.Status.FETCHED &&
-            this.state.projectId) {
+    componentDidUpdate (prevProps, prevState) {
+        if (this.state.projectId &&
+            ((this.props.sessionStatus !== prevProps.sessionStatus &&
+            this.props.sessionStatus === sessionActions.Status.FETCHED) ||
+            (this.state.projectId !== prevState.projectId))) {
             this.fetchCommunityData();
+        }
+        if (this.state.projectId === '0' && this.state.projectId !== prevState.projectId) {
+            this.props.resetProject();
         }
         if (this.props.projectInfo.id !== prevProps.projectInfo.id) {
             if (typeof this.props.projectInfo.id === 'undefined') {
@@ -340,10 +344,8 @@ class Preview extends React.Component {
             let newUrl;
             if (projectId === '0') {
                 newUrl = `/${parts[0]}/editor`;
-                this.props.resetProject();
             } else {
                 newUrl = `/${parts[0]}/${projectId}/editor`;
-                this.fetchCommunityData();
             }
             history.pushState(
                 `project ${projectId}`,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -338,7 +338,7 @@ class Preview extends React.Component {
                 .split('/')
                 .filter(Boolean);
             let newUrl;
-            if (projectId === 0) {
+            if (projectId === '0') {
                 newUrl = `/${parts[0]}/editor`;
                 this.props.resetProject();
             } else {
@@ -466,7 +466,7 @@ Preview.propTypes = {
         visible: PropTypes.bool
     }),
     canAddToStudio: PropTypes.bool,
-    canCreateNew: PropTypes.bool, // NOTE: rename these?
+    canCreateNew: PropTypes.bool,
     canRemix: PropTypes.bool,
     canReport: PropTypes.bool,
     canSave: PropTypes.bool,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -68,7 +68,7 @@ class Preview extends React.Component {
             extensions: [],
             favoriteCount: 0,
             loveCount: 0,
-            projectId: parts[1] === 'editor' ? 0 : parts[1],
+            projectId: parts[1] === 'editor' ? '0' : parts[1],
             addToStudioOpen: false,
             reportOpen: false
         };
@@ -437,7 +437,6 @@ class Preview extends React.Component {
                         canRemix={this.props.canRemix}
                         canSave={this.props.canSave}
                         canSaveAsCopy={this.props.canSaveAsCopy}
-                        canSaveNew={this.props.canSaveNew}
                         canShare={this.props.canShare}
                         className="gui"
                         enableCommunity={this.props.enableCommunity}
@@ -472,7 +471,6 @@ Preview.propTypes = {
     canReport: PropTypes.bool,
     canSave: PropTypes.bool,
     canSaveAsCopy: PropTypes.bool,
-    canSaveNew: PropTypes.bool,
     canShare: PropTypes.bool,
     comments: PropTypes.arrayOf(PropTypes.object),
     enableCommunity: PropTypes.bool,
@@ -595,9 +593,8 @@ const mapStateToProps = state => {
         canCreateNew: true,
         canRemix: false,
         canReport: isLoggedIn && !userOwnsProject,
-        canSave: userOwnsProject,
+        canSave: isLoggedIn && (userOwnsProject || !state.preview.projectInfo.id),
         canSaveAsCopy: false,
-        canSaveNew: isLoggedIn,
         canShare: userOwnsProject && state.permissions.social,
         comments: state.preview.comments,
         enableCommunity: state.preview.projectInfo && state.preview.projectInfo.id > 0,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -84,15 +84,22 @@ class Preview extends React.Component {
             this.fetchCommunityData();
         }
         if (this.props.projectInfo.id !== prevProps.projectInfo.id) {
-            this.getExtensions(this.state.projectId);
-            this.initCounts(this.props.projectInfo.stats.favorites, this.props.projectInfo.stats.loves);
-            if (this.props.projectInfo.remix.parent !== null) {
-                this.props.getParentInfo(this.props.projectInfo.remix.parent);
-            }
-            if (this.props.projectInfo.remix.root !== null &&
-                this.props.projectInfo.remix.root !== this.props.projectInfo.remix.parent
-            ) {
-                this.props.getOriginalInfo(this.props.projectInfo.remix.root);
+            if (typeof this.props.projectInfo.id === 'undefined') {
+                this.initCounts(0, 0);
+                this.setState({ // eslint-disable-line react/no-did-update-set-state
+                    extensions: []
+                });
+            } else {
+                this.getExtensions(this.state.projectId);
+                this.initCounts(this.props.projectInfo.stats.favorites, this.props.projectInfo.stats.loves);
+                if (this.props.projectInfo.remix.parent !== null) {
+                    this.props.getParentInfo(this.props.projectInfo.remix.parent);
+                }
+                if (this.props.projectInfo.remix.root !== null &&
+                    this.props.projectInfo.remix.root !== this.props.projectInfo.remix.parent
+                ) {
+                    this.props.getOriginalInfo(this.props.projectInfo.remix.root);
+                }
             }
         }
         if (this.props.playerMode !== prevProps.playerMode || this.props.fullScreen !== prevProps.fullScreen) {
@@ -327,15 +334,16 @@ class Preview extends React.Component {
         // NOTE: this needs more work
         // NOTE: need to load everything for new project that is loaded in componentDidUpdate
         this.setState({projectId: projectId}, () => {
-            this.fetchCommunityData();
             const parts = window.location.pathname.toLowerCase()
                 .split('/')
                 .filter(Boolean);
             let newUrl;
             if (projectId === 0) {
                 newUrl = `/${parts[0]}/editor`;
+                this.props.resetProject();
             } else {
                 newUrl = `/${parts[0]}/${projectId}/editor`;
+                this.fetchCommunityData();
             }
             history.pushState(
                 `project ${projectId}`,
@@ -501,6 +509,7 @@ Preview.propTypes = {
     remixes: PropTypes.arrayOf(PropTypes.object),
     replies: PropTypes.objectOf(PropTypes.array),
     reportProject: PropTypes.func,
+    resetProject: PropTypes.func,
     sessionStatus: PropTypes.string,
     setFavedStatus: PropTypes.func.isRequired,
     setFullScreen: PropTypes.func.isRequired,
@@ -583,7 +592,7 @@ const mapStateToProps = state => {
 
     return {
         canAddToStudio: isLoggedIn && userOwnsProject,
-        canCreateNew: true, // NOTE: rename this and canSaveNew?
+        canCreateNew: true,
         canRemix: false,
         canReport: isLoggedIn && !userOwnsProject,
         canSave: userOwnsProject,
@@ -691,6 +700,9 @@ const mapDispatchToProps = dispatch => ({
     },
     reportProject: (id, formData, token) => {
         dispatch(previewActions.reportProject(id, formData, token));
+    },
+    resetProject: () => {
+        dispatch(previewActions.resetProject());
     },
     setOriginalInfo: info => {
         dispatch(previewActions.setOriginalInfo(info));

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -348,8 +348,8 @@ class Preview extends React.Component {
                 newUrl = `/${parts[0]}/${projectId}/editor`;
             }
             history.pushState(
-                `project ${projectId}`,
-                `project ${projectId}`,
+                {projectId: projectId},
+                {projectId: projectId},
                 newUrl
             );
             if (callback) callback();

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -78,7 +78,7 @@ class Preview extends React.Component {
         this.setScreenFromOrientation();
     }
     componentDidUpdate (prevProps, prevState) {
-        if (this.state.projectId &&
+        if (this.state.projectId > 0 &&
             ((this.props.sessionStatus !== prevProps.sessionStatus &&
             this.props.sessionStatus === sessionActions.Status.FETCHED) ||
             (this.state.projectId !== prevState.projectId))) {
@@ -578,7 +578,8 @@ const consolidateStudiosInfo = (curatedStudios, projectStudios, currentStudioIds
 
 const mapStateToProps = state => {
     const projectInfoPresent = Object.keys(state.preview.projectInfo).length > 0;
-    const userPresent = state.session.session.user &&
+    const userPresent = state.session.session.user !== null &&
+        typeof state.session.session.user !== 'undefined' &&
         Object.keys(state.session.session.user).length > 0;
     const isLoggedIn = state.session.status === sessionActions.Status.FETCHED &&
         userPresent;


### PR DESCRIPTION
Wait to merge until https://github.com/LLK/scratch-gui/issues/3391 is merged

* Sets and provides props to gui:
  * canSave: now also true when user is logged in and project page is showing default project
  * enableCommunity: instead of always enabling, only enable when the project actually has a project/community page
* Can reset project page state to reflect change in which project is showing]
  * updates url when gui calls back with new project id

