### PR TITLE
Pin to a specific version of scratch-gui

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "develop",
+    "scratch-gui": "0.1.0-prerelease.20181227160059",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
This will enable us to have more confidence/control over updates to scratch-gui, be able to test updates individually and allow us to rollback if needed.
