### PR TITLE
Integrate www-gui localization

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -12,6 +12,7 @@ const render = require('../../lib/render.jsx');
 const storage = require('../../lib/storage.js').default;
 const log = require('../../lib/log');
 const EXTENSION_INFO = require('../../lib/extensions.js').default;
+const jar = require('../../lib/jar.js');
 
 const PreviewPresentation = require('./presentation.jsx');
 const projectShape = require('./projectshape.jsx').projectShape;
@@ -332,6 +333,9 @@ class Preview extends React.Component {
             title: title
         });
     }
+    handleSetLanguage (locale) {
+        jar.set('scratchlanguage', locale);
+    }
     handleUpdateProjectId (projectId, callback) {
         this.setState({projectId: projectId}, () => {
             const parts = window.location.pathname.toLowerCase()
@@ -444,6 +448,7 @@ class Preview extends React.Component {
                         renderLogin={this.renderLogin}
                         onLogOut={this.props.handleLogOut}
                         onOpenRegistration={this.props.handleOpenRegistration}
+                        onSetLanguage={this.handleSetLanguage}
                         onShare={this.handleShare}
                         onToggleLoginOpen={this.props.handleToggleLoginOpen}
                         onUpdateProjectId={this.handleUpdateProjectId}
@@ -707,6 +712,9 @@ render(
         preview: previewActions.previewReducer,
         ...GUI.guiReducers
     },
-    {scratchGui: initGuiState(GUI.guiInitialState)},
+    {
+        locales: GUI.initLocale(GUI.localesInitialState, window._locale),
+        scratchGui: initGuiState(GUI.guiInitialState)
+    },
     GUI.guiMiddleware
 );


### PR DESCRIPTION
### Resolves:

Fixes #2172 (along with https://github.com/LLK/scratch-gui/pull/3431)

### Changes:
* Initialize `locales` in redux using methods exported by GUI.
* pass GUI method to set the `scratchlanguage` cookie

NOTE: The  does not reload the page, so switching back to the project page will not reflect language changes made in gui until the next page reload. Reloading the page will lose project state so we don’t want to do that.

### Test Coverage:

- [ ] Change language in www, load preview, then see inside: the gui should load in the currently selected language (the language needs to be in both gui and www)
- [ ] View a project in the editor: you can switch languages.
- [ ] View community after changing languages in gui: the preview will still be in the previous language. On reload it will show the new language.

