### PR TITLE
Fix alignment of the placeholder and text in project instructions & note

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -171,6 +171,11 @@ $stage-width: 480px;
         margin-left: 1rem;
     }
 
+    .inplace-textarea::placeholder {
+        text-align: start;
+        padding: 0;
+    }
+
     .comments-container {
         padding-right: 1.5rem;
         min-width: 65%;


### PR DESCRIPTION
The placeholder text in notes/instructions did not line up with the cursor / typed input. That looked very odd. I assume this wasn't intentional, but if it was let me know

Previously: 
![image](https://user-images.githubusercontent.com/654102/48857447-e0570500-ed86-11e8-96f6-9d5a1bc51014.png)


Now:
![image](https://user-images.githubusercontent.com/654102/48857453-e4832280-ed86-11e8-9690-b957fd3aaf62.png)


(You can see the cursor in each of those image)