### PR TITLE
Add missing tutorial shortcuts

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -478,6 +478,13 @@
     {
         "name": "fly-tutorial-redirect",
         "pattern": "^/fly/?$",
+        "routeAlias": "/(makeit)?fly/?$",
+        "redirect": "/tips"
+    },
+    {
+        "name": "makeitfly-tutorial-redirect",
+        "pattern": "^/makeitfly/?$",
+        "routeAlias": "/(makeit)?fly/?$",
         "redirect": "/tips"
     },
     {
@@ -553,6 +560,11 @@
     {
         "name": "makey-tutorial-redirects",
         "pattern": "^/makey(piano|drum)?/?$",
+        "redirect": "/tips"
+    },
+    {
+        "name": "bird-redirect",
+        "pattern": "^/bird/?$",
         "redirect": "/tips"
     }
 ]


### PR DESCRIPTION
### Resolves:
fixes #2364

### Changes:
Add `/bird` and `/makeitfly` as redirects to the tips page. `makeitfly` is an alias for `fly`

### Test Coverage:

Manual testing:
- [ ] `/bird` redirects to /tips
- [ ] `/makeitfly` redirects to /tips
- [ ] `fly` continues to redirect to tips
