### PR TITLE
since api proxy of share endpoint returns string, handle string or boolean

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -810,7 +810,8 @@ const mapStateToProps = state => {
         state.session.session.user.id.toString() === authorId;
 
     // if we don't have projectInfo, assume it's shared until we know otherwise
-    const isShared = !projectInfoPresent || state.preview.projectInfo.is_published;
+    const isShared = !projectInfoPresent ||
+            (state.preview.projectInfo.is_published === true || state.preview.projectInfo.is_published === 'true');
 
     return {
         authorId: authorId,


### PR DESCRIPTION

### Resolves:

Helps deal with https://github.com/LLK/scratch-api/issues/680 without really resolving the problem

### Changes:

sets `isShared` to true if `is_published` value received from api is the string `"true"`, not just the boolean value `true`.

### Test Coverage:

none