### PR TITLE
[Master] Show link to view all remixes on project page

### DIFF
--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -22,7 +22,7 @@
     "project.remixButton.altText": "Save a copy of this project and add your own ideas.",
     "project.remixButton.remixing": "Remixing...",
     "project.remixes": "Remixes",
-    "project.viewAllRemixes": "View all",
+    "project.viewAllInList": "View all",
     "project.inviteToRemix": "Invite user to remix",
     "project.instructionsLabel": "Instructions",
     "project.notesAndCreditsLabel": "Notes and Credits",

--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -22,6 +22,7 @@
     "project.remixButton.altText": "Save a copy of this project and add your own ideas.",
     "project.remixButton.remixing": "Remixing...",
     "project.remixes": "Remixes",
+    "project.viewAllRemixes": "View all",
     "project.inviteToRemix": "Invite user to remix",
     "project.instructionsLabel": "Instructions",
     "project.notesAndCreditsLabel": "Notes and Credits",

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -577,7 +577,10 @@ const PreviewPresentation = ({
                                         projectId={projectId}
                                         remixes={remixes}
                                     />
-                                    <StudioList studios={projectStudios} />
+                                    <StudioList
+                                        projectId={projectId}
+                                        studios={projectStudios}
+                                    />
                                 </FlexRow>
                             </FlexRow>
                         </div>

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -573,7 +573,10 @@ const PreviewPresentation = ({
                                     </FlexRow>
                                 </div>
                                 <FlexRow className="column">
-                                    <RemixList remixes={remixes} />
+                                    <RemixList
+                                        projectId={projectId}
+                                        remixes={remixes}
+                                    />
                                     <StudioList studios={projectStudios} />
                                 </FlexRow>
                             </FlexRow>

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -554,6 +554,7 @@ $stage-width: 480px;
     .remix-list,
     .studio-list {
         flex-direction: column;
+        width: 14.625rem;
 
         .list-header {
             display: flex;
@@ -561,16 +562,25 @@ $stage-width: 480px;
             justify-content: space-between;
         }
 
+        .list-header-spacer {
+            flex: 1 0 1px;
+        }
+
         .list-title {
             margin-left: 1rem;
             font-size: 1.2rem;
             font-weight: bold;
             align-self: flex-start;
+            line-height: 110%;
+            text-align: left;
         }
 
         .list-header-link {
             margin-right: 1rem;
-            align-self: center;
+            align-self: flex-end;
+            font-size: .75rem;
+            line-height: 110%;
+            text-align: right;
         }
 
         .creator-image img {
@@ -596,6 +606,7 @@ $stage-width: 480px;
 
         @media #{$medium-and-smaller} {
             margin-top: 1rem;
+            width: 100%;
         }
     }
 }

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -555,11 +555,22 @@ $stage-width: 480px;
     .studio-list {
         flex-direction: column;
 
+        .list-header {
+            display: flex;
+            width: 100%;
+            justify-content: space-between;
+        }
+
         .list-title {
             margin-left: 1rem;
             font-size: 1.2rem;
             font-weight: bold;
             align-self: flex-start;
+        }
+
+        .list-header-link {
+            margin-right: 1rem;
+            align-self: center;
         }
 
         .creator-image img {

--- a/src/views/preview/remix-list.jsx
+++ b/src/views/preview/remix-list.jsx
@@ -14,6 +14,7 @@ const RemixList = props => {
                 <div className="list-title">
                     <FormattedMessage id="project.remixes" />
                 </div>
+                <div className="list-header-spacer" />
                 <div className="list-header-link">
                     <a href={`/projects/${props.projectId}/remixes`}>
                         <FormattedMessage id="project.viewAllRemixes" />

--- a/src/views/preview/remix-list.jsx
+++ b/src/views/preview/remix-list.jsx
@@ -17,7 +17,7 @@ const RemixList = props => {
                 <div className="list-header-spacer" />
                 <div className="list-header-link">
                     <a href={`/projects/${props.projectId}/remixes`}>
-                        <FormattedMessage id="project.viewAllRemixes" />
+                        <FormattedMessage id="project.viewAllInList" />
                     </a>
                 </div>
             </div>

--- a/src/views/preview/remix-list.jsx
+++ b/src/views/preview/remix-list.jsx
@@ -10,8 +10,15 @@ const RemixList = props => {
     if (remixes.length === 0) return null;
     return (
         <FlexRow className="remix-list">
-            <div className="list-title">
-                <FormattedMessage id="project.remixes" />
+            <div className="list-header">
+                <div className="list-title">
+                    <FormattedMessage id="project.remixes" />
+                </div>
+                <div className="list-header-link">
+                    <a href={`/projects/${props.projectId}/remixes`}>
+                        <FormattedMessage id="project.viewAllRemixes" />
+                    </a>
+                </div>
             </div>
             {remixes.length === 0 ? (
                 // TODO: style remix invitation
@@ -32,6 +39,7 @@ const RemixList = props => {
 };
 
 RemixList.propTypes = {
+    projectId: PropTypes.string,
     remixes: PropTypes.arrayOf(projectShape)
 };
 

--- a/src/views/preview/studio-list.jsx
+++ b/src/views/preview/studio-list.jsx
@@ -10,8 +10,16 @@ const StudioList = props => {
     if (studios.length === 0) return null;
     return (
         <FlexRow className="studio-list">
-            <div className="list-title">
-                <FormattedMessage id="general.studios" />
+            <div className="list-header">
+                <div className="list-title">
+                    <FormattedMessage id="general.studios" />
+                </div>
+                <div className="list-header-spacer" />
+                <div className="list-header-link">
+                    <a href={`/projects/${props.projectId}/studios`}>
+                        <FormattedMessage id="project.viewAllInList" />
+                    </a>
+                </div>
             </div>
             {studios.length === 0 ? (
                 // TODO: style remix invitation
@@ -32,6 +40,7 @@ const StudioList = props => {
 };
 
 StudioList.propTypes = {
+    projectId: PropTypes.string,
     studios: PropTypes.arrayOf(projectShape)
 };
 


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2584

### Changes:

Adds a "View all" link at the top of the list of remixes on the project page

On Safari:
![image](https://user-images.githubusercontent.com/3431616/50667835-4db2a400-0f89-11e9-9b17-efd64ac6756f.png)

On Chrome:
![image](https://user-images.githubusercontent.com/3431616/50667841-60c57400-0f89-11e9-8621-9237bf43f2fb.png)


/cc: @carljbowman @kathymakes