### PR TITLE
Change the endpoint for loading single comments

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -481,7 +481,7 @@ module.exports.getTopLevelComments = (id, offset, isAdmin, token) => (dispatch =
 module.exports.getCommentById = (projectId, commentId, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHING));
     api({
-        uri: `${isAdmin ? '/admin' : ''}/projects/comments/${commentId}`,
+        uri: `${isAdmin ? '/admin' : ''}/projects/${projectId}/comments/${commentId}`,
         authentication: isAdmin ? token : null
     }, (err, body) => {
         if (err) {


### PR DESCRIPTION
In order to make it possible to invalidate the cache on all project comments, move the comment loading endpoint to /projects/:id/comments/:id