### PR TITLE
Deploy sound reordering fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190117144636",
+    "scratch-gui": "0.1.0-prerelease.20190117204552",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190117204552",
+    "scratch-gui": "0.1.0-prerelease.20190118203059",
     "scratch-l10n": "latest",
     "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",

--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -61,19 +61,30 @@ const Credits = () => (
                             className="logo"
                             key={`logo-${index}`}
                         >
-                            <a href={supporter.logoDestination}>
+                            {supporter.logoDestination ? (<a href={supporter.logoDestination}>
                                 {supporter.logoSrc ? (
                                     <img
                                         alt=""
                                         src={supporter.logoSrc}
                                         width={supporter.width}
                                     />
-                                ) :
+                                ) : (
                                     <div className="text-logo">
                                         {supporter.textLogo}
                                     </div>
-                                }
-                            </a>
+                                )}
+                            </a>) : (supporter.logoSrc ? (
+                                <img
+                                    alt=""
+                                    src={supporter.logoSrc}
+                                    width={supporter.width}
+                                />
+                            ) : (
+                                <div className="text-logo">
+                                    {supporter.textLogo}
+                                </div>
+                            ))
+                            }
                         </span>
                     ))}
                 </div>


### PR DESCRIPTION
Fixes a bug where reordering a sound could cause a crash.

Also brings in the change to the credits page where logos without links don't link to nowhere.

