### PR TITLE
[MASTER] love and favorite proxy, and use x-requested-with header

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -88,7 +88,7 @@
     "general.copyLink": "Copy Link",
     "general.report": "Report",
     "general.notAvailableHeadline": "Whoops! Our server is Scratch'ing its head",
-    "general.notAvailableSubtitle": "We couldn't find the page you're looking for. Check to make sure you've typed the url correctly.",
+    "general.notAvailableSubtitle": "We couldn't find the page you're looking for. Check to make sure you've typed the URL correctly.",
     "general.seeAllComments": "See all comments",
 
     "general.all": "All",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -12,7 +12,7 @@ const urlParams = require('./url-params');
  *       CSRF forgeries (see: https://www.squarefree.com/securitytips/web-developers.html#CSRF)
  *
  * It also takes in other arguments specified in the xhr library spec.
- * 
+ *
  * @param  {object}   opts     optional xhr args (see above)
  * @param  {Function} callback [description]
  */

--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -574,6 +574,51 @@ module.exports.setFavedStatus = (faved, id, username, token) => (dispatch => {
     }
 });
 
+module.exports.setFavedStatusViaProxy = (faved, id, username, token) => (dispatch => {
+    dispatch(module.exports.setFetchStatus('faved', module.exports.Status.FETCHING));
+    if (faved) {
+        api({
+            uri: `/proxy/projects/${id}/favorites/user/${username}`,
+            authentication: token,
+            withCredentials: true,
+            method: 'POST',
+            useCsrf: true,
+            headers: {'X-Requested-With': 'XMLHttpRequest'}
+        }, (err, body, res) => {
+            if (err || res.statusCode !== 200) {
+                dispatch(module.exports.setError(err));
+                return;
+            }
+            if (typeof body === 'undefined') {
+                dispatch(module.exports.setError('Set favorites returned no data'));
+                return;
+            }
+            dispatch(module.exports.setFetchStatus('faved', module.exports.Status.FETCHED));
+            dispatch(module.exports.setFaved(body.userFavorite));
+        });
+    } else {
+        api({
+            uri: `/proxy/projects/${id}/favorites/user/${username}`,
+            authentication: token,
+            withCredentials: true,
+            method: 'DELETE',
+            useCsrf: true,
+            headers: {'X-Requested-With': 'XMLHttpRequest'}
+        }, (err, body, res) => {
+            if (err || res.statusCode !== 200) {
+                dispatch(module.exports.setError(err));
+                return;
+            }
+            if (typeof body === 'undefined') {
+                dispatch(module.exports.setError('Set favorites returned no data'));
+                return;
+            }
+            dispatch(module.exports.setFetchStatus('faved', module.exports.Status.FETCHED));
+            dispatch(module.exports.setFaved(false));
+        });
+    }
+});
+
 module.exports.getLovedStatus = (id, username, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('loved', module.exports.Status.FETCHING));
     api({
@@ -621,6 +666,51 @@ module.exports.setLovedStatus = (loved, id, username, token) => (dispatch => {
             method: 'DELETE'
         }, (err, body) => {
             if (err) {
+                dispatch(module.exports.setError(err));
+                return;
+            }
+            if (typeof body === 'undefined') {
+                dispatch(module.exports.setError('Set loved returned no data'));
+                return;
+            }
+            dispatch(module.exports.setFetchStatus('loved', module.exports.Status.FETCHED));
+            dispatch(module.exports.setLoved(body.userLove));
+        });
+    }
+});
+
+module.exports.setLovedStatusViaProxy = (loved, id, username, token) => (dispatch => {
+    dispatch(module.exports.setFetchStatus('loved', module.exports.Status.FETCHING));
+    if (loved) {
+        api({
+            uri: `/proxy/projects/${id}/loves/user/${username}`,
+            authentication: token,
+            withCredentials: true,
+            method: 'POST',
+            useCsrf: true,
+            headers: {'X-Requested-With': 'XMLHttpRequest'}
+        }, (err, body, res) => {
+            if (err || res.statusCode !== 200) {
+                dispatch(module.exports.setError(err));
+                return;
+            }
+            if (typeof body === 'undefined') {
+                dispatch(module.exports.setError('Set loved returned no data'));
+                return;
+            }
+            dispatch(module.exports.setFetchStatus('loved', module.exports.Status.FETCHED));
+            dispatch(module.exports.setLoved(body.userLove));
+        });
+    } else {
+        api({
+            uri: `/proxy/projects/${id}/loves/user/${username}`,
+            authentication: token,
+            withCredentials: true,
+            method: 'DELETE',
+            useCsrf: true,
+            headers: {'X-Requested-With': 'XMLHttpRequest'}
+        }, (err, body, res) => {
+            if (err || res.statusCode !== 200) {
                 dispatch(module.exports.setError(err));
                 return;
             }

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -379,8 +379,7 @@ const PreviewPresentation = ({
                                                         })
                                                     }}
                                                     validations={{
-                                                        // TODO: actual 5000
-                                                        maxLength: 1000
+                                                        maxLength: 5000
                                                     }}
                                                     value={projectInfo.instructions}
                                                 />
@@ -423,8 +422,7 @@ const PreviewPresentation = ({
                                                         })
                                                     }}
                                                     validations={{
-                                                        // TODO: actual 5000
-                                                        maxLength: 1000
+                                                        maxLength: 5000
                                                     }}
                                                     value={projectInfo.description}
                                                 />
@@ -522,7 +520,7 @@ const PreviewPresentation = ({
                                         <FlexRow className="comments-root-reply">
                                             {projectInfo.comments_allowed ? (
                                                 isLoggedIn ? (
-                                                    <ComposeComment
+                                                    isShared && <ComposeComment
                                                         projectId={projectId}
                                                         onAddComment={onAddComment}
                                                     />
@@ -543,7 +541,7 @@ const PreviewPresentation = ({
                                             <TopLevelComment
                                                 author={comment.author}
                                                 canDelete={canDeleteComments}
-                                                canReply={isLoggedIn && projectInfo.comments_allowed}
+                                                canReply={isLoggedIn && projectInfo.comments_allowed && isShared}
                                                 canReport={isLoggedIn}
                                                 canRestore={canRestoreComments}
                                                 content={comment.content}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -470,7 +470,8 @@ $stage-width: 480px;
 
         &.has-error {
             .validation-message {
-                transform: translate(26rem, 0);
+                top: 100%;
+                right: 0;
             }
         }
 

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -948,7 +948,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(previewActions.getFavedStatus(id, username, token));
     },
     setFavedStatus: (faved, id, username, token) => {
-        dispatch(previewActions.setFavedStatus(faved, id, username, token));
+        dispatch(previewActions.setFavedStatusViaProxy(faved, id, username, token));
     },
     getLovedStatus: (id, username, token) => {
         dispatch(previewActions.getLovedStatus(id, username, token));
@@ -957,7 +957,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(previewActions.logProjectView(id, authorUsername, token));
     },
     setLovedStatus: (loved, id, username, token) => {
-        dispatch(previewActions.setLovedStatus(loved, id, username, token));
+        dispatch(previewActions.setLovedStatusViaProxy(loved, id, username, token));
     },
     shareProject: (id, token) => {
         dispatch(previewActions.shareProject(id, token));


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2614 (together with API proxy addition to address https://github.com/LLK/scratch-api/issues/696 )

### Changes:

* introduce new `setLovedStatusViaProxy` and `setFavedStatusViaProxy` functions to use the new API proxy endpoints
* use `X-Requested-With` header with value `XMLHttpRequest` in these api queries, so that scratchr2 receives the correct headers in the proxy request from -api

