### PR TITLE
project page will no longer vanish when project metadata update fails on the backend

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -754,9 +754,9 @@ module.exports.updateProject = (id, jsonData, username, token) => (dispatch => {
             dispatch(module.exports.setError('No project info'));
             return;
         }
-        if (res.statusCode === 500) { // InternalServer
+        if (res.statusCode >= 400) { // API responding with error
             dispatch(module.exports.setFetchStatus('project', module.exports.Status.ERROR));
-            dispatch(module.exports.setError('API Internal Server Error'));
+            dispatch(module.exports.setError('API Error Response'));
             return;
         }
         dispatch(module.exports.setFetchStatus('project', module.exports.Status.FETCHED));


### PR DESCRIPTION
One of the weird behaviors identified in the issue https://github.com/LLK/scratch-api/issues/638 is that currently, if you edit project metadata on a censored project, the project disappears:

![dec-04-2018 15-29-21](https://user-images.githubusercontent.com/3431616/49470908-70f70180-f7d9-11e8-82fd-435d08300dea.gif)

That's because we're only checking for status code == 500, and so we are acting in the code like status code === 404 is valid, and setting the project metadata to the response body (which is empty)