### PR TITLE
LEGO branding updates

### DIFF
--- a/src/lib/extensions.js
+++ b/src/lib/extensions.js
@@ -25,7 +25,7 @@ const EXTENSION_INFO = {
         icon: 'extension-translate.svg'
     },
     wedo2: {
-        name: 'LEGO WeDo 2.0',
+        name: 'WeDo 2.0',
         icon: 'extension-wedo2.svg',
         hasStatus: true
     },

--- a/src/routes.json
+++ b/src/routes.json
@@ -272,7 +272,7 @@
         "pattern": "^/wedo/?$",
         "routeAlias": "/wedo/?$",
         "view": "wedo2/wedo2",
-        "title": "LEGO WeDo 2.0"
+        "title": "WeDo 2.0"
     },
     {
         "name": "wedo2-legacy",

--- a/src/views/wedo2/l10n.json
+++ b/src/views/wedo2/l10n.json
@@ -29,7 +29,7 @@
     "wedo2.updateLinkText": "Make sure you have installed the latest version of Scratch Link.",
     "wedo2.legacyInfoTitle": "Using Scratch 2.0?",
     "wedo2.legacyInfoText": "Visit our page about {wedoLegacyLink}.",
-    "wedo2.legacyLinkText": "using LEGO WeDo with Scratch 2.0",
+    "wedo2.legacyLinkText": "using WeDo with Scratch 2.0",
     "wedo2.imgAltWeDoIllustration": "An illustration of a WeDo2 featuring a tilt sensor and a motor.",
     "wedo2.imgAltStarter1Pet": "A Scratch project with a dog and a taco.",
     "wedo2.imgAltStarter2Fox": "A Scratch project with a fox moving back and forth.",

--- a/src/views/wedo2/l10n.json
+++ b/src/views/wedo2/l10n.json
@@ -1,5 +1,5 @@
 {
-    "wedo2.headerText": "{wedo2Link} is an introductory invention kit you can use to build interactive robots and other creations. You can snap together Scratch programming blocks to interact with your LEGO WeDo creations and add animations and sounds.",
+    "wedo2.headerText": "{wedo2Link} is an introductory invention kit you can use to build interactive robots and other creations. You can snap together Scratch programming blocks to interact with your WeDo 2.0 creations and add animations and sounds.",
     "wedo2.gettingStarted": "Getting Started",
     "wedo2.connectingWedo2": "Connecting WeDo 2.0 to Scratch",
     "wedo2.useScratch3": "Use the {scratch3Link} editor.",

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -34,7 +34,7 @@ class Wedo2 extends ExtensionLanding {
                             <h1><img
                                 alt=""
                                 src="/images/wedo2/wedo2.svg"
-                            />LEGO WeDo 2.0</h1>
+                            />LEGO Education WeDo 2.0</h1>
                             <FormattedMessage
                                 id="wedo2.headerText"
                                 values={{


### PR DESCRIPTION
Update the wording for the WeDo 2.0 extension landing page, so that it is always referred to as either "LEGO Education WeDo 2.0" or "WeDo 2.0" (and _not_ "LEGO WeDo 2.0").

- Page title (shown on the tab) is "Scratch - WeDo 2.0"
- Header title is "LEGO Education WeDo 2.0"
- Wording in the header text includes "your WeDo 2.0 creations"
- Link in the troubleshooting area to the WeDo legacy page says "using WeDo with Scratch 2.0." (this is a special case, because a) the page includes info about both WeDo 2.0 and WeDo 1.0 and b) repeating "2.0" twice in the sentence looks even more confusing).

Also update the extension chip to read "WeDo 2.0"