### PR TITLE
pass onUpdateProjectThumbnail to gui when on project page

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -103,6 +103,7 @@ const PreviewPresentation = ({
     onToggleStudio,
     onUpdate,
     onUpdateProjectId,
+    onUpdateProjectThumbnail,
     originalInfo,
     parentInfo,
     showCloudDataAlert,
@@ -297,6 +298,7 @@ const PreviewPresentation = ({
                                     onGreenFlag={onGreenFlag}
                                     onRemixing={onRemixing}
                                     onUpdateProjectId={onUpdateProjectId}
+                                    onUpdateProjectThumbnail={onUpdateProjectThumbnail}
                                 />
                             </div>
                             <MediaQuery maxWidth={frameless.tablet - 1}>
@@ -643,6 +645,7 @@ PreviewPresentation.propTypes = {
     onToggleStudio: PropTypes.func,
     onUpdate: PropTypes.func,
     onUpdateProjectId: PropTypes.func,
+    onUpdateProjectThumbnail: PropTypes.func,
     originalInfo: projectShape,
     parentInfo: projectShape,
     projectHost: PropTypes.string,

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -640,6 +640,7 @@ class Preview extends React.Component {
                             onToggleStudio={this.handleToggleStudio}
                             onUpdate={this.handleUpdate}
                             onUpdateProjectId={this.handleUpdateProjectId}
+                            onUpdateProjectThumbnail={this.props.handleUpdateProjectThumbnail}
                         />
                     </Page> :
                     <React.Fragment>


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2484 
(together with https://github.com/LLK/scratch-gui/pull/4111 , but the two do not depend on each other)

### Changes:

Passes onUpdateProjectThumbnail function prop to `PreviewPresentation` and from there to `GUI`, so that the project page player has access to it (not just in editor view).

### Test Coverage:

none