### PR TITLE
Resolved issue #2263

### DIFF
--- a/src/views/preview/stats.jsx
+++ b/src/views/preview/stats.jsx
@@ -16,14 +16,14 @@ const Stats = props => (
             key="loves"
             onClick={props.onLoveClicked}
         >
-            {approx(props.loveCount, {decimal: false})}
+            {approx(Math.max(0, props.loveCount), {decimal: false})}
         </div>
         <div
             className={classNames('project-favorites', {favorited: props.faved})}
             key="favorites"
             onClick={props.onFavoriteClicked}
         >
-            {approx(props.favoriteCount, {decimal: false})}
+            {approx(Math.max(0, props.favoriteCount), {decimal: false})}
         </div>
         <div
             className="project-remixes"


### PR DESCRIPTION
### Resolves https://github.com/LLK/scratch-www/issues/2263 on Client Side

Implemented simple sanity checks to ensure that `loveCount` and `favoriteCount` can never display as negative. We may still need to resolve this issue server side. 