### PR TITLE
Add IP Mute message to project comment errors

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -222,7 +222,7 @@
     "comments.isMuted": "Hmm, the filterbot is pretty sure your recent comments weren't ok for Scratch, so your account has been muted for the rest of the day. :/",
     "comments.isUnconstructive": "Hmm, the filterbot thinks your comment may be mean or disrespectful. Remember, most projects on Scratch are made by people who are just learning how to program.",
     "comments.isDisallowed": "Hmm, it looks like comments have been turned off for this page. :/",
-    "comments.isIPMuted": "Sorry, the Scratch Team had to prevent your network from sharing comments or projects because it was used to break our community guidelines too many times. You can still share comments and projects from another network.",
+    "comments.isIPMuted": "Sorry, the Scratch Team had to prevent your network from sharing comments or projects because it was used to break our community guidelines too many times. You can still share comments and projects from another network. If you'd like to appeal this block, you can contact appeals@scratch.mit.edu and reference Case Number {appealId}.",
     "comments.isTooLong": "That comment is too long! Please find a way to shorten your text.",
     "comments.error": "Oops! Something went wrong posting your comment",
     "comments.posting": "Posting...",

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -38,14 +38,16 @@ class ComposeComment extends React.Component {
         this.state = {
             message: '',
             status: ComposeStatus.EDITING,
-            error: null
+            error: null,
+            appealId: null
         };
     }
     handleInput (event) {
         this.setState({
             message: event.target.value,
             status: ComposeStatus.EDITING,
-            error: null
+            error: null,
+            appealId: null
         });
     }
     handlePost () {
@@ -70,7 +72,8 @@ class ComposeComment extends React.Component {
                 // Note: does not reset the message state
                 this.setState({
                     status: ComposeStatus.REJECTED,
-                    error: body.rejected
+                    error: body.rejected,
+                    appealId: body.appealId
                 });
                 return;
             }
@@ -79,7 +82,8 @@ class ComposeComment extends React.Component {
             this.setState({
                 message: '',
                 status: ComposeStatus.EDITING,
-                error: null
+                error: null,
+                appealId: null
             });
 
             // Add the username, which isn't included right now from scratch-api
@@ -92,7 +96,8 @@ class ComposeComment extends React.Component {
         this.setState({
             message: '',
             status: ComposeStatus.EDITING,
-            error: null
+            error: null,
+            appealId: null
         });
         if (this.props.onCancel) this.props.onCancel();
     }
@@ -108,7 +113,12 @@ class ComposeComment extends React.Component {
                     {this.state.error ? (
                         <FlexRow className="compose-error-row">
                             <div className="compose-error-tip">
-                                <FormattedMessage id={`comments.${this.state.error}`} />
+                                <FormattedMessage
+                                    id={`comments.${this.state.error}`}
+                                    values={{
+                                        appealId: this.state.appealId
+                                    }}
+                                />
                             </div>
                         </FlexRow>
                     ) : null}


### PR DESCRIPTION
Enhances the error message for preview page comments in the case of IP Mute to include showing an appeal case ID. This PR expects that info to be included with the `{rejected: 'IPMuted'}` response from API in a key called `appealId`. This PR is safe to merge before the API is in place, just will show a blank case number. 