### PR TITLE
Fix some spacing issues on the download page. Adds a more padding und…

### DIFF
--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -191,9 +191,9 @@ class Download extends React.Component {
                         <h2 className="title">
                             <FormattedMessage id="download.olderVersionsTitle" />
                         </h2>
-                        <h3 className="faq-question">
+                        <p>
                             <FormattedMessage id="download.olderVersions" />
-                        </h3>
+                        </p>
                         <FlexRow>
                             <div className="older-version">
                                 <a href="/download/scratch2">

--- a/src/views/download/download.scss
+++ b/src/views/download/download.scss
@@ -7,7 +7,7 @@
 
 .download {
     .title {
-        margin-bottom: 1rem;
+        margin-bottom: 2rem;
         font-size: 2rem;
     }
 


### PR DESCRIPTION
…er heading titles and makes the text in the older versions section have normal text styling.

See screenshots below for comparison of old and new. The one on top is the new one, the second is the old one.

![screen shot 2018-12-17 at 3 06 40 pm](https://user-images.githubusercontent.com/15675877/50112554-73138400-020d-11e9-943b-a4808ceeefaa.png)
![screen shot 2018-12-17 at 3 06 12 pm](https://user-images.githubusercontent.com/15675877/50112558-7575de00-020d-11e9-897a-9d489e96cf59.png)
![screen shot 2018-12-17 at 3 05 54 pm](https://user-images.githubusercontent.com/15675877/50112565-7a3a9200-020d-11e9-915e-7e7025b19b28.png)
![screen shot 2018-12-17 at 3 05 46 pm](https://user-images.githubusercontent.com/15675877/50112569-7dce1900-020d-11e9-9d6f-72564032e892.png)
