### PR TITLE
Add support for "Recent" on search

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -18,7 +18,7 @@ const Tabs = require('../../components/tabs/tabs.jsx');
 const Page = require('../../components/page/www/page.jsx');
 const render = require('../../lib/render.jsx');
 
-const ACCEPTABLE_MODES = ['trending', 'popular'];
+const ACCEPTABLE_MODES = ['trending', 'popular', 'recent'];
 
 require('./search.scss');
 


### PR DESCRIPTION
The Scratch API supports 3 modes, but in the search page there are only 2. This adds support for the missing one (recent).

### Changes:
Add the "Recent" option to the search page.

### Test Coverage:
I didn't