### PR TITLE
Update the integration test for the Scratch Conference link in the fo…

### DIFF
--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -281,9 +281,9 @@ tap.test('clickScratchDayLink', options, t => {
 // SCRATCH CONFERENCE
 tap.test('clickScratchConferenceLink', options, t => {
     const linkText = 'Scratch Conference';
-    const expectedHref = '/conference/2019';
+    const expectedHref = '/conference/20';
     clickFooterLinks(linkText).then(url => {
-        t.equal(url.substr(-expectedHref.length), expectedHref);
+        t.match(url.substr(-(expectedHref.length + 2)), expectedHref);
         t.end();
     });
 });

--- a/test/integration/smoke-testing/test_footer_links.js
+++ b/test/integration/smoke-testing/test_footer_links.js
@@ -281,7 +281,7 @@ tap.test('clickScratchDayLink', options, t => {
 // SCRATCH CONFERENCE
 tap.test('clickScratchConferenceLink', options, t => {
     const linkText = 'Scratch Conference';
-    const expectedHref = '/conference';
+    const expectedHref = '/conference/2019';
     clickFooterLinks(linkText).then(url => {
         t.equal(url.substr(-expectedHref.length), expectedHref);
         t.end();


### PR DESCRIPTION
### Resolves:

The integration tests were not passing because we changed the Scratch Conference link in the footer to redirect to /conference/2019

### Changes:

The test now looks for the correct URL
