### PR TITLE
[MASTER] Deploy sentry fix to stop noisy errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190109195039",
+    "scratch-gui": "0.1.0-prerelease.20190109203727",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190108222744",
+    "scratch-gui": "0.1.0-prerelease.20190109195039",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -39,11 +39,11 @@ const Sentry = require('@sentry/browser');
 if (`${process.env.SENTRY_DSN}` !== '') {
     Sentry.init({
         dsn: `${process.env.SENTRY_DSN}`,
-        integrations: integrations =>
-            // Do not collect global onerror, only collect specifically from React error boundaries.
-            integrations.filter(i => i.name !== 'GlobalHandlers')
+        // Do not collect global onerror, only collect specifically from React error boundaries.
+        // TryCatch plugin also includes errors from setTimeouts (i.e. the VM)
+        integrations: integrations => integrations.filter(i =>
+            !(i.name === 'GlobalHandlers' || i.name === 'TryCatch'))
     });
-    window.onerror = () => {}; // Doesn't look like global handlers filtering works, just stub window onerror
     window.Sentry = Sentry; // Allow GUI access to Sentry via window
 }
 

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -43,6 +43,7 @@ if (`${process.env.SENTRY_DSN}` !== '') {
             // Do not collect global onerror, only collect specifically from React error boundaries.
             integrations.filter(i => i.name !== 'GlobalHandlers')
     });
+    window.onerror = () => {}; // Doesn't look like global handlers filtering works, just stub window onerror
     window.Sentry = Sentry; // Allow GUI access to Sentry via window
 }
 


### PR DESCRIPTION
Override window.onerror to prevent sending so many errors. I will test this when it builds on staging, but I wanted to have the PR ready!