### PR TITLE
Add flag for dynamic meta tags in the template

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -167,7 +167,8 @@
         "pattern": "^/projects(/editor|(/\\d+(/editor|/fullscreen|/embed)?)?)?/?(\\?.*)?$",
         "routeAlias": "/projects/?$",
         "view": "preview/preview",
-        "title": "Scratch Project"
+        "title": "Scratch Project",
+        "dynamicMetaTags": true
     },
     {
         "name": "3faq",

--- a/src/template.ejs
+++ b/src/template.ejs
@@ -8,23 +8,25 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=<%= htmlWebpackPlugin.options.viewportWidth %>, initial-scale=1">
 
-        <title>Scratch - <%= htmlWebpackPlugin.options.title %></title>
-
         <!-- Prevent mobile Safari from making phone numbers -->
         <meta name="format-detection" content="telephone=no">
 
-        <!-- Search & Open Graph-->
-        <meta name="description" content="<%= htmlWebpackPlugin.options.description %>" />
-        <meta name="google-site-verification" content="m_3TAXDreGTFyoYnEmU9mcKB4Xtw5mw6yRkuJtXRKxM" />
+        <% if (!htmlWebpackPlugin.options.dynamicMetaTags) { %>
+            <title>Scratch - <%= htmlWebpackPlugin.options.title %></title>
 
-        <meta property="og:url" content="https://scratch.mit.edu/" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Scratch - <%= htmlWebpackPlugin.options.title %>" />
-        <meta property="og:description" content="<%= htmlWebpackPlugin.options.description %>" />
-        <meta property="og:image" content="<%- htmlWebpackPlugin.options.og_image %>" />
-        <meta property="og:image:type" content="<%- htmlWebpackPlugin.options.og_image_type %>" />
-        <meta property="og:image:width" content="<%- htmlWebpackPlugin.options.og_image_width %>" />
-        <meta property="og:image:height" content="<%- htmlWebpackPlugin.options.og_image_height %>" />
+            <!-- Search & Open Graph-->
+            <meta name="description" content="<%= htmlWebpackPlugin.options.description %>" />
+            <meta name="google-site-verification" content="m_3TAXDreGTFyoYnEmU9mcKB4Xtw5mw6yRkuJtXRKxM" />
+
+            <meta property="og:url" content="https://scratch.mit.edu/" />
+            <meta property="og:type" content="website" />
+            <meta property="og:title" content="Scratch - <%= htmlWebpackPlugin.options.title %>" />
+            <meta property="og:description" content="<%= htmlWebpackPlugin.options.description %>" />
+            <meta property="og:image" content="<%- htmlWebpackPlugin.options.og_image %>" />
+            <meta property="og:image:type" content="<%- htmlWebpackPlugin.options.og_image_type %>" />
+            <meta property="og:image:width" content="<%- htmlWebpackPlugin.options.og_image_width %>" />
+            <meta property="og:image:height" content="<%- htmlWebpackPlugin.options.og_image_height %>" />
+        <% } %>
 
         <!-- Favicon & CSS normalize -->
         <link rel="shortcut icon" href="/favicon.ico" />
@@ -60,19 +62,21 @@
         <script src="/<%= htmlWebpackPlugin.files.chunks[htmlWebpackPlugin.options.route.name].entry %>"></script>
 
         <!-- Translate title element -->
-        <script>
-            var loc = window._locale || 'en';
-            if (typeof window._messages !== 'undefined' && loc !== 'en') {
-                if (typeof window._messages[loc] === 'undefined') {
-                    loc = loc.split('-')[0];
-                }
-                if (typeof window._messages[loc] !== 'undefined') {
-                    var localizedTitle = window._messages[loc]['general.' + '<%= htmlWebpackPlugin.options.title %>'.toLowerCase()] || '';
-                    if (localizedTitle.length > 0) {
-                        document.title = 'Scratch - ' + localizedTitle;
+        <% if (!htmlWebpackPlugin.options.dynamicMetaTags) { %>
+            <script>
+                var loc = window._locale || 'en';
+                if (typeof window._messages !== 'undefined' && loc !== 'en') {
+                    if (typeof window._messages[loc] === 'undefined') {
+                        loc = loc.split('-')[0];
+                    }
+                    if (typeof window._messages[loc] !== 'undefined') {
+                        var localizedTitle = window._messages[loc]['general.' + '<%= htmlWebpackPlugin.options.title %>'.toLowerCase()] || '';
+                        if (localizedTitle.length > 0) {
+                            document.title = 'Scratch - ' + localizedTitle;
+                        }
                     }
                 }
-            }
-        </script>
+            </script>
+        <% } %>
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,8 @@ module.exports = {
             return new HtmlWebpackPlugin(defaults({}, {
                 title: route.title,
                 filename: route.name + '.html',
-                route: route
+                route: route,
+                dynamicMetaTags: route.dynamicMetaTags
             }, templateConfig));
         })
     ).concat([


### PR DESCRIPTION
Resolves https://github.com/LLK/scratch-www/issues/2354 by allowing routes to declare `dynamicMetaTags: true`, in which case we do not render the default meta information, allowing the dynamic ones to take over.

@rschamp I know we mentioned using a separate template, but I didn't want to duplicate some of the things that are shared, like favicon, google site verification, etc, so I did it as a flag.