### PR TITLE
Bump GUI for midweek deploy testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190111141703",
+    "scratch-gui": "0.1.0-prerelease.20190115175637",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190115175637",
+    "scratch-gui": "0.1.0-prerelease.20190115212538",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Roughly speaking:

Fix for speech bubble in wrong spot/video motion wrong for vector sprites
Fix for paint editor crashing from eyedropper/working eyedropper on touch 
Fix for variables becoming local/executing before ready 
Loading screen should appear for embed view 
Empty sound BSOD fixes 
Recording a sound BSOD fixes 
Show link to cloud variable log on projects with cloud variables 
Fix allowing you to scroll long context menus in the blocks 
