### PR TITLE
Revert "Bump scratch-gui to bring in renderer and audio fixes"

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190108191302",
+    "scratch-gui": "0.1.0-prerelease.20190108140207",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Reverts LLK/scratch-www#2636

Reverting to pull out the renderer update. Will re-update with a new version of GUI when ready