### PR TITLE
Copy the gui localized image chunks to static

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,6 +145,10 @@ module.exports = {
             to: 'static/blocks-media'
         }]),
         new CopyWebpackPlugin([{
+            from: 'node_modules/scratch-gui/dist/chunks',
+            to: 'static/chunks'
+        }]),
+        new CopyWebpackPlugin([{
             from: 'node_modules/scratch-gui/dist/extension-worker.js'
         }]),
         new CopyWebpackPlugin([{


### PR DESCRIPTION
Support for dynamically loading translated images.

### Resolves:

Fixes https://github.com/LLK/scratch-gui/issues/3632 

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._
Copy over dynamic chunks for gui so that webpack can load the files.

