### PR TITLE
Pass canSave to both editor and player view to allow cloud reconnecting.

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -51,6 +51,7 @@ const PreviewPresentation = ({
     canRemix,
     canReport,
     canRestoreComments,
+    canSave,
     canShare,
     canUseBackpack,
     cloudHost,
@@ -209,6 +210,7 @@ const PreviewPresentation = ({
                                     backpackVisible={canUseBackpack}
                                     basePath="/"
                                     canRemix={canRemix}
+                                    canSave={canSave}
                                     className="guiPlayer"
                                     cloudHost={cloudHost}
                                     isFullScreen={isFullScreen}
@@ -498,6 +500,7 @@ PreviewPresentation.propTypes = {
     canRemix: PropTypes.bool,
     canReport: PropTypes.bool,
     canRestoreComments: PropTypes.bool,
+    canSave: PropTypes.bool,
     canShare: PropTypes.bool,
     canUseBackpack: PropTypes.bool,
     cloudHost: PropTypes.string,

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -441,6 +441,7 @@ class Preview extends React.Component {
                         canRemix={this.props.canRemix}
                         canReport={this.props.canReport}
                         canRestoreComments={this.props.isAdmin}
+                        canSave={this.props.canSave}
                         canShare={this.props.canShare}
                         canUseBackpack={this.props.canUseBackpack}
                         cloudHost={this.props.cloudHost}


### PR DESCRIPTION
The canSave prop was being passed to the editor view, but needs to also be passed to the player view because it is used to decide whether to connect the viewer to cloud variables. People cannot connect to cloud variables after entering editor mode on anothers project.

### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Resolves an issue where as the owner of a project with cloud vars, switching from editor view to project page view would not reconnect to the cloud server.

