### PR TITLE
Show the username of the parent comment in replies

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -5,6 +5,7 @@ const classNames = require('classnames');
 
 const FlexRow = require('../../../components/flex-row/flex-row.jsx');
 const Avatar = require('../../../components/avatar/avatar.jsx');
+const EmojiText = require('../../../components/emoji-text/emoji-text.jsx');
 const FormattedRelative = require('react-intl').FormattedRelative;
 const FormattedMessage = require('react-intl').FormattedMessage;
 const ComposeComment = require('./compose-comment.jsx');
@@ -166,7 +167,10 @@ class Comment extends React.Component {
                             {replyUsername && (
                                 <a href={`/users/${replyUsername}`}>@{replyUsername}&nbsp;</a>
                             )}
-                            {content}
+                            <EmojiText
+                                as="span"
+                                text={content}
+                            />
                         </span>
                         <FlexRow className="comment-bottom-row">
                             <span className="comment-time">

--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -93,6 +93,7 @@ class Comment extends React.Component {
             datetimeCreated,
             id,
             projectId,
+            replyUsername,
             visibility
         } = this.props;
 
@@ -160,7 +161,13 @@ class Comment extends React.Component {
                           * @user links in replies
                           * links to scratch.mit.edu pages
                           */}
-                        <span className="comment-content">{content}</span>
+
+                        <span className="comment-content">
+                            {replyUsername && (
+                                <a href={`/users/${replyUsername}`}>@{replyUsername}&nbsp;</a>
+                            )}
+                            {content}
+                        </span>
                         <FlexRow className="comment-bottom-row">
                             <span className="comment-time">
                                 <FormattedRelative value={new Date(datetimeCreated)} />
@@ -228,6 +235,7 @@ Comment.propTypes = {
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
     projectId: PropTypes.string,
+    replyUsername: PropTypes.string,
     visibility: PropTypes.string
 };
 

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -22,6 +22,9 @@ class TopLevelComment extends React.Component {
         this.state = {
             expanded: false
         };
+
+        // A cache of {commentId: username, ...} in order to show reply usernames
+        this.commentUsernameCache = {};
     }
 
     handleExpandThread () {
@@ -48,6 +51,19 @@ class TopLevelComment extends React.Component {
 
     handleAddComment (comment) {
         this.props.onAddComment(comment, this.props.id);
+    }
+
+    commentUsername (parentId) {
+        if (this.commentUsernameCache[parentId]) return this.commentUsernameCache[parentId];
+
+        // If the cache misses, rebuild it. Every reply has a parent id that is
+        // either a reply to this top level comment or to one of the replies.
+        this.commentUsernameCache[this.props.id] = this.props.author.username;
+        const replies = this.props.replies;
+        for (let i = 0; i < replies.length; i++) {
+            this.commentUsernameCache[replies[i].id] = replies[i].author.username;
+        }
+        return this.commentUsernameCache[parentId];
     }
 
     render () {
@@ -111,6 +127,7 @@ class TopLevelComment extends React.Component {
                                 id={reply.id}
                                 key={reply.id}
                                 projectId={projectId}
+                                replyUsername={this.commentUsername(reply.parent_id)}
                                 visibility={reply.visibility}
                                 onAddComment={this.handleAddComment}
                                 onDelete={this.handleDeleteReply}


### PR DESCRIPTION
Prefix comment content with `@username` that links to that users profile

The only thing I'm uncertain about is whether the API should take care of naming the parent username, but I figured since the TopLevelComment component has all the necessary information to do it, it might as well. I think moving this to the API would make it more resilient to loading non-sequential sub-slices of replies, or other situations where you might not have the entire thread.

The second commit also makes the comment use the EmojiText component for showing the content, which is unrelated, but it should have been doing it from the beginning so that the API can emojify the comment content (the way it already is doing for comment notifications). 

![image](https://user-images.githubusercontent.com/654102/47161461-143e9680-d2c0-11e8-8dc5-b6d02d8df8ed.png)
