### PR TITLE
[Master] Fix hashtag search

### DIFF
--- a/src/lib/decorate-text.jsx
+++ b/src/lib/decorate-text.jsx
@@ -32,11 +32,11 @@ module.exports = (text, opts) => {
 
     // Match hashtags
     if (opts.hashtags) {
-        replacedText = reactStringReplace(replacedText, /(#[\w-]+)/g, (match, i) => (
+        replacedText = reactStringReplace(replacedText, /#([\w-]+)/g, (match, i) => (
             <a
                 href={`/search/projects?q=${match}`}
                 key={match + i}
-            >{match}</a>
+            >#{match}</a>
         ));
     }
 


### PR DESCRIPTION
Fixes an issue where the #search would lead to a search that included the `#` in it. 

@rschamp made this against master as per request? Is this right?

/cc @christanbalch @thisandagain 