### PR TITLE
Show comment actions on hover and fix report translation

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -158,7 +158,7 @@ class Comment extends React.Component {
                                             className="comment-report"
                                             onClick={this.handleReport}
                                         >
-                                            <FormattedMessage id="comments.report" />
+                                            <FormattedMessage id="general.report" />
                                         </span>
                                     )}
                                 </React.Fragment>

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -289,3 +289,7 @@
         margin-right: -50%;
     }
 }
+
+/* Hide the action list buttons (delete/report/restore) until hover over */
+.comment .action-list { opacity: 0; }
+.comment:hover .action-list { opacity: 1; }


### PR DESCRIPTION
Resolves two minor issues with comments

1. The actions (delete/report/restore) should only show on hover, that just had gone unimplemented. /cc @kathymakes the hover target is the entire comment
2. There was an incorrect translation string for reporting comments, causing this 
![image](https://user-images.githubusercontent.com/654102/48856086-7b4de000-ed83-11e8-96f4-b89f51e7f4e2.png), fixed it
