### PR TITLE
show autocensored message if API indicates project was autocensored

### DIFF
--- a/src/views/preview/censored-message.jsx
+++ b/src/views/preview/censored-message.jsx
@@ -15,29 +15,42 @@ const communityGuidelinesLink = (
     </a>
 );
 
-const CensoredMessage = ({messageHTML, reshareable}) => (
+const CensoredMessage = ({censoredByCommunity, messageHTML, reshareable}) => (
     <React.Fragment>
         {/* if message HTML is provided, set innerHTML with it */}
-        {messageHTML ? embedCensorMessage(messageHTML) : (
-            // if message is blank or missing, use default
-            <React.Fragment>
-                <FormattedMessage id="project.defaultCensoredMessage" />
-                <br />
-                <br />
-                {reshareable ? (
+        {messageHTML ? embedCensorMessage(messageHTML) :
+            (censoredByCommunity ? (
+                <React.Fragment>
+                    <FormattedMessage id="project.communityCensoredMessage" />
+                    <br />
+                    <br />
                     <FormattedMessage
-                        id="project.tempCensoredMessage"
+                        id="project.willReviewCensoredMessage"
                         values={{communityGuidelinesLink: communityGuidelinesLink}}
                     />
-                ) : (
-                    <FormattedMessage id="project.permCensoredMessage" />
-                )}
-            </React.Fragment>
-        )}
+                </React.Fragment>
+            ) : (
+                // if message is blank or missing, use default
+                <React.Fragment>
+                    <FormattedMessage id="project.defaultCensoredMessage" />
+                    <br />
+                    <br />
+                    {reshareable ? (
+                        <FormattedMessage
+                            id="project.tempCensoredMessage"
+                            values={{communityGuidelinesLink: communityGuidelinesLink}}
+                        />
+                    ) : (
+                        <FormattedMessage id="project.permCensoredMessage" />
+                    )}
+                </React.Fragment>
+            ))
+        }
     </React.Fragment>
 );
 
 CensoredMessage.propTypes = {
+    censoredByCommunity: PropTypes.bool,
     messageHTML: PropTypes.string,
     reshareable: PropTypes.bool
 };

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -144,6 +144,7 @@ const PreviewPresentation = ({
     } else if (visibilityInfo.censored) {
         const censoredMessage = (
             <CensoredMessage
+                censoredByCommunity={visibilityInfo.censoredByCommunity}
                 messageHTML={visibilityInfo.message}
                 reshareable={visibilityInfo.reshareable}
             />
@@ -730,6 +731,8 @@ PreviewPresentation.propTypes = {
     userOwnsProject: PropTypes.bool,
     visibilityInfo: PropTypes.shape({
         censored: PropTypes.bool,
+        censoredByAdmin: PropTypes.bool,
+        censoredByCommunity: PropTypes.bool,
         message: PropTypes.string,
         deleted: PropTypes.bool,
         reshareable: PropTypes.bool

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -829,6 +829,8 @@ Preview.propTypes = {
     userPresent: PropTypes.bool,
     visibilityInfo: PropTypes.shape({
         censored: PropTypes.bool,
+        censoredByAdmin: PropTypes.bool,
+        censoredByCommunity: PropTypes.bool,
         message: PropTypes.string,
         deleted: PropTypes.bool,
         reshareable: PropTypes.bool


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-api/issues/724 , by implementing client side handling of the API changes in https://github.com/LLK/scratch-api/pull/722 .

### Changes:

* Changes the `PropTypes` spec of `visibilityInfo` to include two new fields: `censoredByAdmin` (currently unused) and `censoredByCommunity`.
* `preview/presentation.jsx` passes `censoredByCommunity` to the `CensoredMessage` component
* `CensoredMessage` component shows distinct, autocensored-specific message if no manual message has been included, and `censoredByCommunity` is true

### Test Coverage:

None