### PR TITLE
Do not rely on total comment number for load more functionality

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -59,6 +59,7 @@ const PreviewPresentation = ({
     isShared,
     loved,
     loveCount,
+    moreCommentsToLoad,
     originalInfo,
     parentInfo,
     projectHost,
@@ -89,7 +90,6 @@ const PreviewPresentation = ({
     onUpdate
 }) => {
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
-    const loadedCommentCount = comments.length + Object.keys(replies).reduce((acc, id) => acc + replies[id].length, 0);
     return (
         <div className="preview">
             {!isShared && (
@@ -381,7 +381,7 @@ const PreviewPresentation = ({
                                                 onRestore={onRestoreComment}
                                             />
                                         ))}
-                                        {loadedCommentCount < projectInfo.stats.comments &&
+                                        {moreCommentsToLoad &&
                                         <Button
                                             className="button load-more-button"
                                             onClick={onLoadMore}
@@ -426,6 +426,7 @@ PreviewPresentation.propTypes = {
     isShared: PropTypes.bool,
     loveCount: PropTypes.number,
     loved: PropTypes.bool,
+    moreCommentsToLoad: PropTypes.bool,
     onAddComment: PropTypes.func,
     onAddToStudioClicked: PropTypes.func,
     onAddToStudioClosed: PropTypes.func,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -400,6 +400,7 @@ class Preview extends React.Component {
                         isShared={this.props.isShared}
                         loveCount={this.state.loveCount}
                         loved={this.props.loved}
+                        moreCommentsToLoad={this.props.moreCommentsToLoad}
                         originalInfo={this.props.original}
                         parentInfo={this.props.parent}
                         projectHost={this.props.projectHost}
@@ -501,6 +502,7 @@ Preview.propTypes = {
     isLoggedIn: PropTypes.bool,
     isShared: PropTypes.bool,
     loved: PropTypes.bool,
+    moreCommentsToLoad: PropTypes.bool,
     original: projectShape,
     parent: projectShape,
     playerMode: PropTypes.bool,
@@ -579,6 +581,7 @@ const mapStateToProps = state => {
         // if we don't have projectInfo, assume it's shared until we know otherwise
         isShared: !projectInfoPresent || state.preview.projectInfo.is_published,
         loved: state.preview.loved,
+        moreCommentsToLoad: state.preview.moreCommentsToLoad,
         original: state.preview.original,
         parent: state.preview.parent,
         playerMode: state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
Show the load more comments button any time the last comment page was filled to the requested limit. As noted in the comment, this heuristic will be wrong at most 5% of the time but the failure mode (showing load more which, when clicked doesn't load any more, just goes away) is very mild, and for the overwhelming majority of project views that happen on projects with many, many comments, this is very unlikely to ever be noticed. It obviously isn't a perfect solution, but I cannot think of another that does not need the server to do another query to find out the total number of visible comments, or to find out if there are more comments after the requested offset+limit.

After talking it over with @colbygk, I think this is the best way to avoid adding extra pagination logic to the comments API or burdening the projects API with extra joins to get comment visibility when counting.