### PR TITLE
moved getExtensions out of constructor, and out of projectInfo response

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -73,7 +73,6 @@ class Preview extends React.Component {
             addToStudioOpen: false,
             reportOpen: false
         };
-        this.getExtensions(this.state.projectId);
         this.addEventListeners();
         /* In the beginning, if user is on mobile and landscape, go to fullscreen */
         this.setScreenFromOrientation();
@@ -84,12 +83,12 @@ class Preview extends React.Component {
             this.props.sessionStatus === sessionActions.Status.FETCHED) ||
             (this.state.projectId !== prevState.projectId))) {
             this.fetchCommunityData();
+            this.getExtensions(this.state.projectId);
         }
         if (this.state.projectId === '0' && this.state.projectId !== prevState.projectId) {
             this.props.resetProject();
         }
         if (this.props.projectInfo.id !== prevProps.projectInfo.id) {
-            this.getExtensions(this.state.projectId);
             if (typeof this.props.projectInfo.id === 'undefined') {
                 this.initCounts(0, 0);
             } else {


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2216

### Changes:

* moves getExtensions call out of Preview constructor, where it causes a warning because it attempt to setState before Preview is constructed
* moves the other getExtensions call out of a place in the code where it doesn't fit -- it was waiting for projectInfo to be fetched, when it doesn't need projectInfo, just projectId
