### PR TITLE
Update chromedriver so tests pass more reliably

### DIFF
--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "selenium-webdriver": "3.6.0",
-        "chromedriver": "2.37.0"
+        "chromedriver": "2.43.1"
     }
 }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -61,7 +61,7 @@ class SeleniumHelper {
         let driverConfig = {
             browserName: 'chrome',
             platform: 'macOS 10.13',
-            version: '67.0'
+            version: '70.0'
         };
         var driver = new webdriver.Builder()
             .withCapabilities({


### PR DESCRIPTION
### Resolves:

test_footer_links tests were failing due to a problem in the version of chromedriver. 

### Changes:

Updates the package.json in test/integration to include the latest and working version of chromedriver.

### Test Coverage:

`SMOKE_USERNAME=[username] SMOKE_PASSWORD_[password] npm run smoke` passing in a valid staging username and password.  The tests should now pass.
