### PR TITLE
make share banner appear only if user has the power to share this project

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -48,6 +48,7 @@ const PreviewPresentation = ({
     canDeleteComments,
     canReport,
     canRestoreComments,
+    canShare,
     cloudHost,
     comments,
     editable,
@@ -94,7 +95,7 @@ const PreviewPresentation = ({
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
     return (
         <div className="preview">
-            {!isShared && (
+            {canShare && !isShared && (
                 <ShareBanner onShare={onShare} />
             )}
             { projectInfo && projectInfo.author && projectInfo.author.id && (
@@ -440,6 +441,7 @@ PreviewPresentation.propTypes = {
     canDeleteComments: PropTypes.bool,
     canReport: PropTypes.bool,
     canRestoreComments: PropTypes.bool,
+    canShare: PropTypes.bool,
     cloudHost: PropTypes.string,
     comments: PropTypes.arrayOf(PropTypes.object),
     editable: PropTypes.bool,

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -405,6 +405,7 @@ class Preview extends React.Component {
                         canDeleteComments={this.props.isAdmin || this.props.userOwnsProject}
                         canReport={this.props.canReport}
                         canRestoreComments={this.props.isAdmin}
+                        canShare={this.props.canShare}
                         cloudHost={this.props.cloudHost}
                         comments={this.props.comments}
                         editable={this.props.isEditable}


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2273

### Changes:

passes `canShare` boolean prop to preview presentation, which uses it to show or hide the share banner accordingly.

