### PR TITLE
Point scratch-gui dependency back to develop tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux-thunk": "2.0.1",
     "sass-lint": "1.5.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "latest",
+    "scratch-gui": "develop",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
This was accidentally changed to "latest" when the merge from @rschamp's latest hotfix to master was made.
