### PR TITLE
Actually return the mapping of extension info

### DIFF
--- a/src/lib/project-info.js
+++ b/src/lib/project-info.js
@@ -3,10 +3,9 @@ const EXTENSION_INFO = require('./extensions.js').default;
 module.exports = {
     // Keys match the projectVersion key from project serialization
     3: {
-        extensions: project => {
+        extensions: project =>
             (project.extensions || []).map(ext => EXTENSION_INFO[ext])
-                .filter(ext => !!ext); // Only include extensions in the info lib
-        },
+                .filter(ext => !!ext), // Only include extensions in the info lib
         spriteCount: project =>
             project.targets.length - 1, // don't count stage
         scriptCount: project => project.targets


### PR DESCRIPTION
### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Fixes an issue where 3.0 projects arent showing their extensions.

@kchadha this was just a typo in our PR.