### PR TITLE
Prevent uncaught errors from going to sentry

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -39,11 +39,11 @@ const Sentry = require('@sentry/browser');
 if (`${process.env.SENTRY_DSN}` !== '') {
     Sentry.init({
         dsn: `${process.env.SENTRY_DSN}`,
-        integrations: integrations =>
-            // Do not collect global onerror, only collect specifically from React error boundaries.
-            integrations.filter(i => i.name !== 'GlobalHandlers')
+        // Do not collect global onerror, only collect specifically from React error boundaries.
+        // TryCatch plugin also includes errors from setTimeouts (i.e. the VM)
+        integrations: integrations => integrations.filter(i =>
+            !(i.name === 'GlobalHandlers' || i.name === 'TryCatch'))
     });
-    window.onerror = () => {}; // Doesn't look like global handlers filtering works, just stub window onerror
     window.Sentry = Sentry; // Allow GUI access to Sentry via window
 }
 


### PR DESCRIPTION
For real this time. Just needed to figure out the right plugins to filter. TryCatch plugin is the one that reports errors from setTimeouts, which the VM executes code in.

Remove the previous window.onerror kludge, it was not working and prevented errors from reaching the console.

Tested locally by providing the staging DSN for Sentry

/cc @rschamp 