### PR TITLE
removed erroneous share button icon

### DIFF
--- a/src/views/preview/share-banner.scss
+++ b/src/views/preview/share-banner.scss
@@ -19,16 +19,17 @@ $navigation-height: 50px;
     font-size: .875rem;
     font-weight: normal;
 
-    &:before {
-        display: inline-block;
-        margin-right: .5rem;
-        background-image: url("/svgs/project/share-white.svg");
-        background-repeat: no-repeat;
-        background-position: center center;
-        background-size: contain;
-        width: 1.25rem;
-        height: 1.25rem;
-        vertical-align: middle;
-        content: "";
-    }
+    // don't show an image in share button, for now.
+    // &:before {
+    //     display: inline-block;
+    //     margin-right: .5rem;
+    //     background-image: url("/svgs/project/share-white.svg");
+    //     background-repeat: no-repeat;
+    //     background-position: center center;
+    //     background-size: contain;
+    //     width: 1.25rem;
+    //     height: 1.25rem;
+    //     vertical-align: middle;
+    //     content: "";
+    // }
 }


### PR DESCRIPTION
### Resolves:

https://github.com/LLK/scratch-www/issues/2248

### Changes:

Comments out css that put a placeholder icon in the Share button.

I'm keeping the code there because we will probably put an icon in there soon.

Before: 
![screen shot 2018-10-29 at 5 31 42 pm](https://user-images.githubusercontent.com/3431616/47682072-a2a8f700-dba1-11e8-9383-d82a5e8dcc3a.png)


After:
![screen shot 2018-10-29 at 5 39 05 pm](https://user-images.githubusercontent.com/3431616/47682083-aa689b80-dba1-11e8-8550-adeab6647eb5.png)
