### PR TITLE
Show projectNotAvailable view in editor mode also

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -25,7 +25,6 @@ const InplaceInput = require('../../components/forms/inplace-input.jsx');
 const TopLevelComment = require('./comment/top-level-comment.jsx');
 const ComposeComment = require('./comment/compose-comment.jsx');
 const ExtensionChip = require('./extension-chip.jsx');
-const NotAvailable = require('../../components/not-available/not-available.jsx');
 
 const projectShape = require('./projectshape.jsx').projectShape;
 require('./preview.scss');
@@ -90,7 +89,6 @@ const PreviewPresentation = ({
     projectHost,
     projectId,
     projectInfo,
-    projectNotAvailable,
     projectStudios,
     remixes,
     replies,
@@ -99,14 +97,6 @@ const PreviewPresentation = ({
     userOwnsProject
 }) => {
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
-
-    if (projectNotAvailable) {
-        return (
-            <div className="preview">
-                <NotAvailable />
-            </div>
-        );
-    }
 
     return (
         <div className="preview">
@@ -498,7 +488,6 @@ PreviewPresentation.propTypes = {
     projectHost: PropTypes.string,
     projectId: PropTypes.string,
     projectInfo: projectShape,
-    projectNotAvailable: PropTypes.bool,
     projectStudios: PropTypes.arrayOf(PropTypes.object),
     remixes: PropTypes.arrayOf(PropTypes.object),
     replies: PropTypes.objectOf(PropTypes.array),

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -20,6 +20,7 @@ const projectShape = require('./projectshape.jsx').projectShape;
 const Registration = require('../../components/registration/registration.jsx');
 const ConnectedLogin = require('../../components/login/connected-login.jsx');
 const CanceledDeletionModal = require('../../components/login/canceled-deletion-modal.jsx');
+const NotAvailable = require('../../components/not-available/not-available.jsx');
 
 const sessionActions = require('../../redux/session.js');
 const navigationActions = require('../../redux/navigation.js');
@@ -400,6 +401,16 @@ class Preview extends React.Component {
         );
     }
     render () {
+        if (this.props.projectNotAvailable) {
+            return (
+                <Page>
+                    <div className="preview">
+                        <NotAvailable />
+                    </div>
+                </Page>
+            );
+        }
+
         return (
             this.props.playerMode ?
                 <Page>
@@ -431,7 +442,6 @@ class Preview extends React.Component {
                         projectHost={this.props.projectHost}
                         projectId={this.state.projectId}
                         projectInfo={this.props.projectInfo}
-                        projectNotAvailable={this.props.projectNotAvailable}
                         projectStudios={this.props.projectStudios}
                         remixes={this.props.remixes}
                         replies={this.props.replies}


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-www/issues/1873 by promoting the NotAvailable component above the editor/project page switch. 

This fixes the issue where going to /editor would still load the editor, even if the project was unshared.