### PR TITLE
change studios for project API request to use admin status, owner status and token

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -763,10 +763,11 @@ module.exports.getRemixes = id => (dispatch => {
     });
 });
 
-module.exports.getProjectStudios = id => (dispatch => {
+module.exports.getProjectStudios = (id, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
     api({
-        uri: `/projects/${id}/studios`
+        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/studios`,
+        authentication: token
     }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));

--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -763,12 +763,16 @@ module.exports.getRemixes = id => (dispatch => {
     });
 });
 
+
 module.exports.getProjectStudios = (id, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.FETCHING));
-    api({
-        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/studios`,
-        authentication: token
-    }, (err, body, res) => {
+    const opts = {
+        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/studios`
+    };
+    if (token) {
+        Object.assign(opts, {authentication: token});
+    }
+    api(opts, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('projectStudios', module.exports.Status.ERROR));
             dispatch(module.exports.setError(err));

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -160,7 +160,10 @@ class Preview extends React.Component {
             if (typeof this.props.projectInfo.id === 'undefined') {
                 this.initCounts(0, 0);
             } else {
+                const token = this.props.user ? this.props.user.token : null;
                 this.initCounts(this.props.projectInfo.stats.favorites, this.props.projectInfo.stats.loves);
+                this.props.getProjectStudios(this.props.projectInfo.id,
+                    this.props.authorUsername, this.props.isAdmin, token);
                 if (this.props.projectInfo.remix.parent !== null) {
                     this.props.getParentInfo(this.props.projectInfo.remix.parent);
                 }
@@ -216,7 +219,6 @@ class Preview extends React.Component {
             }
             this.props.getProjectInfo(this.state.projectId, token);
             this.props.getRemixes(this.state.projectId, token);
-            this.props.getProjectStudios(this.state.projectId, token);
             this.props.getCuratedStudios(username);
             this.props.getFavedStatus(this.state.projectId, username, token);
             this.props.getLovedStatus(this.state.projectId, username, token);
@@ -228,7 +230,6 @@ class Preview extends React.Component {
             }
             this.props.getProjectInfo(this.state.projectId);
             this.props.getRemixes(this.state.projectId);
-            this.props.getProjectStudios(this.state.projectId);
         }
     }
     setScreenFromOrientation () {
@@ -984,8 +985,8 @@ const mapDispatchToProps = dispatch => ({
     getRemixes: id => {
         dispatch(previewActions.getRemixes(id));
     },
-    getProjectStudios: id => {
-        dispatch(previewActions.getProjectStudios(id));
+    getProjectStudios: (id, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getProjectStudios(id, ownerUsername, isAdmin, token));
     },
     getCuratedStudios: (username, token) => {
         dispatch(previewActions.getCuratedStudios(username, token));


### PR DESCRIPTION
### Resolves:

Together with API PR https://github.com/LLK/scratch-api/pull/810, resolves https://github.com/LLK/scratch-api/issues/756

Must be merged at the same time as that API PR , as both change the URL for the same endpoint

### Changes:

Changes handling of the "studios for project" endpoint:

* URI now includes owner of project
* now passes auth token
* waits until after retrieving project info to request studios list, because we need to know ownership of project
* determines whether to hit admin endpoint or regular endpoint by checking if current user is admin

### Test Coverage:

None