### PR TITLE
Avoid displaying an error when /news returns a 500

### DIFF
--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -71,7 +71,10 @@ class Splash extends React.Component {
     getNews () {
         api({
             uri: '/news?limit=3'
-        }, (err, body) => {
+        }, (err, body, resp) => {
+            if (resp.statusCode !== 200) {
+                return log.error(`Unexpected status code ${resp.statusCode} received from news request`);
+            }
             if (!body) return log.error('No response body');
             if (!err) return this.setState({news: body});
         });


### PR DESCRIPTION
This situation probably occurs most frequently when running dev servers while offline, but could also happen if the API is having issues. 500 responses from the API should not take down the homepage so drastically, and are also sometimes unavoidable while working offline.
