### PR TITLE
Use parent_id and commentee_id correctly when posting comments.

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -93,6 +93,7 @@ class Comment extends React.Component {
             content,
             datetimeCreated,
             id,
+            parentId,
             projectId,
             replyUsername,
             visibility
@@ -192,7 +193,8 @@ class Comment extends React.Component {
                     {this.state.replying ? (
                         <FlexRow className="comment-reply-row">
                             <ComposeComment
-                                parentId={id}
+                                commenteeId={author.id}
+                                parentId={parentId || id}
                                 projectId={projectId}
                                 onAddComment={this.handlePostReply}
                                 onCancel={this.handleToggleReplying}
@@ -241,6 +243,7 @@ Comment.propTypes = {
     onDelete: PropTypes.func,
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
+    parentId: PropTypes.number,
     projectId: PropTypes.string,
     replyUsername: PropTypes.string,
     visibility: PropTypes.string

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -58,7 +58,7 @@ class ComposeComment extends React.Component {
             json: {
                 content: this.state.message,
                 parent_id: this.props.parentId || '',
-                comentee_id: this.props.comenteeId || ''
+                commentee_id: this.props.commenteeId || ''
             }
         }, (err, body, res) => {
             if (err || res.statusCode !== 200) {
@@ -158,7 +158,7 @@ class ComposeComment extends React.Component {
 }
 
 ComposeComment.propTypes = {
-    comenteeId: PropTypes.number,
+    commenteeId: PropTypes.number,
     onAddComment: PropTypes.func,
     onCancel: PropTypes.func,
     parentId: PropTypes.number,

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -23,8 +23,8 @@ class TopLevelComment extends React.Component {
             expanded: false
         };
 
-        // A cache of {commentId: username, ...} in order to show reply usernames
-        this.commentUsernameCache = {};
+        // A cache of {userId: username, ...} in order to show reply usernames
+        this.authorUsernameCache = {};
     }
 
     handleExpandThread () {
@@ -53,17 +53,19 @@ class TopLevelComment extends React.Component {
         this.props.onAddComment(comment, this.props.id);
     }
 
-    commentUsername (parentId) {
-        if (this.commentUsernameCache[parentId]) return this.commentUsernameCache[parentId];
+    authorUsername (authorId) {
+        if (this.authorUsernameCache[authorId]) return this.authorUsernameCache[authorId];
 
         // If the cache misses, rebuild it. Every reply has a parent id that is
         // either a reply to this top level comment or to one of the replies.
-        this.commentUsernameCache[this.props.id] = this.props.author.username;
+        this.authorUsernameCache[this.props.author.id] = this.props.author.username;
         const replies = this.props.replies;
         for (let i = 0; i < replies.length; i++) {
-            this.commentUsernameCache[replies[i].id] = replies[i].author.username;
+            this.authorUsernameCache[replies[i].author.id] = replies[i].author.username;
         }
-        return this.commentUsernameCache[parentId];
+        // Default to top level author if no author is found from authorId
+        // This can happen if there is no commentee_id stored with the comment
+        return this.authorUsernameCache[authorId] || this.props.author.username;
     }
 
     render () {
@@ -126,8 +128,9 @@ class TopLevelComment extends React.Component {
                                 datetimeCreated={reply.datetime_created}
                                 id={reply.id}
                                 key={reply.id}
+                                parentId={id}
                                 projectId={projectId}
-                                replyUsername={this.commentUsername(reply.parent_id)}
+                                replyUsername={this.authorUsername(reply.commentee_id)}
                                 visibility={reply.visibility}
                                 onAddComment={this.handleAddComment}
                                 onDelete={this.handleDeleteReply}


### PR DESCRIPTION
This resolves an issue on the preview page where the parent_id was being set to the comment being replied to, instead of what it should be, the top-level parent comment. The commentee_id was being left out, it needs to be the id of the user the comment is directed at, possibly different from the top-level parent comment author.

This PR also changes the auto `@` tagging to use the commentee_id instead of the parent_id for finding the username to show. The logic of that function remains very similar though, it just builds the cache from the author.id instead of comment.id. 
