### PR TITLE
point to scratch-gui latest npm release, not develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "develop",
+    "scratch-gui": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
See: https://github.com/LLK/scratch-www/pull/2241 , https://github.com/LLK/scratch-www/pull/2276

We want to specifically test the `latest` release build of gui in staging. Not the `develop` release build, which changes out of step with this branch.

We don't intend this change to be merged back into the www `develop` branch; or if it is, we would have to revert or otherwise reverse it.