### PR TITLE
Remove dependency on scratchr2_translations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -80,6 +80,12 @@ source_file = src/views/splash/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
+[scratch-website.conference-index-2019-l10njson]
+file_filter = localizations/conference-index-2019/<lang>.json
+source_file = src/views/conference/2019/index/l10n.json
+source_lang = en
+type = KEYVALUEJSON
+
 [scratch-website.conference-index-2017-l10njson]
 file_filter = localizations/conference-index-2017/<lang>.json
 source_file = src/views/conference/2017/index/l10n.json
@@ -89,12 +95,6 @@ type = KEYVALUEJSON
 [scratch-website.credits-l10njson]
 file_filter = localizations/credits/<lang>.json
 source_file = src/views/credits/l10n.json
-source_lang = en
-type = KEYVALUEJSON
-
-[scratch-website.tips-l10njson]
-file_filter = localizations/tips/<lang>.json
-source_file = src/views/tips/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
@@ -122,12 +122,6 @@ source_file = src/views/messages/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
-[scratch-website.preview-faq-l10njson]
-file_filter = localizations/preview-faq/<lang>.json
-source_file = src/views/preview-faq/l10n.json
-source_lang = en
-type = KEYVALUEJSON
-
 [scratch-website.research-l10njson]
 file_filter = localizations/research/<lang>.json
 source_file = src/views/research/l10n.json
@@ -147,12 +141,6 @@ type = KEYVALUEJSON
 
 [scratch-website.microbit-l10njson]
 source_file = src/views/microbit/l10n.json
-source_lang = en
-type = KEYVALUEJSON
-
-[scratch-website.3faq-l10njson]
-file_filter = localizations/preview-faq/<lang>.json
-source_file = src/views/preview-faq/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
@@ -179,5 +167,10 @@ type = KEYVALUEJSON
 
 [scratch-website.ideas-l10njson]
 source_file = src/views/ideas/l10n.json
+source_lang = en
+type = KEYVALUEJSON
+
+[scratch-website.starter-projects-l10njson]
+source_file = src/views/starter-projects/l10n.json
 source_lang = en
 type = KEYVALUEJSON

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ deploy:
 
 translations:
 	./bin/get-localized-urls localized-urls.json
-	./bin/build-locales node_modules/scratchr2_translations/www/translations intl
+	./bin/build-locales node_modules/scratch-l10n/www intl
 
 webpack:
 	$(WEBPACK) --bail

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -123,6 +123,16 @@ var defaultLocales = {
 var views = [];
 var localizedAssetUrls = {};
 
+// Most views will have the same name for:
+//   - the view folder
+//   - the route name
+//   - the transifex resource
+// Add exceptions:
+//   - txMapping: if the name of the transifex resource is different from the route name 
+var txMapping = {
+    'projects': 'preview',
+    'scratch_1.4': 'scratch_14' // transifex doesn't allow dots in resource names
+};
 // start with english default for all views
 for (var v in routes) {
     if (typeof routes[v].redirect !== 'undefined') {
@@ -193,11 +203,12 @@ async.forEachLimit(views, 5, function (view, cb) {
 
     // merge view specific english strings, first then other languages
     async.forEach(allLangs, function (isoCode, cb) {
+        var txResource = txMapping[view] || view;
         var translationsFile = path.resolve(
             __dirname,
             '../',
             localesDir,
-            'scratch-website.' + view + '-l10njson',
+            'scratch-website.' + txResource + '-l10njson',
             isoCode + '.json'
         );
         fs.readFile(translationsFile, 'utf8', function (err, data) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "smoke-sauce": "SMOKE_REMOTE=true tap ./test/integration/smoke-testing/*.js --timeout=60000",
     "watch": "make watch",
     "build": "make build",
-    "dev": "make watch && make start &"
+    "dev": "make watch && make start &",
+    "translate:urls": "node ./bin/get-localized-urls localized-urls.json",
+    "translate:files": "node ./bin/build-locales node_modules/scratch-l10n/www intl",
+    "translate": "npm run translate:urls && npm run translate:files"
   },
   "repository": {
     "type": "git",
@@ -104,7 +107,6 @@
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
     "scratch-l10n": "latest",
-    "scratchr2_translations": "git://github.com/LLK/scratchr2_translations.git#master",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",
     "style-loader": "0.12.3",

--- a/test/localization/check_valid_json.js
+++ b/test/localization/check_valid_json.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var glob = require('glob');
 var tap = require('tap');
 
-var TRANSLATIONS_PATTERN = './node_modules/scratchr2_translations/www/**/*.json';
+var TRANSLATIONS_PATTERN = './node_modules/scratch-l10n/www/**/*.json';
 var files = glob.sync(TRANSLATIONS_PATTERN);
 
 const checkJson = (data, name) => {


### PR DESCRIPTION
### Resolves:

fixes #2665 

As a follow-up, we should add scripts to allow automated update of source files on a regular schedule (like gui, etc)


### Changes:

Removes `scratchr2_translations` dependency from the package.json, and updates build scripts to use data from `scratch-l10n` instead.

### Test Coverage:

No functional changes, updated translations json test to use scratch-l10n.
