### PR TITLE
if remix parent or original is unshared, don't crash project page

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -394,6 +394,10 @@ module.exports.getOriginalInfo = id => (dispatch => {
             return;
         }
         dispatch(module.exports.setFetchStatus('original', module.exports.Status.FETCHED));
+        if (body && body.code === 'NotFound') {
+            dispatch(module.exports.setOriginalInfo({}));
+            return;
+        }
         dispatch(module.exports.setOriginalInfo(body));
     });
 });
@@ -414,6 +418,10 @@ module.exports.getParentInfo = id => (dispatch => {
             return;
         }
         dispatch(module.exports.setFetchStatus('parent', module.exports.Status.FETCHED));
+        if (body && body.code === 'NotFound') {
+            dispatch(module.exports.setParentInfo({}));
+            return;
+        }
         dispatch(module.exports.setParentInfo(body));
     });
 });

--- a/src/views/preview/remix-credit.jsx
+++ b/src/views/preview/remix-credit.jsx
@@ -8,6 +8,7 @@ const thumbnailUrl = require('../../lib/user-thumbnail');
 const RemixCredit = props => {
     const projectInfo = props.projectInfo;
     if (Object.keys(projectInfo).length === 0) return null;
+    if (!projectInfo.author) return null;
     return (
         <FlexRow className="remix-credit">
             <Avatar


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2201

### Changes:

Checks for return values from API indicating that the parent project (of a remix) or original project (in the remix tree) was not found, which is usually because it was unshared.

Checks in `remix-credit.jsx` to make sure parent or original info object has needed fields before assuming that they are there.

### Test Coverage:

None