### PR TITLE
Bring in the min sizes for GUI to allow scrollable UI

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -18,6 +18,11 @@ $stage-width: 480px;
     margin: 0;
     width: 100%;
     height: 100%;
+
+    /* Setting min height/width makes the UI scroll below those sizes */
+    /* Copied from GUI playground index.css */
+    min-width: 1024px;
+    min-height: 640px; /* Min height to fit sprite/backdrop button */
 }
 
 .page-has-admin-panel {


### PR DESCRIPTION
/cc @rschamp @thisandagain 

Bring in the min sizes from the [GUI playground](https://github.com/LLK/scratch-gui/blob/develop/src/playground/index.css#L9-L11) to allow for scrollable UI. I double checked that this is the correct class used in the editor view and not used in the regular project page view. 

