### PR TITLE
Prevent seeing /projects/0/fullscreen URL

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -410,6 +410,9 @@ class Preview extends React.Component {
         this.setState({isProjectLoaded: true});
     }
     pushHistory (push) {
+        // Do not push history for projects without a real ID
+        if (this.state.projectId === '0') return;
+
         // update URI to match mode
         const idPath = this.state.projectId ? `${this.state.projectId}/` : '';
         let modePath = '';


### PR DESCRIPTION

### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Resolves https://github.com/LLK/scratch-gui/issues/4212

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

This fixes the issue where you could go from `/projects/editor` => `/projects/0/fullscreen` by entering fullscreen mode on a new unsaved project.

Since there is no such route as `/projects/fullscreen`, just abandon the history management for projects that have ID=0 (i.e. not saved on the server)

### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._

Tested manually by:
1. Be logged out
2. Click "create" on the homepage to create a project (i.e. be on /projects/editor)
3. Click the "fullscreen" button, note the URL has not changed.
4. Try this while logged in and see that you _do_ see the /fullscreen if your project has a real ID.