### PR TITLE
Add route for `/tutorials` shortcut

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -408,6 +408,11 @@
         "redirect": "/ideas"
     },
     {
+        "name": "all-tutorials-redirect",
+        "pattern": "^/tutorials/?$",
+        "redirect": "/projects/editor/?tutorial=all"
+    },
+    {
         "name": "create-tutorial-redirect",
         "pattern": "^/create/?$",
         "redirect": "/projects/editor/?tutorial=getStarted"


### PR DESCRIPTION
### Resolves:

Fixes #2271 

### Changes:

Adds a route for `/tutorials` or `/tutorials/` that redirects to `/projects/editor/?tutorial=all`

### Test Coverage:

- [ ] `/tutorials/` opens the editor showing the tutorials library
- [ ] `/tutorials` opens the editor showing the tutorials library
