### PR TITLE
Set capability flags to be passed to GUI, to support remix and save as copy

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -435,10 +435,10 @@ class Preview extends React.Component {
                         assetHost={this.props.assetHost}
                         backpackOptions={this.props.backpackOptions}
                         basePath="/"
+                        canCreateCopy={this.props.canCreateCopy}
                         canCreateNew={this.props.canCreateNew}
                         canRemix={this.props.canRemix}
                         canSave={this.props.canSave}
-                        canSaveAsCopy={this.props.canSaveAsCopy}
                         canShare={this.props.canShare}
                         className="gui"
                         enableCommunity={this.props.enableCommunity}
@@ -469,11 +469,11 @@ Preview.propTypes = {
         visible: PropTypes.bool
     }),
     canAddToStudio: PropTypes.bool,
+    canCreateCopy: PropTypes.bool,
     canCreateNew: PropTypes.bool,
     canRemix: PropTypes.bool,
     canReport: PropTypes.bool,
     canSave: PropTypes.bool,
-    canSaveAsCopy: PropTypes.bool,
     canShare: PropTypes.bool,
     comments: PropTypes.arrayOf(PropTypes.object),
     enableCommunity: PropTypes.bool,
@@ -560,11 +560,11 @@ const mapStateToProps = state => {
 
     return {
         canAddToStudio: userOwnsProject,
+        canCreateCopy: userOwnsProject && projectInfoPresent,
         canCreateNew: isLoggedIn,
         canRemix: isLoggedIn && projectInfoPresent && !userOwnsProject,
         canReport: isLoggedIn && !userOwnsProject,
         canSave: isLoggedIn && userOwnsProject,
-        canSaveAsCopy: userOwnsProject && projectInfoPresent,
         canShare: userOwnsProject && state.permissions.social,
         comments: state.preview.comments,
         enableCommunity: projectInfoPresent,


### PR DESCRIPTION
Commit alongside: https://github.com/LLK/scratch-gui/pull/3461

### Resolves

- Resolves https://github.com/LLK/scratch-gui/issues/3034 (or, at least, helps gui #3461 resolve it)

### Proposed Changes

Introduces handling for the user's permission and capability to Remix and Save as a copy. Improves the logic around several capabilities.

