### PR TITLE
Revise unsupported browser

### DIFF
--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -5,11 +5,5 @@ import bowser from 'bowser';
  * @returns {boolean} False if the platform is definitely not supported.
  */
 export default function () {
-    if (bowser.msie ||
-        bowser.vivaldi ||
-        bowser.opera ||
-        bowser.silk) {
-        return false;
-    }
-    return true;
+    return !bowser.msie;
 }


### PR DESCRIPTION
Only reject IE, other gui errors should get handled by error boundary in gui.
