### PR TITLE
Revised unsupported browser info

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -101,9 +101,9 @@
 
     "general.teacherAccounts": "Teacher Accounts",
     
-    "general.unsupportedBrowser": "Browser is not supported",
+    "general.unsupportedBrowser": "This browser is not supported",
     "general.unsupportedBrowserDescription": "We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge.",
-    "general.3faq": "To learn more, go to the {previewFaqLink}.",
+    "general.3faq": "To learn more, go to the {faqLink}.",
 
     "footer.discuss": "Discussion Forums",
     "footer.scratchFamily": "Scratch Family",

--- a/src/views/preview/unsupported-browser.jsx
+++ b/src/views/preview/unsupported-browser.jsx
@@ -32,10 +32,10 @@ const UnsupportedBrowser = () => (
                     <FormattedMessage
                         id="general.3faq"
                         values={{
-                            previewFaqLink: (
+                            faqLink: (
                                 <a
                                     className="faq-link"
-                                    href="//scratch.mit.edu/3faq"
+                                    href="/info/faq"
                                 >
                                     <FormattedMessage id="general.faq" />
                                 </a>


### PR DESCRIPTION
### Resolves:

Fixes #2352 

### Changes:

- Header reads ‘This browser is not supported’
- FAQ link goes to general Scratch FAQ.

### Test Coverage:
Current tests run.
