### PR TITLE
Use #comments-id instead of #comment-id for fetching single comments

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -117,7 +117,7 @@ class Comment extends React.Component {
                 className={classNames('flex-row', 'comment', {
                     'highlighted-comment': highlighted
                 })}
-                id={`comment-${id}`}
+                id={`comments-${id}`}
                 ref={this.setRef}
             >
                 <a href={`/users/${author.username}`}>

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -66,8 +66,8 @@ class Preview extends React.Component {
         // parts[1]: either :id or 'editor'
         // parts[2]: undefined if no :id, otherwise either 'editor' or 'fullscreen'
 
-        // Get single-comment id from url hash, using the #comment-{id} scheme from scratch2
-        const commentHashPrefix = '#comment-';
+        // Get single-comment id from url hash, using the #comments-{id} scheme from scratch2
+        const commentHashPrefix = '#comments-';
         const singleCommentId = window.location.hash.indexOf(commentHashPrefix) !== -1 &&
             parseInt(window.location.hash.replace(commentHashPrefix, ''), 10);
 


### PR DESCRIPTION
Fix a typo with the url anchor for comments