### PR TITLE
Track scratch-gui@latest 

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "develop",
+    "scratch-gui": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
Previously, we chose to track scratch-gui@develop instead of @latest: https://github.com/LLK/scratch-www/pull/2119
The reason then was "The lag between releases for scratch-gui@latest hinders testing scratch-gui/www integration changes"... which is true!

But right now, we want to specifically test the latest release build of gui in staging.

We should revisit this question soon.