### PR TITLE
Use top level + replies count to control "Load More" comments button

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -90,6 +90,7 @@ const PreviewPresentation = ({
     onUpdate
 }) => {
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
+    const loadedCommentCount = comments.length + Object.keys(replies).reduce((acc, id) => acc + replies[id].length, 0);
     return (
         <div className="preview">
             {!isShared && (
@@ -383,7 +384,7 @@ const PreviewPresentation = ({
                                                 onRestore={onRestoreComment}
                                             />
                                         ))}
-                                        {comments.length < projectInfo.stats.comments &&
+                                        {loadedCommentCount < projectInfo.stats.comments &&
                                         <Button
                                             className="button load-more-button"
                                             onClick={onLoadMore}


### PR DESCRIPTION
This fixes an issue where a project with one top-level comment and one reply would should the "Load more" button at the bottom, even though there were no more to load

On develop
![image](https://user-images.githubusercontent.com/654102/47166797-f9bdea80-d2ca-11e8-830b-f27f33852dc2.png)


With this fix
![image](https://user-images.githubusercontent.com/654102/47166802-fdea0800-d2ca-11e8-95a7-2ff49ca2cefd.png)
