### PR TITLE
add ownerUsername to comment API endpoint URIs

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -466,7 +466,7 @@ module.exports.getTopLevelComments = (id, offset, ownerUsername, isAdmin, token)
     dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHING));
     api({
         uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/comments`,
-        authentication: isAdmin ? token : null,
+        authentication: token ? token : null,
         params: {offset: offset || 0, limit: COMMENT_LIMIT}
     }, (err, body, res) => {
         if (err) {
@@ -496,7 +496,7 @@ module.exports.getCommentById = (projectId, commentId, ownerUsername, isAdmin, t
     dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHING));
     api({
         uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${projectId}/comments/${commentId}`,
-        authentication: isAdmin ? token : null
+        authentication: token ? token : null
     }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('comments', module.exports.Status.ERROR));
@@ -527,7 +527,7 @@ module.exports.getReplies = (projectId, commentIds, offset, ownerUsername, isAdm
     async.eachLimit(commentIds, 10, (parentId, callback) => {
         api({
             uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${projectId}/comments/${parentId}/replies`,
-            authentication: isAdmin ? token : null,
+            authentication: token ? token : null,
             params: {offset: offset || 0, limit: COMMENT_LIMIT}
         }, (err, body, res) => {
             if (err) {
@@ -767,7 +767,7 @@ module.exports.getProjectStudios = (id, ownerUsername, isAdmin, token) => (dispa
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
     api({
         uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/studios`,
-        authentication: token
+        authentication: token ? token : null
     }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -171,6 +171,13 @@ class Preview extends React.Component {
                 ) {
                     this.props.getOriginalInfo(this.props.projectInfo.remix.root);
                 }
+                if (this.state.singleCommentId) {
+                    this.props.getCommentById(this.state.projectId, this.state.singleCommentId,
+                        this.props.authorUsername, this.props.isAdmin, token);
+                } else {
+                    this.props.getTopLevelComments(this.state.projectId, this.props.comments.length,
+                        this.props.authorUsername, this.props.isAdmin, token);
+                }
             }
         }
         if (this.props.faved !== prevProps.faved || this.props.loved !== prevProps.loved) {
@@ -209,24 +216,12 @@ class Preview extends React.Component {
         if (this.props.userPresent) {
             const username = this.props.user.username;
             const token = this.props.user.token;
-            if (this.state.singleCommentId) {
-                this.props.getCommentById(this.state.projectId, this.state.singleCommentId,
-                    this.props.isAdmin, token);
-            } else {
-                this.props.getTopLevelComments(this.state.projectId, this.props.comments.length,
-                    this.props.isAdmin, token);
-            }
             this.props.getProjectInfo(this.state.projectId, token);
             this.props.getRemixes(this.state.projectId, token);
             this.props.getCuratedStudios(username);
             this.props.getFavedStatus(this.state.projectId, username, token);
             this.props.getLovedStatus(this.state.projectId, username, token);
         } else {
-            if (this.state.singleCommentId) {
-                this.props.getCommentById(this.state.projectId, this.state.singleCommentId);
-            } else {
-                this.props.getTopLevelComments(this.state.projectId, this.props.comments.length);
-            }
             this.props.getProjectInfo(this.state.projectId);
             this.props.getRemixes(this.state.projectId);
         }
@@ -994,14 +989,14 @@ const mapDispatchToProps = dispatch => ({
             dispatch(previewActions.leaveStudio(studioId, id, token));
         }
     },
-    getTopLevelComments: (id, offset, isAdmin, token) => {
-        dispatch(previewActions.getTopLevelComments(id, offset, isAdmin, token));
+    getTopLevelComments: (id, offset, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getTopLevelComments(id, offset, ownerUsername, isAdmin, token));
     },
-    getCommentById: (projectId, commentId, isAdmin, token) => {
-        dispatch(previewActions.getCommentById(projectId, commentId, isAdmin, token));
+    getCommentById: (projectId, commentId, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getCommentById(projectId, commentId, ownerUsername, isAdmin, token));
     },
-    getMoreReplies: (projectId, commentId, offset, isAdmin, token) => {
-        dispatch(previewActions.getReplies(projectId, [commentId], offset, isAdmin, token));
+    getMoreReplies: (projectId, commentId, offset, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getReplies(projectId, [commentId], offset, ownerUsername, isAdmin, token));
     },
     getFavedStatus: (id, username, token) => {
         dispatch(previewActions.getFavedStatus(id, username, token));


### PR DESCRIPTION

Must be merged at the same time as https://github.com/LLK/scratch-api/pull/774, which changes the same endpoint on the backend.

### Resolves:

Resolves https://github.com/LLK/scratch-api/issues/755

### Changes:

* adds `ownerUsername` to all 3 comment API endpoint URIs
* handles error responses to those requests in a less catastrophic way; before, we would crash the page with an "Oops" message; now, we just fail silently (this came up in development)

### Test Coverage:

None