### PR TITLE
Add * to comments from staff on preview

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -111,7 +111,9 @@ class Comment extends React.Component {
                         <a
                             className="username"
                             href={`/users/${author.username}`}
-                        >{author.username}</a>
+                        >
+                            {author.username}{author.is_staff ? '*' : ''}
+                        </a>
                         <div className="action-list">
                             {visible ? (
                                 <React.Fragment>
@@ -214,6 +216,7 @@ Comment.propTypes = {
     author: PropTypes.shape({
         id: PropTypes.number,
         image: PropTypes.string,
+        is_staff: PropTypes.bool,
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,

--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -112,7 +112,7 @@ class Comment extends React.Component {
                             className="username"
                             href={`/users/${author.username}`}
                         >
-                            {author.username}{author.is_staff ? '*' : ''}
+                            {author.username}{author.scratchteam ? '*' : ''}
                         </a>
                         <div className="action-list">
                             {visible ? (
@@ -216,7 +216,7 @@ Comment.propTypes = {
     author: PropTypes.shape({
         id: PropTypes.number,
         image: PropTypes.string,
-        is_staff: PropTypes.bool,
+        scratchteam: PropTypes.bool,
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -142,6 +142,7 @@ TopLevelComment.propTypes = {
     author: PropTypes.shape({
         id: PropTypes.number,
         image: PropTypes.string,
+        is_staff: PropTypes.bool,
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -142,7 +142,7 @@ TopLevelComment.propTypes = {
     author: PropTypes.shape({
         id: PropTypes.number,
         image: PropTypes.string,
-        is_staff: PropTypes.bool,
+        scratchteam: PropTypes.bool,
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,


### PR DESCRIPTION
This PR will show the staff * next to staff usernames on comments, once that information starts coming from the API on comments. 

