### PR TITLE
Get integration tests to pass after preview to project change

### DIFF
--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,5 +1,6 @@
 const webdriver = require('selenium-webdriver');
 const bindAll = require('lodash.bindall');
+require('chromedriver');
 
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;

--- a/test/integration/smoke-testing/test-my-stuff.js
+++ b/test/integration/smoke-testing/test-my-stuff.js
@@ -82,7 +82,7 @@ test('clicking See Inside should take you to the editor', t => {
         .then(() => clickXpath('//a[@data-control="edit"]'))
         .then(() => driver.getCurrentUrl())
         .then(function (u) {
-            var expectedUrl = '/#editor';
+            var expectedUrl = '/editor';
             t.equal(u.substr(-expectedUrl.length), expectedUrl, 'after clicking, the URL should end in #editor');
         })
         .then(() => t.end());


### PR DESCRIPTION
### Resolves:

The www tests failing on scratch.ly

### Changes:

explicitly requires chromedriver in the helper file, without which sometimes the tests wouldn't run.
Changes an expected url in the See Inside test under "test-my-stuff" so that that test passes.

There was another test in the "test_navbar_links" tests that was failing.  I changed some things but then put them back the way they were and now they pass.  I'm not sure what caused the failure yet and we should keep an eye out for it in the future.
