### PR TITLE
collapse empty project instructions or notes and credits

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -124,9 +124,9 @@ const PreviewPresentation = ({
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
     const revisedDate = ((projectInfo.history && projectInfo.history.modified)) ? projectInfo.history.modified : '';
     const showInstructions = editable || projectInfo.instructions ||
-        (!projectInfo.instructions && !projectInfo.description);
+        (!projectInfo.instructions && !projectInfo.description); // show if both are empty
     const showNotesAndCredits = editable || projectInfo.description ||
-        (!projectInfo.instructions && !projectInfo.description);
+        (!projectInfo.instructions && !projectInfo.description); // show if both are empty
 
     // Allow embedding html in banner messages coming from the server
     const embedCensorMessage = message => (

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -123,6 +123,10 @@ const PreviewPresentation = ({
 }) => {
     const shareDate = ((projectInfo.history && projectInfo.history.shared)) ? projectInfo.history.shared : '';
     const revisedDate = ((projectInfo.history && projectInfo.history.modified)) ? projectInfo.history.modified : '';
+    const showInstructions = editable || projectInfo.instructions ||
+        (!projectInfo.instructions && !projectInfo.description);
+    const showNotesAndCredits = editable || projectInfo.description ||
+        (!projectInfo.instructions && !projectInfo.description);
 
     // Allow embedding html in banner messages coming from the server
     const embedCensorMessage = message => (
@@ -348,89 +352,93 @@ const PreviewPresentation = ({
                                         </FlexRow>
                                     </FlexRow>
                                 </MediaQuery>
-                                <div className="description-block">
-                                    <div className="project-textlabel">
-                                        <FormattedMessage id="project.instructionsLabel" />
-                                    </div>
-                                    {editable ?
-                                        <Formsy
-                                            className="project-description-form"
-                                            onKeyPress={onKeyPress}
-                                        >
-                                            <InplaceInput
-                                                className={classNames(
-                                                    'project-description-edit',
-                                                    {remixes: parentInfo && parentInfo.author}
-                                                )}
-                                                handleUpdate={onUpdate}
-                                                name="instructions"
-                                                placeholder={intl.formatMessage({
-                                                    id: 'project.descriptionPlaceholder'
-                                                })}
-                                                type="textarea"
-                                                validationErrors={{
-                                                    maxLength: intl.formatMessage({
-                                                        id: 'project.descriptionMaxLength'
-                                                    })
-                                                }}
-                                                validations={{
-                                                    // TODO: actual 5000
-                                                    maxLength: 1000
-                                                }}
-                                                value={projectInfo.instructions}
-                                            />
-                                        </Formsy> :
-                                        <div className="project-description">
-                                            {decorateText(projectInfo.instructions, {
-                                                usernames: true,
-                                                hashtags: true,
-                                                scratchLinks: false
-                                            })}
+                                {showInstructions && (
+                                    <div className="description-block">
+                                        <div className="project-textlabel">
+                                            <FormattedMessage id="project.instructionsLabel" />
                                         </div>
-                                    }
-                                </div>
-                                <div className="description-block">
-                                    <div className="project-textlabel">
-                                        <FormattedMessage id="project.notesAndCreditsLabel" />
-                                    </div>
-                                    {editable ?
-                                        <Formsy
-                                            className="project-description-form"
-                                            onKeyPress={onKeyPress}
-                                        >
-                                            <InplaceInput
-                                                className={classNames(
-                                                    'project-description-edit',
-                                                    'last',
-                                                    {remixes: parentInfo && parentInfo.author}
-                                                )}
-                                                handleUpdate={onUpdate}
-                                                name="description"
-                                                placeholder={intl.formatMessage({
-                                                    id: 'project.notesPlaceholder'
+                                        {editable ?
+                                            <Formsy
+                                                className="project-description-form"
+                                                onKeyPress={onKeyPress}
+                                            >
+                                                <InplaceInput
+                                                    className={classNames(
+                                                        'project-description-edit',
+                                                        {remixes: parentInfo && parentInfo.author}
+                                                    )}
+                                                    handleUpdate={onUpdate}
+                                                    name="instructions"
+                                                    placeholder={intl.formatMessage({
+                                                        id: 'project.descriptionPlaceholder'
+                                                    })}
+                                                    type="textarea"
+                                                    validationErrors={{
+                                                        maxLength: intl.formatMessage({
+                                                            id: 'project.descriptionMaxLength'
+                                                        })
+                                                    }}
+                                                    validations={{
+                                                        // TODO: actual 5000
+                                                        maxLength: 1000
+                                                    }}
+                                                    value={projectInfo.instructions}
+                                                />
+                                            </Formsy> :
+                                            <div className="project-description">
+                                                {decorateText(projectInfo.instructions, {
+                                                    usernames: true,
+                                                    hashtags: true,
+                                                    scratchLinks: false
                                                 })}
-                                                type="textarea"
-                                                validationErrors={{
-                                                    maxLength: intl.formatMessage({
-                                                        id: 'project.descriptionMaxLength'
-                                                    })
-                                                }}
-                                                validations={{
-                                                    // TODO: actual 5000
-                                                    maxLength: 1000
-                                                }}
-                                                value={projectInfo.description}
-                                            />
-                                        </Formsy> :
-                                        <div className="project-description last">
-                                            {decorateText(projectInfo.description, {
-                                                usernames: true,
-                                                hashtags: true,
-                                                scratchLinks: false
-                                            })}
+                                            </div>
+                                        }
+                                    </div>
+                                )}
+                                {showNotesAndCredits && (
+                                    <div className="description-block">
+                                        <div className="project-textlabel">
+                                            <FormattedMessage id="project.notesAndCreditsLabel" />
                                         </div>
-                                    }
-                                </div>
+                                        {editable ?
+                                            <Formsy
+                                                className="project-description-form"
+                                                onKeyPress={onKeyPress}
+                                            >
+                                                <InplaceInput
+                                                    className={classNames(
+                                                        'project-description-edit',
+                                                        'last',
+                                                        {remixes: parentInfo && parentInfo.author}
+                                                    )}
+                                                    handleUpdate={onUpdate}
+                                                    name="description"
+                                                    placeholder={intl.formatMessage({
+                                                        id: 'project.notesPlaceholder'
+                                                    })}
+                                                    type="textarea"
+                                                    validationErrors={{
+                                                        maxLength: intl.formatMessage({
+                                                            id: 'project.descriptionMaxLength'
+                                                        })
+                                                    }}
+                                                    validations={{
+                                                        // TODO: actual 5000
+                                                        maxLength: 1000
+                                                    }}
+                                                    value={projectInfo.description}
+                                                />
+                                            </Formsy> :
+                                            <div className="project-description last">
+                                                {decorateText(projectInfo.description, {
+                                                    usernames: true,
+                                                    hashtags: true,
+                                                    scratchLinks: false
+                                                })}
+                                            </div>
+                                        }
+                                    </div>
+                                )}
                                 {/*  eslint-enable max-len */}
                             </FlexRow>
                         </FlexRow>


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/1938

### Changes:

On the project page, conditionally shows project instructions, and project notes&credits. If both have text, both will show, taking up half the height. If either one is empty, it will hide, allowing the other to occupy all of the vertical space, UNLESS both are blank, in which case they both display normally.

This behavior was cleared with the mods.

(Note that admins will always see both fields, as in 2.0.)

Examples of new behavior:

Both empty:
![image](https://user-images.githubusercontent.com/3431616/50652961-11198500-0f56-11e9-908f-dc6d6d370072.png)

Empty instructions, non-empty notes&credits:
![image](https://user-images.githubusercontent.com/3431616/50652987-21c9fb00-0f56-11e9-8d21-1e87b0495235.png)

Empty notes&credits, non-empty instructions:
![image](https://user-images.githubusercontent.com/3431616/50653007-2db5bd00-0f56-11e9-9a24-bcb86baf6098.png)

Both non-empty:
![image](https://user-images.githubusercontent.com/3431616/50653012-33130780-0f56-11e9-8aa6-a761dbd7c41f.png)


