### PR TITLE
Change video id to one without autoplay

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -26,7 +26,7 @@ const About = () => (
             <div className="video-container">
                 <Video
                     className="about-scratch-video"
-                    videoId="joal01i8b1"
+                    videoId="sucupcznsp"
                 />
             </div>
         </div>


### PR DESCRIPTION
We decided that the version of the Scratch Video on the About page should not autoplay.