### PR TITLE
Connect the consolidated studio data directly

### DIFF
--- a/src/components/modal/addtostudio/container.jsx
+++ b/src/components/modal/addtostudio/container.jsx
@@ -8,7 +8,8 @@ class AddToStudioModal extends React.Component {
         super(props);
         bindAll(this, [
             'handleRequestClose',
-            'handleSubmit'
+            'handleSubmit',
+            'handleToggleStudio'
         ]);
 
         this.state = {
@@ -48,6 +49,14 @@ class AddToStudioModal extends React.Component {
         });
     }
 
+    handleToggleStudio (id) {
+        const studioId = parseInt(id, 10);
+        if (isNaN(studioId)) { // sanity check in case event had no integer data-id
+            return;
+        }
+        this.props.onToggleStudio(this.props.studios.find(studio => studio.id === studioId));
+    }
+
     render () {
         return (
             <AddToStudioModalPresentation
@@ -56,7 +65,7 @@ class AddToStudioModal extends React.Component {
                 waitingToClose={this.state.waitingToClose}
                 onRequestClose={this.handleRequestClose}
                 onSubmit={this.handleSubmit}
-                onToggleStudio={this.props.onToggleStudio}
+                onToggleStudio={this.handleToggleStudio}
             />
         );
     }

--- a/src/views/preview/add-to-studio.jsx
+++ b/src/views/preview/add-to-studio.jsx
@@ -1,0 +1,54 @@
+const connect = require('react-redux').connect;
+
+const previewActions = require('../../redux/preview.js');
+const AddToStudioModal = require('../../components/modal/addtostudio/container.jsx');
+
+// Build consolidated curatedStudios object from all studio info.
+// We add flags to indicate whether the project is currently in the studio,
+// and the status of requests to join/leave studios.
+const consolidateStudiosInfo = (curatedStudios, projectStudios, currentStudioIds, studioRequests) => {
+    const consolidatedStudios = [];
+
+    projectStudios.forEach(projectStudio => {
+        const includesProject = (currentStudioIds.indexOf(projectStudio.id) !== -1);
+        const consolidatedStudio =
+            Object.assign({}, projectStudio, {includesProject: includesProject});
+        consolidatedStudios.push(consolidatedStudio);
+    });
+
+    // copy the curated studios that project is not in
+    curatedStudios.forEach(curatedStudio => {
+        if (!projectStudios.some(projectStudio => (projectStudio.id === curatedStudio.id))) {
+            const includesProject = (currentStudioIds.indexOf(curatedStudio.id) !== -1);
+            const consolidatedStudio =
+                Object.assign({}, curatedStudio, {includesProject: includesProject});
+            consolidatedStudios.push(consolidatedStudio);
+        }
+    });
+
+    // set studio state to hasRequestOutstanding==true if it's being fetched,
+    // false if it's not
+    consolidatedStudios.forEach(consolidatedStudio => {
+        const id = consolidatedStudio.id;
+        consolidatedStudio.hasRequestOutstanding =
+            ((id in studioRequests) &&
+           (studioRequests[id] === previewActions.Status.FETCHING));
+    });
+
+    return consolidatedStudios;
+};
+
+const mapStateToProps = state => ({
+    studios: consolidateStudiosInfo(state.preview.curatedStudios,
+        state.preview.projectStudios, state.preview.currentStudioIds,
+        state.preview.status.studioRequests)
+});
+
+const mapDispatchToProps = () => ({});
+
+const ConnectedAddToStudioModal = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(AddToStudioModal);
+
+module.exports = ConnectedAddToStudioModal;

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -69,7 +69,6 @@ const PreviewPresentation = ({
     replies,
     addToStudioOpen,
     projectStudios,
-    studios,
     userOwnsProject,
     onAddComment,
     onDeleteComment,
@@ -183,7 +182,6 @@ const PreviewPresentation = ({
                                         projectInfo={projectInfo}
                                         reportOpen={reportOpen}
                                         shareDate={shareDate}
-                                        studios={studios}
                                         onAddToStudioClicked={onAddToStudioClicked}
                                         onAddToStudioClosed={onAddToStudioClosed}
                                         onReportClicked={onReportClicked}
@@ -296,7 +294,6 @@ const PreviewPresentation = ({
                                     projectInfo={projectInfo}
                                     reportOpen={reportOpen}
                                     shareDate={shareDate}
-                                    studios={studios}
                                     onAddToStudioClicked={onAddToStudioClicked}
                                     onAddToStudioClosed={onAddToStudioClosed}
                                     onReportClicked={onReportClicked}
@@ -454,7 +451,6 @@ PreviewPresentation.propTypes = {
     remixes: PropTypes.arrayOf(PropTypes.object),
     replies: PropTypes.objectOf(PropTypes.array),
     reportOpen: PropTypes.bool,
-    studios: PropTypes.arrayOf(PropTypes.object),
     userOwnsProject: PropTypes.bool
 };
 

--- a/src/views/preview/subactions.jsx
+++ b/src/views/preview/subactions.jsx
@@ -4,7 +4,7 @@ const React = require('react');
 const FlexRow = require('../../components/flex-row/flex-row.jsx');
 
 const Button = require('../../components/forms/button.jsx');
-const AddToStudioModal = require('../../components/modal/addtostudio/container.jsx');
+const AddToStudioModal = require('./add-to-studio.jsx');
 const ReportModal = require('../../components/modal/report/modal.jsx');
 
 require('./subactions.scss');
@@ -35,14 +35,15 @@ const Subactions = props => (
                         onClick={props.onAddToStudioClicked}
                     >
                         Add to Studio
-                    </Button>,
-                    <AddToStudioModal
-                        isOpen={props.addToStudioOpen}
-                        key="add-to-studio-modal"
-                        studios={props.studios}
-                        onRequestClose={props.onAddToStudioClosed}
-                        onToggleStudio={props.onToggleStudio}
-                    />
+                    </Button>
+                    {props.addToStudioOpen && (
+                        <AddToStudioModal
+                            isOpen
+                            key="add-to-studio-modal"
+                            onRequestClose={props.onAddToStudioClosed}
+                            onToggleStudio={props.onToggleStudio}
+                        />
+                    )}
                 </React.Fragment>
             }
             <Button className="action-button copy-link-button">
@@ -56,14 +57,16 @@ const Subactions = props => (
                     onClick={props.onReportClicked}
                 >
                     Report
-                </Button>,
-                <ReportModal
-                    isOpen={props.reportOpen}
-                    key="report-modal"
-                    type="project"
-                    onReport={props.onReportSubmit}
-                    onRequestClose={props.onReportClose}
-                />
+                </Button>
+                {props.reportOpen && (
+                    <ReportModal
+                        isOpen
+                        key="report-modal"
+                        type="project"
+                        onReport={props.onReportSubmit}
+                        onRequestClose={props.onReportClose}
+                    />
+                )}
             </React.Fragment>
             }
         </FlexRow>
@@ -81,8 +84,7 @@ Subactions.propTypes = {
     onReportSubmit: PropTypes.func.isRequired,
     onToggleStudio: PropTypes.func,
     reportOpen: PropTypes.bool,
-    shareDate: PropTypes.string,
-    studios: PropTypes.arrayOf(PropTypes.object)
+    shareDate: PropTypes.string
 };
 
 module.exports = Subactions;


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-www/issues/2209

There was a performance problem because of returning a new array for consolidatedStudios, which was causing the page to rerender constantly. Instead, move the logic into a connected container for `AddToStudioModal`, and only render the modal if it is visible, ensuring these updates only happen when the modal is open. 

An alternative solution would be to memoize the result of `consolidateStudios`, but it felt better to extract that logic into its own place and fix the issues with rendering invisible modals. 

/cc @rschamp @benjiwheeler 

ps a good way to see that this fixes the issue, beside FPS, is to use the `Highlight Updates` option in the React dev tools (under the gear at the top right). It is like the highlight paint in the chrome dev tools, but for react components (shows any time render is called, but that may not result in a DOM update, so another tool is needed).

![highlight-updates](https://user-images.githubusercontent.com/654102/47183579-6b5f5e00-d2f6-11e8-9a0f-eda146dffee9.gif)


Here is with it fixed

![highlight-updates-fixes](https://user-images.githubusercontent.com/654102/47183584-6f8b7b80-d2f6-11e8-8890-ff9369897163.gif)
