### PR TITLE
corrected mail list form; links use _blank; redirect conference url; logo links to main site

### DIFF
--- a/src/components/navigation/conference/2019/navigation.jsx
+++ b/src/components/navigation/conference/2019/navigation.jsx
@@ -12,13 +12,20 @@ const Navigation = () => (
             <li className="li-left mod-logo mod-2019">
                 <a
                     className="logo-a"
-                    href="/conference"
+                    href="https://scratch.mit.edu"
                 >
                     <img
                         alt="Scratch Logo"
                         className="logo-a-image"
                         src="/images/logo_sm.png"
                     />
+                </a>
+            </li>
+            <li className="li-left mod-logo mod-2019">
+                <a
+                    className="logo-a"
+                    href="/conference/2019"
+                >
                     <p className="logo-a-title">
                         <FormattedMessage id="general.conferences" />
                     </p>

--- a/src/routes.json
+++ b/src/routes.json
@@ -24,9 +24,7 @@
         "name": "conference-index",
         "pattern": "^/conference/?(\\?.*)?$",
         "routeAlias": "/conference(?!/201[4-9])",
-        "view": "conference/2019/index/index",
-        "title": "Scratch Conference",
-        "viewportWidth": "device-width"
+        "redirect": "/conference/2019"
     },
     {
         "name": "conference-index-2017",
@@ -77,7 +75,7 @@
         "pattern": "^/conference/2019/?$",
         "routeAlias": "/conference(?!/201[4-9])",
         "view": "conference/2019/index/index",
-        "title": "Scratch Conference",
+        "title": "Scratch Conferences",
         "viewportWidth": "device-width"
     },
     {

--- a/src/views/conference/2019/index/index.jsx
+++ b/src/views/conference/2019/index/index.jsx
@@ -135,6 +135,8 @@ const ConferenceSplash = () => (
                 <a
                     className="button mod-2019-conf mod-2019-conf-website-button"
                     href="http://www.scratchalsur.org"
+                    rel="noopener noreferrer"
+                    target="_blank"
                 >
                     <FormattedMessage id="conference-2019.website" />
                 </a>
@@ -230,6 +232,8 @@ const ConferenceSplash = () => (
                 <a
                     className="button mod-2019-conf mod-2019-conf-website-button"
                     href="https://www.scratchafrica.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
                 >
                     <FormattedMessage id="conference-2019.website" />
                 </a>
@@ -324,6 +328,8 @@ const ConferenceSplash = () => (
                 <a
                     className="button mod-2019-conf mod-2019-conf-website-button"
                     href="https://www.raspberrypi.org/blog/announcing-scratch-conference-europe-2019/"
+                    rel="noopener noreferrer"
+                    target="_blank"
                 >
                     <FormattedMessage id="conference-2019.website" />
                 </a>
@@ -340,7 +346,9 @@ const ConferenceSplash = () => (
             </h3>
             <a
                 className="button mod-2019-conf mod-2019-conf-maillist-button"
-                href="https://docs.google.com/document/d/1M_LJqOjAxxYFm3j-D8WbvFtWhZJgPCbZ5aNGSA2KZyc/edit?ts=5c65f2c4#"
+                href="http://eepurl.com/cws7_f"
+                rel="noopener noreferrer"
+                target="_blank"
             >
                 <FormattedMessage id="conference-2019.joinMailingListButtonText" />
             </a>

--- a/src/views/conference/2019/index/index.jsx
+++ b/src/views/conference/2019/index/index.jsx
@@ -346,7 +346,7 @@ const ConferenceSplash = () => (
             </h3>
             <a
                 className="button mod-2019-conf mod-2019-conf-maillist-button"
-                href="http://eepurl.com/cws7_f"
+                href="https://us9.list-manage.com/subscribe?u=96e741c12c99f46f1f3e95e09&id=149bd1a4c2"
                 rel="noopener noreferrer"
                 target="_blank"
             >


### PR DESCRIPTION
Four small fixes to 2019 conference page:

1. mailing list link links to correct form
2. "visit website" buttons open in new tab/window
3. /conference should redirect to conference/2019, not just show same content
4. main Scratch logo should link back to regular site