### PR TITLE
Fix wedo-legacy translations

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -302,7 +302,7 @@
         "title": "LEGO WeDo 2.0"
     },
     {
-        "name": "wedo-legacy",
+        "name": "wedo2-legacy",
         "pattern": "^/wedo-legacy/?$",
         "routeAlias": "/wedo-legacy/?$",
         "view": "wedo2-legacy/wedo2",


### PR DESCRIPTION
### Resolves:
The translation generation script uses the view name from the routes file when generating the translations files. So the route `name:` and `view:` must match.

Symptom: when generating translations there were warnings that there were no translations for `wedo-legacy`.

### Changes:
Changes the wedo2-legacy route name to match the view. (not the route pattern which is still `wedo-legacy`)

On fastly this should change the name of the `rewrites/wedo-legacy` header to `rewrites/wedo2-legacy`, and it will change the filename from `wedo-legacy.html` to `wedo2-legacy.html`. However the URL `/wedo-legacy` should not change.

### Test Coverage:

@rschamp do we have a way to 'test' what gets generated on fastly other than looking on staging?

/cc FYI @benjiwheeler 
