### PR TITLE
Allow admins to see share banner

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -471,7 +471,7 @@ class Preview extends React.Component {
                         canReport={this.props.canReport}
                         canRestoreComments={this.props.isAdmin}
                         canSave={this.props.canSave}
-                        canShare={this.props.canShare}
+                        canShare={this.props.canShare || this.props.isAdmin}
                         canUseBackpack={this.props.canUseBackpack}
                         cloudHost={this.props.cloudHost}
                         comments={this.props.comments}


### PR DESCRIPTION
Admins should see the "this project is not shared" message if the project is not shared. Right now, they cannot.

Fixes https://github.com/LLK/scratch-www/issues/2400