### PR TITLE
switch to editor after remixing from project page

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -288,7 +288,7 @@ class Preview extends React.Component {
                 this.setState({
                     justRemixed: true,
                     justShared: false
-                });
+                }, this.handleSeeInside);
             }
         }
     }


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2339

### Changes:

As soon as remix is done on project page, calls the same code that clicking the See inside button calls.

Note that the UX is kind of fiddly because so much react state changes so many times before it all settles

### Test Coverage:

None.