### PR TITLE
Check for recommended browser version

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -103,7 +103,7 @@
     "general.teacherAccounts": "Teacher Accounts",
 
     "general.unsupportedBrowser": "This browser is not supported",
-    "general.unsupportedBrowserDescription": "We're very sorry, but Scratch 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge.",
+    "general.unsupportedBrowserDescription": "We are very sorry, but Scratch does not support this browser version. We recommend updating to the latest version of a supported browser such as Google Chrome, Mozilla Firefox, Microsoft Edge, or Apple Safari.",
     "general.3faq": "To learn more, go to the {faqLink}.",
 
     "footer.discuss": "Discussion Forums",

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -6,10 +6,18 @@ import bowser from 'bowser';
  */
 export default function () {
     if (bowser.msie ||
-        bowser.vivaldi ||
         bowser.opera ||
         bowser.silk) {
         return false;
     }
-    return true;
+    // IMPORTANT: If you change versions here, also change them in gui
+    // minimum versions for recommended browsers
+    const minVersions = {
+        chrome: '63',
+        msedge: '15',
+        firefox: '57',
+        safari: '11'
+    };
+    // strict mode == false so any browser not mentioned in the min Versions is ok
+    return !bowser.isUnsupportedBrowser(minVersions, false);
 }


### PR DESCRIPTION
### Resolves
Many people who were seeing crashes on the site were using very old versions of browsers that we support

### Proposed Changes

_Describe what this Pull Request does_
In addition to excluding certain browsers, it checks the browser version to ensure that it meets the minimum specified in the FAQ.
Also removed Vivaldi from the rejected list to match gui

### Testing

- [ ] any version of IE, Opera, Silk should be unsupported
- [ ] Chrome:
  - [ ] version 63+ should work
  - [ ] versions <63 should be unsupported
- [ ] Edge:
  - [ ] version 15+ should work
  - [ ] versions <15 should be unsupported
- [ ] Firefox:
  - [ ] version 57+ should work
  - [ ] versions <57 should be unsupported
- [ ] Safari:
  - [ ] version 11+ should work
  - [ ] versions <11 should be unsupported
- [ ] Vivaldi is not officially supported, but it's not excluded, so any version should load the gui not the unsupported modal. 

