### PR TITLE
Capitalize URL

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -88,7 +88,7 @@
     "general.copyLink": "Copy Link",
     "general.report": "Report",
     "general.notAvailableHeadline": "Whoops! Our server is Scratch'ing its head",
-    "general.notAvailableSubtitle": "We couldn't find the page you're looking for. Check to make sure you've typed the url correctly.",
+    "general.notAvailableSubtitle": "We couldn't find the page you're looking for. Check to make sure you've typed the URL correctly.",
     "general.seeAllComments": "See all comments",
 
     "general.all": "All",


### PR DESCRIPTION
### Resolves:
Fixes #2572 
### Changes:
Changes the word from "url" to "URL." (aka capitalization)