### PR TITLE
fix "make translations" command

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -106,7 +106,9 @@ for ( var l in languages ) {
             l + '.json'
         );
         fs.accessSync(langTranslations);
-        generalLocales[l] = JSON.parse(fs.readFileSync(langTranslations, 'utf8'));
+        if (l !== 'en') {
+            generalLocales[l] = JSON.parse(fs.readFileSync(langTranslations, 'utf8'));
+        }
     } catch (err) {
         // just use english
         generalLocales[l] = generalLocales['en'];
@@ -128,7 +130,7 @@ var localizedAssetUrls = {};
 //   - the route name
 //   - the transifex resource
 // Add exceptions:
-//   - txMapping: if the name of the transifex resource is different from the route name 
+//   - txMapping: if the name of the transifex resource is different from the route name
 var txMapping = {
     'projects': 'preview',
     'scratch_1.4': 'scratch_14' // transifex doesn't allow dots in resource names
@@ -228,8 +230,11 @@ async.forEachLimit(views, 5, function (view, cb) {
                 }
             }
             try {
-                viewLocales[isoCode] = merge({}, generalLocales[isoCode], JSON.parse(data));
-                defaults(viewLocales[isoCode], viewLocales['en']);
+                // don't overwrite english view strings
+                if (isoCode !== 'en') {
+                    viewLocales[isoCode] = merge({}, generalLocales[isoCode], JSON.parse(data));
+                    defaults(viewLocales[isoCode], viewLocales['en']);
+                }
             } catch (e) {
                 return cb(e);
             }


### PR DESCRIPTION

This change was made by @chrisgarrity in https://github.com/LLK/scratch-www/pull/2952/commits/3a651fa9fd1778fb80ce8f1d6b4a712bc3801610 , but we decided to move it to its own PR.

### Resolves:

Hopefully, resolves https://github.com/LLK/scratch-www/issues/2959

### Changes:

When dowloading translations from transifex, don't overwrite local english defaults (contained in various `l10n.json` files).

This effectively fixes translations for new strings in the www build, so the english versions will be displayed by default, rather than the new string's IDs.

### Test Coverage:

Don't know how we can add a test for `build-locales`. I added an issue to track this: https://github.com/LLK/scratch-www/issues/2968