### PR TITLE
redirect hash urls to url pathnames

### DIFF
--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -743,13 +743,17 @@ const ConnectedPreview = connect(
 
 // replace old Scratch 2.0-style hashtag URLs with updated format
 if (window.location.hash) {
+    let pathname = window.location.pathname;
+    if (pathname.substr(-1) !== '/') {
+        pathname = `${pathname}/`;
+    }
     if (window.location.hash === '#editor') {
         history.replaceState({}, document.title,
-            `${window.location.origin}${window.location.pathname}editor${window.location.search}`);
+            `${pathname}editor${window.location.search}`);
     }
     if (window.location.hash === '#fullscreen') {
         history.replaceState({}, document.title,
-            `${window.location.origin}${window.location.pathname}fullscreen${window.location.search}`);
+            `${pathname}fullscreen${window.location.search}`);
     }
 }
 

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -741,6 +741,19 @@ const ConnectedPreview = connect(
     mapDispatchToProps
 )(Preview);
 
+// replace old Scratch 2.0-style hashtag URLs with updated format
+if (window.location.hash) {
+    if (window.location.hash === '#editor') {
+        history.replaceState({}, document.title,
+            `${window.location.origin}${window.location.pathname}editor${window.location.search}`);
+    }
+    if (window.location.hash === '#fullscreen') {
+        history.replaceState({}, document.title,
+            `${window.location.origin}${window.location.pathname}fullscreen${window.location.search}`);
+    }
+}
+
+// initialize GUI by calling its reducer functions depending on URL
 GUI.setAppElement(document.getElementById('app'));
 const initGuiState = guiInitialState => {
     const pathname = window.location.pathname.toLowerCase();


### PR DESCRIPTION
### Resolves:

- Resolves https://github.com/LLK/scratch-www/issues/2095

### Changes:

Before www preview page renders or components mount, check if the page's url hash matches `#editor` or `#fullscreen`. If so, replace that hash tag with the equivalent path. Maintain querystring, protocol, etc.

Note: not IE-safe because we use `window.location.origin`. Is that bad? Will we show IE is unsupported earlier?

### Test Coverage:

NEED TO WRITE TESTS