### PR TITLE
Add Community Moderator listing

### DIFF
--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -26,19 +26,16 @@ const Jobs = () => (
         <div className="bottom">
             <div className="inner">
                 <h3><FormattedMessage id="jobs.openings" /></h3>
-                <FormattedMessage id="jobs.nojobs" />
-                {/*
                 <ul>
                     <li>
-                        <a href="https://www.media.mit.edu/about/job-opportunities/full-stack-engineer-lifelong-kindergarten/">
-                            Full Stack Engineer
+                        <a href="https://scratch.mit.edu/jobs/moderator">
+                            Community Moderator
                         </a>
                         <span>
-                            MIT Media Lab, Cambridge, MA
+                            Remote
                         </span>
                     </li>
                 </ul>
-                */}
             </div>
         </div>
     </div>

--- a/src/views/jobs/jobs.jsx
+++ b/src/views/jobs/jobs.jsx
@@ -26,6 +26,7 @@ const Jobs = () => (
         <div className="bottom">
             <div className="inner">
                 <h3><FormattedMessage id="jobs.openings" /></h3>
+                {/* <FormattedMessage id="jobs.nojobs" /> */}
                 <ul>
                     <li>
                         <a href="https://scratch.mit.edu/jobs/moderator">


### PR DESCRIPTION
### Resolves:

Resolves #2625 

### Changes:

Adds the Community Moderator job listing, and removes the message about there being no jobs available.

I know it's no longer help-wanted, but I'm sure you wouldn't mind an outside pull anyway, right?