### PR TITLE
Refresh the data related to the project json on switch back from editor

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -126,6 +126,11 @@ class Preview extends React.Component {
         if (this.props.playerMode !== prevProps.playerMode || this.props.fullScreen !== prevProps.fullScreen) {
             this.pushHistory(history.state === null);
         }
+
+        // Switching out of editor mode, refresh data that comes from project json
+        if (this.props.playerMode && !prevProps.playerMode) {
+            this.getProjectData(this.state.projectId);
+        }
     }
     componentWillUnmount () {
         this.removeEventListeners();


### PR DESCRIPTION
Fixes an issue where the information related to the project JSON (i.e. moderation data and extension data) would be out of date if you went "see inside" -> add extension -> "see community". The data needs to be re-fetched when switching back from editor mode.

Originally mentioned by @ericrosenbaum 