### PR TITLE
Make internal URL clickable

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -393,7 +393,7 @@ const PreviewPresentation = ({
                                                 {decorateText(projectInfo.instructions, {
                                                     usernames: true,
                                                     hashtags: true,
-                                                    scratchLinks: false
+                                                    scratchLinks: true
                                                 })}
                                             </div>
                                         }
@@ -436,7 +436,7 @@ const PreviewPresentation = ({
                                                 {decorateText(projectInfo.description, {
                                                     usernames: true,
                                                     hashtags: true,
-                                                    scratchLinks: false
+                                                    scratchLinks: true
                                                 })}
                                             </div>
                                         }


### PR DESCRIPTION
### Resolves:
Resolves #2662 

### Changes:
Makes the scratch.mit.edu links clickable.