### PR TITLE
Remove share button on censored project banner.

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -132,19 +132,10 @@ const PreviewPresentation = ({
             message={<FormattedMessage id="project.deletedBanner" />}
         />);
     } else if (visibilityInfo.censored) {
-        if (visibilityInfo.reshareable) {
-            banner = (<Banner
-                actionMessage={<FormattedMessage id="project.share.shareButton" />}
-                className="banner-danger"
-                message={embedCensorMessage(visibilityInfo.message)}
-                onAction={onShare}
-            />);
-        } else {
-            banner = (<Banner
-                className="banner-danger"
-                message={embedCensorMessage(visibilityInfo.message)}
-            />);
-        }
+        banner = (<Banner
+            className="banner-danger"
+            message={embedCensorMessage(visibilityInfo.message)}
+        />);
     } else if (justRemixed) {
         banner = (
             <Banner


### PR DESCRIPTION
Because it doesn't work until the project has changed, it is a little misleading and shouldn't be so big. The functionality needs reconsidering.
