### PR TITLE
Raise z-index of navbar

### DIFF
--- a/src/components/navigation/base/navigation.scss
+++ b/src/components/navigation/base/navigation.scss
@@ -5,7 +5,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 10;
+    z-index: 99;
     border-bottom: 1px solid $active-gray;
 
     box-shadow: 0 0 3px $box-shadow-gray;

--- a/src/components/navigation/base/navigation.scss
+++ b/src/components/navigation/base/navigation.scss
@@ -5,7 +5,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 99;
+    z-index: 10;
     border-bottom: 1px solid $active-gray;
 
     box-shadow: 0 0 3px $box-shadow-gray;

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -274,7 +274,12 @@ const PreviewPresentation = ({
                             </MediaQuery>
                         </FlexRow>
                         <FlexRow className="preview-row">
-                            <div className="guiPlayer">
+                            <div
+                                className={classNames(
+                                    'guiPlayer',
+                                    {fullscreen: isFullScreen}
+                                )}
+                            >
                                 {showCloudDataAlert && (
                                     <FlexRow className="project-info-alert">
                                         <FormattedMessage id="project.cloudDataAlert" />

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -345,6 +345,7 @@ $stage-width: 480px;
         display: inline-block;
         position: relative;
         width: $player-width;
+        z-index: 1;
 
         $alert-bg: rgba(255, 255, 255, .85);
         .project-info-alert {
@@ -356,6 +357,10 @@ $stage-width: 480px;
             padding: .75rem;
             text-align: center;
             font-size: .95rem;
+        }
+
+        &.fullscreen {
+            z-index: 200;
         }
 
         @media #{$small} {

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -604,7 +604,7 @@ class Preview extends React.Component {
                             extensions={this.state.extensions}
                             faved={this.state.clientFaved}
                             favoriteCount={this.state.favoriteCount}
-                            isFullScreen={this.state.isFullScreen}
+                            isFullScreen={this.props.fullScreen}
                             isLoggedIn={this.props.isLoggedIn}
                             isNewScratcher={this.props.isNewScratcher}
                             isRemixing={this.state.isRemixing}


### PR DESCRIPTION
### Resolves:
Resolves LLK/scratch-gui#4230

### Changes:
Changes the z-index to 99.

According to my research, 99 is the best value for this - navbar should be under modal overlay (like reporting), which has `z-index:100;`.

Confirmed working with Firefox 64's inspector

NOTE: It might not work for Account Settings in editor. 