### PR TITLE
include comments with visibility set to marked by filter

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -111,7 +111,9 @@ class Comment extends React.Component {
             visibility
         } = this.props;
 
-        const visible = visibility === 'visible';
+        // we allow comments that are fully visible, or markedByFilter (flagged by
+        // our bad words filter, but not at the critical level of offensiveness)
+        const visible = visibility === 'visible' || visibility === 'markedbyfilter';
 
         let commentText = content;
         if (replyUsername) {


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-api/issues/701 , along with https://github.com/LLK/scratch-api/pull/775

Should be merged at the same time as https://github.com/LLK/scratch-api/pull/775

### Changes:

Considers both comments visibility values of `'visible'` and `'markedbyfilter'` to indicate that comments should be visible.

### Test Coverage:

None :(