### PR TITLE
reenable commenting on mobile, which was disabled in #2512

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -38,6 +38,7 @@
     .compose-bottom-row {
         width: 100%;
         justify-content: space-between;
+        flex-direction: row;
 
         .compose-post {
             margin-right: .5rem;

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -1,5 +1,4 @@
 @import "../../../colors";
-@import "../../../frameless";
 
 .compose-comment {
     margin-left: .5rem;
@@ -229,14 +228,6 @@
                     content: "";
                 }
             }
-
-            /* hide comment input on tablets and mobile */
-            @media #{$medium-and-smaller} {
-                .comment-reply {
-                    display: none;
-                }
-            }
-
         }
     }
 
@@ -263,13 +254,6 @@
 
 .comments-root-reply {
     margin-bottom: 1.5rem;
-}
-
-/* hide comment input on tablets and mobile */
-@media #{$medium-and-smaller} {
-    .comments-root-reply {
-        display: none;
-    }
 }
 
 .comment-reply-row {


### PR DESCRIPTION
https://github.com/LLK/scratch-www/pull/2512 had the effect of disabled commenting on mobile, per a decision from december that was not implemented then in the interests of keeping the build stable for launch.

On further discussion with designers, we're not going to remove comment creation on mobile at this time.