### PR TITLE
Disable global error handling for sentry

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -38,7 +38,10 @@ const localStorageAvailable = 'localStorage' in window && window.localStorage !=
 const Sentry = require('@sentry/browser');
 if (`${process.env.SENTRY_DSN}` !== '') {
     Sentry.init({
-        dsn: `${process.env.SENTRY_DSN}`
+        dsn: `${process.env.SENTRY_DSN}`,
+        integrations: integrations =>
+            // Do not collect global onerror, only collect specifically from React error boundaries.
+            integrations.filter(i => i.name !== 'GlobalHandlers')
     });
     window.Sentry = Sentry; // Allow GUI access to Sentry via window
 }


### PR DESCRIPTION
Following the advice at the bottom of https://github.com/getsentry/sentry-javascript/pull/1050

/cc @rschamp it isn't as easy as I was hoping...