### PR TITLE
Make it clear that only Scratchers can use the cloud

### DIFF
--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -33,6 +33,6 @@
     "project.descriptionMaxLength": "Description is too long",
     "project.notesPlaceholder": "How did you make this project? Did you use ideas, scripts or artwork from other people? Thank them here.",
     "project.descriptionPlaceholder": "Tell people how to use your project (such as which keys to press).",
-    "project.cloudDataAlert": "This project uses cloud data - a feature that is only available to signed in users.",
+    "project.cloudDataAlert": "This project uses cloud data - a feature that is only available to signed in Scratchers.",
     "project.usernameBlockAlert": "This project can detect who is using it, through the \"username\" block. To hide your identity, sign out before using the project."
 }


### PR DESCRIPTION
### Resolves:

Resolves #2491 

### Changes:

Changes "users" to "Scratchers", to make it clear that new users can't use the cloud.

### Test Coverage:

N/A
