### PR TITLE
don't use flex-row class to wrap instructions and credits

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -345,7 +345,7 @@ const PreviewPresentation = ({
                                         </FlexRow>
                                     </FlexRow>
                                 </MediaQuery>
-                                <FlexRow className="description-block">
+                                <div className="description-block">
                                     <div className="project-textlabel">
                                         <FormattedMessage id="project.instructionsLabel" />
                                     </div>
@@ -385,8 +385,8 @@ const PreviewPresentation = ({
                                             })}
                                         </div>
                                     }
-                                </FlexRow>
-                                <FlexRow className="description-block">
+                                </div>
+                                <div className="description-block">
                                     <div className="project-textlabel">
                                         <FormattedMessage id="project.notesAndCreditsLabel" />
                                     </div>
@@ -427,7 +427,7 @@ const PreviewPresentation = ({
                                             })}
                                         </div>
                                     }
-                                </FlexRow>
+                                </div>
                                 {/*  eslint-enable max-len */}
                             </FlexRow>
                         </FlexRow>


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2458

### Changes:

Changes the `<FlexRow>` element that wraps the instructions and credits sections on the project page into a <div> instead, so it won't use the `flex-row` class, so it won't use the `flex-wrap: wrap` property, which can make the "instructions" and "notes and credits" wrap
