### PR TITLE
Credits link has changed

### DIFF
--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -91,7 +91,7 @@ tap.test('clickForDevelopersScratchLink', options, t => {
 // CREDITS
 tap.test('clickCreditsLink', options, t => {
     const linkText = 'Credits';
-    const expectedHref = '/info/credits';
+    const expectedHref = '/credits';
     clickFooterLinks(linkText).then(url => {
         t.equal(url.substr(-expectedHref.length), expectedHref);
         t.end();


### PR DESCRIPTION
### Resolves:

Smoke tests have been failing as the credits link in the footer now lands on `/credits` instead of `/info/credits`

### Test Coverage:

Smoke tests should pass
