### PR TITLE
Add project thumbnail update action to pass into GUI

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -863,3 +863,24 @@ module.exports.reportProject = (id, jsonData, token) => (dispatch => {
         dispatch(module.exports.setFetchStatus('report', module.exports.Status.FETCHED));
     });
 });
+
+module.exports.updateProjectThumbnail = (id, blob) => (dispatch => {
+    dispatch(module.exports.setFetchStatus('project-thumbnail', module.exports.Status.FETCHING));
+    api({
+        uri: `/internalapi/project/thumbnail/${id}/set/`,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'image/png'
+        },
+        withCredentials: true,
+        useCsrf: true,
+        body: blob,
+        host: '' // Not handled by the API, use existing infrastructure
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            dispatch(module.exports.setFetchStatus('project-thumbnail', module.exports.Status.ERROR));
+            return;
+        }
+        dispatch(module.exports.setFetchStatus('project-thumbnail', module.exports.Status.FETCHED));
+    });
+});

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -519,6 +519,7 @@ class Preview extends React.Component {
                         onShare={this.handleShare}
                         onToggleLoginOpen={this.props.handleToggleLoginOpen}
                         onUpdateProjectId={this.handleUpdateProjectId}
+                        onUpdateProjectThumbnail={this.props.handleUpdateProjectThumbnail}
                         onUpdateProjectTitle={this.handleUpdateProjectTitle}
                     />
                     <Registration />
@@ -569,6 +570,7 @@ Preview.propTypes = {
     handleRestoreComment: PropTypes.func,
     handleSeeAllComments: PropTypes.func,
     handleToggleLoginOpen: PropTypes.func,
+    handleUpdateProjectThumbnail: PropTypes.func,
     isAdmin: PropTypes.bool,
     isEditable: PropTypes.bool,
     isLoggedIn: PropTypes.bool,
@@ -716,6 +718,9 @@ const mapDispatchToProps = dispatch => ({
     handleSeeAllComments: (id, isAdmin, token) => {
         dispatch(previewActions.resetComments());
         dispatch(previewActions.getTopLevelComments(id, 0, isAdmin, token));
+    },
+    handleUpdateProjectThumbnail: (id, blob) => {
+        dispatch(previewActions.updateProjectThumbnail(id, blob));
     },
     getOriginalInfo: id => {
         dispatch(previewActions.getOriginalInfo(id));


### PR DESCRIPTION
Add an action that uses the existing infrastructure for storing project thumbnails. As discussed with @rschamp, we don't want to move this to the API and proxy it because it probably will not live permanently in the API. 

This is a bit tough to test locally without the project thumbnail upload infrastructure, but I checked the request against the request made when saving project thumbnails in scratch2 and they seem to match (bare PNG in the body, content-type image/png, x-csrftoken and cookies sent). 

Also we discussed putting this entirely in GUI and having storage manage it, but there are a few reasons that were convincing to me not to do that: 
- The stuff needed to make the request work with existing infrastructure (cookies, csrf, internalapi route) is already being handled in www.
- The thumbnail resembles "project metadata" more closely than project data itself, so it makes sense it would be handled in a way that resembles other project metadata. 

On the other hand, in the future we may want to keep project thumbnails closer to the consumer (native app, e.g.), in which case we might want to handle it through scratch-storage. Cross that bridge... etc. etc.