### PR TITLE
change "studios for project" API request to include owner & token, determine endpoint using admin status

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -765,10 +765,13 @@ module.exports.getRemixes = id => (dispatch => {
 
 module.exports.getProjectStudios = (id, username, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
-    api({
-        uri: `/users/${username}/projects/${id}/studios`,
-        authentication: token
-    }, (err, body, res) => {
+    const apiOpts = {
+        uri: `/users/${username}/projects/${id}/studios`
+    };
+    if (token) {
+        apiOpts.authentication = token;
+    }
+    api(apiOpts, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));
             dispatch(module.exports.setError(err));

--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -763,15 +763,12 @@ module.exports.getRemixes = id => (dispatch => {
     });
 });
 
-module.exports.getProjectStudios = (id, username, token) => (dispatch => {
+module.exports.getProjectStudios = (id, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
-    const apiOpts = {
-        uri: `/users/${username}/projects/${id}/studios`
-    };
-    if (token) {
-        apiOpts.authentication = token;
-    }
-    api(apiOpts, (err, body, res) => {
+    api({
+        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/studios`,
+        authentication: token
+    }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));
             dispatch(module.exports.setError(err));

--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -763,10 +763,11 @@ module.exports.getRemixes = id => (dispatch => {
     });
 });
 
-module.exports.getProjectStudios = id => (dispatch => {
+module.exports.getProjectStudios = (id, username, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
     api({
-        uri: `/projects/${id}/studios`
+        uri: `/users/${username}/projects/${id}/studios`,
+        authentication: token
     }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -159,9 +159,10 @@ class Preview extends React.Component {
             if (typeof this.props.projectInfo.id === 'undefined') {
                 this.initCounts(0, 0);
             } else {
+                const token = this.props.user ? this.props.user.token : null;
                 this.initCounts(this.props.projectInfo.stats.favorites, this.props.projectInfo.stats.loves);
                 this.props.getProjectStudios(this.props.projectInfo.id,
-                    this.props.authorUsername, this.props.user.token);
+                    this.props.authorUsername, this.props.isAdmin, token);
                 if (this.props.projectInfo.remix.parent !== null) {
                     this.props.getParentInfo(this.props.projectInfo.remix.parent);
                 }
@@ -980,8 +981,8 @@ const mapDispatchToProps = dispatch => ({
     getRemixes: id => {
         dispatch(previewActions.getRemixes(id));
     },
-    getProjectStudios: (id, username, token) => {
-        dispatch(previewActions.getProjectStudios(id, username, token));
+    getProjectStudios: (id, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getProjectStudios(id, ownerUsername, isAdmin, token));
     },
     getCuratedStudios: (username, token) => {
         dispatch(previewActions.getCuratedStudios(username, token));

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -160,6 +160,8 @@ class Preview extends React.Component {
                 this.initCounts(0, 0);
             } else {
                 this.initCounts(this.props.projectInfo.stats.favorites, this.props.projectInfo.stats.loves);
+                this.props.getProjectStudios(this.props.projectInfo.id,
+                    this.props.authorUsername, this.props.user.token);
                 if (this.props.projectInfo.remix.parent !== null) {
                     this.props.getParentInfo(this.props.projectInfo.remix.parent);
                 }
@@ -215,7 +217,6 @@ class Preview extends React.Component {
             }
             this.props.getProjectInfo(this.state.projectId, token);
             this.props.getRemixes(this.state.projectId, token);
-            this.props.getProjectStudios(this.state.projectId, token);
             this.props.getCuratedStudios(username);
             this.props.getFavedStatus(this.state.projectId, username, token);
             this.props.getLovedStatus(this.state.projectId, username, token);
@@ -227,7 +228,6 @@ class Preview extends React.Component {
             }
             this.props.getProjectInfo(this.state.projectId);
             this.props.getRemixes(this.state.projectId);
-            this.props.getProjectStudios(this.state.projectId);
         }
     }
     setScreenFromOrientation () {
@@ -980,8 +980,8 @@ const mapDispatchToProps = dispatch => ({
     getRemixes: id => {
         dispatch(previewActions.getRemixes(id));
     },
-    getProjectStudios: id => {
-        dispatch(previewActions.getProjectStudios(id));
+    getProjectStudios: (id, username, token) => {
+        dispatch(previewActions.getProjectStudios(id, username, token));
     },
     getCuratedStudios: (username, token) => {
         dispatch(previewActions.getCuratedStudios(username, token));


### PR DESCRIPTION
### Resolves:

Together with https://github.com/LLK/scratch-api/pull/770, resolves https://github.com/LLK/scratch-api/issues/756

Must be merged at the same time as resolves https://github.com/LLK/scratch-api/pull/770 , as both change the URL for the same endpoint

### Changes:

Changes handling of the "studios for project" endpoint:
* URI now includes owner of project
* now passes auth token
* waits until after retrieving project info to request studios list, because we need to know ownership of project
* determines whether to hit admin endpoint or regular endpoint by checking if current user is admin

### Test Coverage:

None