### PR TITLE
Get thumbnails from the project for reporting

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -954,9 +954,8 @@ module.exports.shareProject = (projectId, token) => (dispatch => {
 
 module.exports.reportProject = (id, jsonData, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('report', module.exports.Status.FETCHING));
-    // scratchr2 will fail if no thumbnail base64 string provided. We don't yet have
-    // a way to get the actual project thumbnail in www/gui, so for now just submit
-    // a minimal base64 png string.
+    // scratchr2 will fail if no thumbnail base64 string provided. If there is not one
+    // included for any reason, include this minimal blank image.
     defaults(jsonData, {
         thumbnail: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC' +
             '0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -106,6 +106,7 @@ const PreviewPresentation = ({
     onRestoreComment,
     onSeeAllComments,
     onSeeInside,
+    onSetProjectThumbnailer,
     onShare,
     onToggleComments,
     onToggleStudio,
@@ -341,6 +342,7 @@ const PreviewPresentation = ({
                                     onGreenFlag={onGreenFlag}
                                     onProjectLoaded={onProjectLoaded}
                                     onRemixing={onRemixing}
+                                    onSetProjectThumbnailer={onSetProjectThumbnailer}
                                     onUpdateProjectId={onUpdateProjectId}
                                     onUpdateProjectThumbnail={onUpdateProjectThumbnail}
                                 />
@@ -709,6 +711,7 @@ PreviewPresentation.propTypes = {
     onRestoreComment: PropTypes.func,
     onSeeAllComments: PropTypes.func,
     onSeeInside: PropTypes.func,
+    onSetProjectThumbnailer: PropTypes.func,
     onShare: PropTypes.func,
     onToggleComments: PropTypes.func,
     onToggleStudio: PropTypes.func,

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -79,6 +79,7 @@ class Preview extends React.Component {
             'handleRemix',
             'handleSeeAllComments',
             'handleSeeInside',
+            'handleSetProjectThumbnailer',
             'handleShare',
             'handleUpdateProjectId',
             'handleUpdateProjectTitle',
@@ -381,7 +382,18 @@ class Preview extends React.Component {
         this.setState({addToStudioOpen: false});
     }
     handleReportSubmit (formData) {
-        this.props.reportProject(this.state.projectId, formData, this.props.user.token);
+        const submit = data => this.props.reportProject(this.state.projectId, data, this.props.user.token);
+        if (this.getProjectThumbnail) {
+            this.getProjectThumbnail(thumbnail => {
+                const data = Object.assign({}, formData, {thumbnail});
+                submit(data);
+            });
+        } else {
+            submit(formData);
+        }
+    }
+    handleSetProjectThumbnailer (fn) {
+        this.getProjectThumbnail = fn;
     }
     handleGreenFlag () {
         if (!this.state.greenFlagRecorded) {
@@ -690,6 +702,7 @@ class Preview extends React.Component {
                             onRestoreComment={this.handleRestoreComment}
                             onSeeAllComments={this.handleSeeAllComments}
                             onSeeInside={this.handleSeeInside}
+                            onSetProjectThumbnailer={this.handleSetProjectThumbnailer}
                             onShare={this.handleShare}
                             onToggleComments={this.handleToggleComments}
                             onToggleStudio={this.handleToggleStudio}


### PR DESCRIPTION
@rschamp this is the WWW side of projects not be reported with their snapshot.

Depends on https://github.com/LLK/scratch-gui/pull/4567

This PR allows WWW to include a thumbnail snapshot of the stage when reporting a project.