### PR TITLE
Disallow comments on unshared projects

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -522,7 +522,7 @@ const PreviewPresentation = ({
                                         <FlexRow className="comments-root-reply">
                                             {projectInfo.comments_allowed ? (
                                                 isLoggedIn ? (
-                                                    <ComposeComment
+                                                    isShared && <ComposeComment
                                                         projectId={projectId}
                                                         onAddComment={onAddComment}
                                                     />
@@ -543,7 +543,7 @@ const PreviewPresentation = ({
                                             <TopLevelComment
                                                 author={comment.author}
                                                 canDelete={canDeleteComments}
-                                                canReply={isLoggedIn && projectInfo.comments_allowed}
+                                                canReply={isLoggedIn && projectInfo.comments_allowed && isShared}
                                                 canReport={isLoggedIn}
                                                 canRestore={canRestoreComments}
                                                 content={comment.content}


### PR DESCRIPTION
### Changes:

check whether project is shared before showing comment form

### Test Coverage:

manual testing:
- [ ] comment form doesn't show up if project is unshared
- [ ] cannot reply to existing comment if project is unshared
- [ ] can still disable comments if unshared

