### PR TITLE
Fix page width by hiding overflow, letting stage width be flexible

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -479,6 +479,7 @@ $stage-width: 480px;
         line-height: 1.5rem;
         flex: 1;
         overflow-wrap: break-word;
+        word-break: break-word;
     }
 
     .project-description:last-of-type {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -365,7 +365,7 @@ $stage-width: 480px;
     .guiPlayer {
         display: inline-block;
         position: relative;
-        width: $player-width;
+        max-width: $player-width;
         z-index: 1;
 
         $alert-bg: rgba(255, 255, 255, .85);

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -38,9 +38,11 @@ $stage-width: 480px;
 
     .inner {
         margin: 0 auto;
+        overflow: auto;
 
         @media #{$medium-and-smaller} {
-            max-width: 90%;
+            // subtract page padding
+            max-width: calc(100% - 1rem);
         }
 
         @media #{$intermediate} {
@@ -146,7 +148,8 @@ $stage-width: 480px;
         flex-grow: 1;
 
         @media #{$medium-and-smaller} {
-            min-width: calc(100% - 2rem);
+            // subtract margin and border
+            min-width: calc(100% - 2rem - 4px);
         }
     }
 
@@ -421,7 +424,7 @@ $stage-width: 480px;
         border-radius: 8px;
         background-color: $ui-blue-10percent;
         padding: .75rem;
-        width: calc(100% - 1.5rem);
+        width: calc(100% - 1.5rem - 2px);
         flex-wrap: nowrap;
         align-items: center;
         justify-content: flex-start;


### PR DESCRIPTION
### Resolves:

Resolves, at least partially: https://github.com/LLK/scratch-www/issues/2513
Resolves https://github.com/LLK/scratch-www/issues/2853
(https://github.com/LLK/scratch-gui/pull/4827 will also help resolve, but this PR does not require it)

### Changes:

* Flexibly allows the project page player stage width to be controlled by gui, rather than enforced to a particular width
* changes overflow handling so that the page width stays matching the window width (rather than becoming out of step, as seen in the screenshot from #2513)

### Before

![image](https://user-images.githubusercontent.com/3431616/62001566-b1392600-b0c1-11e9-978c-b5752ae45a0f.png)

![image](https://user-images.githubusercontent.com/3431616/62001569-b5654380-b0c1-11e9-9b76-a6b129cede59.png)


### After

![image](https://user-images.githubusercontent.com/3431616/62001580-cd3cc780-b0c1-11e9-9e0a-42aa3f75a5c9.png)

![image](https://user-images.githubusercontent.com/3431616/62001581-d2017b80-b0c1-11e9-83ec-e174958663ec.png)


### Test Coverage:

None