### PR TITLE
Update react-intl to bring in māori locale-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
-    "react-intl": "2.4.0",
+    "react-intl": "2.8.0",
     "react-modal": "3.1.11",
     "react-onclickoutside": "6.7.1",
     "react-redux": "5.0.7",


### PR DESCRIPTION
### Resolves:

fixes #2873 

### Changes:
Update react-intl to latest version (2.8.0) which includes the māori locale data. 

### Test Coverage:

- Manually tested that switching to māori no longer shows message ids, and no errors in the console.