### PR TITLE
Wrap ‘need help?’ link when translation is too long

### DIFF
--- a/src/components/login/login.jsx
+++ b/src/components/login/login.jsx
@@ -7,6 +7,7 @@ const Form = require('../forms/form.jsx');
 const Input = require('../forms/input.jsx');
 const Button = require('../forms/button.jsx');
 const Spinner = require('../spinner/spinner.jsx');
+const FlexRow = require('../flex-row/flex-row.jsx');
 
 require('./login.scss');
 
@@ -59,34 +60,35 @@ class Login extends React.Component {
                         name="password"
                         type="password"
                     />
-                    {this.state.waiting ? [
-                        <Button
-                            className="submit-button white"
-                            disabled="disabled"
-                            key="submitButton"
-                            type="submit"
+                    <FlexRow className="submit-row">
+                        {this.state.waiting ? [
+                            <Button
+                                className="submit-button white"
+                                disabled="disabled"
+                                key="submitButton"
+                                type="submit"
+                            >
+                                <Spinner
+                                    className="spinner"
+                                    color="blue"
+                                />
+                            </Button>
+                        ] : [
+                            <Button
+                                className="submit-button white"
+                                key="submitButton"
+                                type="submit"
+                            >
+                                <FormattedMessage id="general.signIn" />
+                            </Button>
+                        ]}
+                        <a
+                            href="/accounts/password_reset/"
+                            key="passwordResetLink"
                         >
-                            <Spinner
-                                className="spinner"
-                                color="blue"
-                            />
-                        </Button>
-                    ] : [
-                        <Button
-                            className="submit-button white"
-                            key="submitButton"
-                            type="submit"
-                        >
-                            <FormattedMessage id="general.signIn" />
-                        </Button>
-                    ]}
-                    <a
-                        className="right"
-                        href="/accounts/password_reset/"
-                        key="passwordResetLink"
-                    >
-                        <FormattedMessage id="login.needHelp" />
-                    </a>
+                            <FormattedMessage id="login.needHelp" />
+                        </a>
+                    </FlexRow>
                     {error}
                 </Form>
             </div>

--- a/src/components/login/login.scss
+++ b/src/components/login/login.scss
@@ -28,14 +28,15 @@
         font-weight: bold;
     }
 
-    .right {
-        float: right;
-    }
-
     .spinner {
         margin: 0 .8rem;
         width: 1rem;
         vertical-align: middle;
+    }
+    
+    .submit-row {
+        justify-content: space-between;
+        flex-direction: row; // override 'column' layout at small widths
     }
 
     .submit-button {
@@ -43,7 +44,7 @@
     }
 
     a {
-        margin-top: 15px;
+        margin: auto 0;
         color: $ui-white;
 
         &:link,


### PR DESCRIPTION
### Resolves:

Fixes #2309 

### Changes:

The `need help` link for resetting a password was awkwardly positioned when the translation was too bit to fit beside the `submit` button. 

Refactored the submit row of the login component to use Flex Row instead of `float: right` for the `need help` link.  The bulk of the changes are white space, so remember to ignore whitespace for review. The link wraps so that it is under the button if it doesn't fit next to it.

### Test Coverage:
A selection of languages:
<img width="251" alt="screen shot 2019-02-01 at 2 20 43 pm" src="https://user-images.githubusercontent.com/399209/52125743-ba26ce80-262d-11e9-87a2-5cd5abeb9665.png">
<img width="250" alt="screen shot 2019-02-01 at 2 14 33 pm" src="https://user-images.githubusercontent.com/399209/52125745-ba26ce80-262d-11e9-883e-11400ba0abee.png">
<img width="248" alt="screen shot 2019-02-01 at 2 13 45 pm" src="https://user-images.githubusercontent.com/399209/52125746-ba26ce80-262d-11e9-80bb-b64815e702ae.png">
<img width="250" alt="screen shot 2019-02-01 at 2 13 19 pm" src="https://user-images.githubusercontent.com/399209/52125748-ba26ce80-262d-11e9-9eca-ef06a6d100cf.png">
<img width="249" alt="screen shot 2019-02-01 at 2 12 54 pm" src="https://user-images.githubusercontent.com/399209/52125750-babf6500-262d-11e9-9b1d-95c4906745ca.png">





