### PR TITLE
Use https for ScratchJR links

### DIFF
--- a/src/components/footer/conference/2016/footer.jsx
+++ b/src/components/footer/conference/2016/footer.jsx
@@ -80,7 +80,7 @@ const ConferenceFooter = () => (
                             <a href="https://scratch.mit.edu">Scratch</a>
                         </li>
                         <li>
-                            <a href="http://www.scratchjr.org/">ScratchJr</a>
+                            <a href="https://www.scratchjr.org/">ScratchJr</a>
                         </li>
                     </FlexRow>
                     <FlexRow

--- a/src/components/footer/conference/2017/footer.jsx
+++ b/src/components/footer/conference/2017/footer.jsx
@@ -23,7 +23,7 @@ const ConferenceFooter = props => (
                             <a href="https://scratch.mit.edu">Scratch</a>
                         </li>
                         <li>
-                            <a href="http://www.scratchjr.org/">ScratchJr</a>
+                            <a href="https://www.scratchjr.org/">ScratchJr</a>
                         </li>
                     </FlexRow>
                     <FlexRow

--- a/src/components/footer/conference/2018/footer.jsx
+++ b/src/components/footer/conference/2018/footer.jsx
@@ -99,7 +99,7 @@ const ConferenceFooter = props => (
                         </li>
                         <li>
                             <a
-                                href="http://www.scratchjr.org/"
+                                href="https://www.scratchjr.org/"
                                 rel="noopener noreferrer"
                                 target="_blank"
                             >

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -186,7 +186,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="http://www.scratchjr.org/">
+                        <a href="https://www.scratchjr.org/">
                             <FormattedMessage id="general.scratchJr" />
                         </a>
                     </dd>

--- a/test/integration-cypress/cypress/smoke-tests/test-footer-links.js
+++ b/test/integration-cypress/cypress/smoke-tests/test-footer-links.js
@@ -262,7 +262,7 @@ describe('test Scratch Family links in footer', function () {
             .click();
         cy
             .url()
-            .should('match', /^http:\/\/www\.scratchjr\.org\/?$/);
+            .should('match', /^https:\/\/www\.scratchjr\.org\/?$/);
     });
 
     it.skip('click Scratch Day', function (){

--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -269,7 +269,7 @@ tap.test('clickScratchEdLink', options, t => {
 // SCRATCH JR (SCRATCHJR)
 tap.test('clickScratchJrLink', options, t => {
     const linkText = 'ScratchJr';
-    const expectedUrl = 'http://www.scratchjr.org/';
+    const expectedUrl = 'https://www.scratchjr.org/';
     clickFooterLinks(linkText).then(url => {
         t.equal(url, expectedUrl);
         t.end();


### PR DESCRIPTION
### Resolves:

Resolves #2297 

### Changes:

This changes all the links to Scratch Jr from http to https.

### Test Coverage:

I don't understand much about testing yet (I use testing for my other node modules of course), but I ran `npm test` and everything passed. 

I also checked the pages and made sure that the links went to https://scratchjr.org.