### PR TITLE
Add missing resource to .tx/config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -104,6 +104,12 @@ source_file = src/views/download/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
+[scratch-website.download-scratch2-l10njson]
+file_filter = localizations/download/scratch2/<lang>.json
+source_file = src/views/download/scratch2/l10n.json
+source_lang = en
+type = KEYVALUEJSON
+
 [scratch-website.camp-l10njson]
 file_filter = localizations/camp/<lang>.json
 source_file = src/views/camp/l10n.json

--- a/src/routes.json
+++ b/src/routes.json
@@ -205,7 +205,7 @@
         "title": "Scratch 1.4"
     },
     {
-        "name": "scratch2",
+        "name": "download-scratch2",
         "pattern": "^/download/scratch2/?(\\?.*)?$",
         "routeAlias": "/download/scratch2",
         "view": "download/scratch2/download",


### PR DESCRIPTION
The `download/scratch2` l10n file was missing from the config file, along with the new ideas page.

Also, the `name` field in the routes json needs to match the resource name. So changed the `download-scratch2` route name to match the l10n name.

This is why you would get lots of things missing when making translations. The resources still need to be included in scratchr2_translations for the 'make' step to work properly.