### PR TITLE
Make www modal z-index consitent with gui

### DIFF
--- a/src/components/modal/base/modal.scss
+++ b/src/components/modal/base/modal.scss
@@ -45,7 +45,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 100;
+    z-index: 510;
     background-color: transparentize($ui-blue, .3);
 }
 


### PR DESCRIPTION
### Resolves:
Fixes https://github.com/LLK/scratch-gui/issues/4046 

I think this also fixes the modal part of https://github.com/LLK/scratch-www/issues/2157 (It appears the loading screen and monitors were fixed previously)

### Changes:

The gui uses z-indices up to 500 for things that should be covered by a modal and sets the modal to 510. www should match gui.

Modals were already above everything with a z-index on www except for the gui-player in fullscreen mode. I created a spreadsheet that documents [gui and www z-indices](https://docs.google.com/spreadsheets/d/169cRxUOGXCfi716BDOLQLrhmP9ei-A-iUQWEK6rSw1A/edit?usp=sharing)

### Test Coverage:
Since this is change to the base modal, we should check that modals are still fine overall.
- registration modal (on any page including project page)
- report modal
- delete comment modal
- add to studio (on project page)
- iframe modal (things like embedded videos)
- activity modals on the ideas page

