### PR TITLE
Update microbit hex file version

### DIFF
--- a/src/views/microbit/microbit.jsx
+++ b/src/views/microbit/microbit.jsx
@@ -119,7 +119,7 @@ class MicroBit extends ExtensionLanding {
                                 <a
                                     download
                                     className="download"
-                                    href="https://downloads.scratch.mit.edu/microbit/scratch-microbit-1.0.hex.zip"
+                                    href="https://downloads.scratch.mit.edu/microbit/scratch-microbit-1.1.0.hex.zip"
                                 >
                                     <FormattedMessage id="microbit.downloadHex" />
                                 </a>


### PR DESCRIPTION
### Changes:

Update the download link for the microbit hex file to version 1.1.0. This version provides support for an incremental update to the microbit hardware.