### PR TITLE
Fix the studio links to use the correct URL

### DIFF
--- a/src/views/preview/studio-list.jsx
+++ b/src/views/preview/studio-list.jsx
@@ -20,7 +20,7 @@ const StudioList = props => {
                 <ThumbnailColumn
                     cards
                     showAvatar
-                    itemType="studio"
+                    itemType="studios"
                     items={studios.slice(0, 5)}
                     showFavorites={false}
                     showLoves={false}


### PR DESCRIPTION
### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Resolves an issue that @BryceLTaylor found this morning where the project page was linking to `/studio/:id` instead of `/studios/:id`

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Fixes the "itemType" property which is used to create the URL for the links.
