### PR TITLE
[RELEASE] fix downloads 3faq routes

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -108,7 +108,7 @@
     },
     {
         "name": "download",
-        "pattern": "^/download/?$",
+        "pattern": "^/download/?(.+)?$",
         "routeAlias": "/download",
         "view": "download/download",
         "title": "Scratch Offline Editor"
@@ -129,7 +129,7 @@
     },
     {
         "name": "faq",
-        "pattern": "^/info/faq/?$",
+        "pattern": "^/info/faq/?(.+)?$",
         "routeAlias": "/info/(cards|communityblocks-interviews|credits|faq)/?$",
         "view": "faq/faq",
         "title": "FAQ"
@@ -205,11 +205,11 @@
         "title": "Scratch 3.0 Preview"
     },
     {
-        "name": "3faq",
-        "pattern": "^/3faq/?$",
-        "routeAlias": "/3faq/?$",
-        "view": "preview-faq/preview-faq",
-        "title": "Scratch 3.0 FAQ"
+        "name": "parents",
+        "pattern": "^/parents/?$",
+        "routeAlias": "/parents/",
+        "view": "parents/parents",
+        "title": "For Parents"
     },
     {
         "name": "preview-faq-redirect",


### PR DESCRIPTION
### Resolves:

Third party websites include extra query parameters to `/faq`, `/download`. Will need to land this and/or make updates to CDN configuration if not landed before release.

### Changes:

Fixes issue with correctly routing in CDN.

### Test Coverage:

N/A