### PR TITLE
Add new localization files to tx config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -177,3 +177,8 @@ type = KEYVALUEJSON
 source_file = src/views/parents/l10n.json
 source_lang = en
 type = KEYVALUEJSON
+
+[scratch-website.scratch_14-l10njson]
+source_file = src/views/scratch_1.4/l10n.json
+source_lang = en
+type = KEYVALUEJSON


### PR DESCRIPTION
* Adds the scratch_1.4 view that was missing from the tx/config file. 
* Ran the `tx push -s` command to make sure that current versions of all l10n sources are on transifex.