### PR TITLE
Rename /preview to /projects

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -198,11 +198,11 @@
         "title": "Microworlds"
     },
     {
-        "name": "preview",
-        "pattern": "^/preview(/editor|(/\\d+(/editor|/fullscreen)?)?)?/?(\\?.*)?$",
-        "routeAlias": "/preview/?$",
+        "name": "projects",
+        "pattern": "^/projects(/editor|(/\\d+(/editor|/fullscreen)?)?)?/?(\\?.*)?$",
+        "routeAlias": "/projects/?$",
         "view": "preview/preview",
-        "title": "Scratch 3.0 Preview"
+        "title": "Scratch Project"
     },
     {
         "name": "3faq",

--- a/src/views/preview/preview.jsx
+++ b/src/views/preview/preview.jsx
@@ -63,7 +63,7 @@ class Preview extends React.Component {
         ]);
         const pathname = window.location.pathname.toLowerCase();
         const parts = pathname.split('/').filter(Boolean);
-        // parts[0]: 'preview'
+        // parts[0]: 'projects'
         // parts[1]: either :id or 'editor'
         // parts[2]: undefined if no :id, otherwise either 'editor' or 'fullscreen'
 
@@ -264,7 +264,7 @@ class Preview extends React.Component {
         if (!this.props.playerMode) modePath = 'editor/';
         // fullscreen overrides editor
         if (this.props.fullScreen) modePath = 'fullscreen/';
-        const newPath = `/preview/${idPath}${modePath}`;
+        const newPath = `/projects/${idPath}${modePath}`;
         if (push) {
             history.pushState(
                 {},
@@ -745,7 +745,7 @@ GUI.setAppElement(document.getElementById('app'));
 const initGuiState = guiInitialState => {
     const pathname = window.location.pathname.toLowerCase();
     const parts = pathname.split('/').filter(Boolean);
-    // parts[0]: 'preview'
+    // parts[0]: 'projects'
     // parts[1]: either :id or 'editor'
     // parts[2]: undefined if no :id, otherwise either 'editor' or 'fullscreen'
     if (parts.indexOf('editor') === -1) {

--- a/src/views/preview/remix-credit.jsx
+++ b/src/views/preview/remix-credit.jsx
@@ -24,7 +24,7 @@ const RemixCredit = props => {
                         ),
                         projectLink: (
                             <a
-                                href={`/preview/${projectInfo.id}`}
+                                href={`/projects/${projectInfo.id}`}
                                 title={projectInfo.title}
                             >
                                 {projectInfo.title}


### PR DESCRIPTION
### Changes:

Redefines the `/preview...` route to `/projects...` in preparation for January.

Note: this does not rename the preview view, resources etc. as there are too many people working on them. I will open a new tech dept issue to track that.

### Test Coverage:

Manual tests:
- [ ] Create in the nav bar opens the 3.0 editor
- [ ] Clicking on a project opens the new project page

