### PR TITLE
pass isShared to gui

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -443,6 +443,7 @@ class Preview extends React.Component {
                         canShare={this.props.canShare}
                         className="gui"
                         enableCommunity={this.props.enableCommunity}
+                        isShared={this.props.isShared}
                         projectHost={this.props.projectHost}
                         projectId={this.state.projectId}
                         projectTitle={this.props.projectInfo.title}


### PR DESCRIPTION
Helps resolve https://github.com/LLK/scratch-gui/issues/3466

passes isShared prop to gui, so gui can decide how to reflect the project's being shared or not

https://github.com/LLK/scratch-gui/pull/3508 depends on this, but this does not depend on it, and can be merged before it