### PR TITLE
remove obsolete code

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -15,7 +15,6 @@ $stage-width: 480px;
 .gui {
     position: absolute;
     top: 0;
-    z-index: 11;
     margin: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Preview doesn’t need to set a z-index (the first version was trying to overlay gui on top of the project view).

resolves #2030 