### PR TITLE
pass onGreenFlag to GUI; when called, call API to register project view

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -884,3 +884,17 @@ module.exports.updateProjectThumbnail = (id, blob) => (dispatch => {
         dispatch(module.exports.setFetchStatus('project-thumbnail', module.exports.Status.FETCHED));
     });
 });
+
+module.exports.logProjectView = (id, username) => (dispatch => {
+    dispatch(module.exports.setFetchStatus('project-log-view', module.exports.Status.FETCHING));
+    api({
+        uri: `/users/${username}/projects/${id}/views`,
+        method: 'POST'
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            dispatch(module.exports.setFetchStatus('project-log-view', module.exports.Status.ERROR));
+            return;
+        }
+        dispatch(module.exports.setFetchStatus('project-log-view', module.exports.Status.FETCHED));
+    });
+});

--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -885,11 +885,14 @@ module.exports.updateProjectThumbnail = (id, blob) => (dispatch => {
     });
 });
 
-module.exports.logProjectView = (id, username) => (dispatch => {
+module.exports.logProjectView = (id, authorUsername, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('project-log-view', module.exports.Status.FETCHING));
     api({
-        uri: `/users/${username}/projects/${id}/views`,
-        method: 'POST'
+        uri: `/users/${authorUsername}/projects/${id}/views`,
+        method: 'POST',
+        authentication: token,
+        withCredentials: true,
+        useCsrf: true
     }, (err, body, res) => {
         if (err || res.statusCode !== 200) {
             dispatch(module.exports.setFetchStatus('project-log-view', module.exports.Status.ERROR));

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -84,6 +84,7 @@ const PreviewPresentation = ({
     onCopyProjectLink,
     onDeleteComment,
     onFavoriteClicked,
+    onGreenFlag,
     onLoadMore,
     onLoveClicked,
     onOpenAdminPanel,
@@ -287,6 +288,7 @@ const PreviewPresentation = ({
                                     previewInfoVisible="false"
                                     projectHost={projectHost}
                                     projectId={projectId}
+                                    onGreenFlag={onGreenFlag}
                                     onRemixing={onRemixing}
                                     onUpdateProjectId={onUpdateProjectId}
                                 />
@@ -620,6 +622,7 @@ PreviewPresentation.propTypes = {
     onCopyProjectLink: PropTypes.func,
     onDeleteComment: PropTypes.func,
     onFavoriteClicked: PropTypes.func,
+    onGreenFlag: PropTypes.func,
     onLoadMore: PropTypes.func,
     onLoveClicked: PropTypes.func,
     onOpenAdminPanel: PropTypes.func,

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -59,6 +59,7 @@ class Preview extends React.Component {
             'handleRestoreComment',
             'handleAddToStudioClick',
             'handleAddToStudioClose',
+            'handleGreenFlag',
             'handleRemix',
             'handleSeeAllComments',
             'handleSeeInside',
@@ -341,6 +342,9 @@ class Preview extends React.Component {
     handleReportSubmit (formData) {
         this.props.reportProject(this.state.projectId, formData, this.props.user.token);
     }
+    handleGreenFlag () {
+        this.props.logProjectView(this.props.projectInfo.id, this.props.user.username);
+    }
     handlePopState () {
         const path = window.location.pathname.toLowerCase();
         const playerMode = path.indexOf('editor') === -1;
@@ -586,6 +590,7 @@ class Preview extends React.Component {
                         onCopyProjectLink={this.handleCopyProjectLink}
                         onDeleteComment={this.handleDeleteComment}
                         onFavoriteClicked={this.handleFavoriteToggle}
+                        onGreenFlag={this.handleGreenFlag}
                         onLoadMore={this.handleLoadMore}
                         onLoveClicked={this.handleLoveToggle}
                         onOpenAdminPanel={this.handleOpenAdminPanel}
@@ -629,6 +634,7 @@ class Preview extends React.Component {
                         projectId={this.state.projectId}
                         projectTitle={this.props.projectInfo.title}
                         renderLogin={this.renderLogin}
+                        onGreenFlag={this.handleGreenFlag}
                         onLogOut={this.props.handleLogOut}
                         onOpenRegistration={this.props.handleOpenRegistration}
                         onRemixing={this.handleIsRemixing}
@@ -694,6 +700,7 @@ Preview.propTypes = {
     isNewScratcher: PropTypes.bool,
     isScratcher: PropTypes.bool,
     isShared: PropTypes.bool,
+    logProjectView: PropTypes.func,
     loved: PropTypes.bool,
     moreCommentsToLoad: PropTypes.bool,
     original: projectShape,
@@ -882,6 +889,9 @@ const mapDispatchToProps = dispatch => ({
     },
     getLovedStatus: (id, username, token) => {
         dispatch(previewActions.getLovedStatus(id, username, token));
+    },
+    logProjectView: (id, username) => {
+        dispatch(previewActions.logProjectView(id, username));
     },
     setLovedStatus: (loved, id, username, token) => {
         dispatch(previewActions.setLovedStatus(loved, id, username, token));

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -343,7 +343,7 @@ class Preview extends React.Component {
         this.props.reportProject(this.state.projectId, formData, this.props.user.token);
     }
     handleGreenFlag () {
-        this.props.logProjectView(this.props.projectInfo.id, this.props.user.username);
+        this.props.logProjectView(this.props.projectInfo.id, this.props.authorUsername, this.props.user.token);
     }
     handlePopState () {
         const path = window.location.pathname.toLowerCase();
@@ -890,8 +890,8 @@ const mapDispatchToProps = dispatch => ({
     getLovedStatus: (id, username, token) => {
         dispatch(previewActions.getLovedStatus(id, username, token));
     },
-    logProjectView: (id, username) => {
-        dispatch(previewActions.logProjectView(id, username));
+    logProjectView: (id, authorUsername, token) => {
+        dispatch(previewActions.logProjectView(id, authorUsername, token));
     },
     setLovedStatus: (loved, id, username, token) => {
         dispatch(previewActions.setLovedStatus(loved, id, username, token));


### PR DESCRIPTION
### Resolves:

Part of resolving https://github.com/LLK/scratch-www/issues/1858

relies on https://github.com/LLK/scratch-gui/pull/3981 and https://github.com/LLK/scratch-api/pull/650

### Changes:

Passes a function callback to GUI, for it to call when green flag clicked. When handling this callback, post to the API endpoint responsible for registering project views.
