### PR TITLE
change /story redirect from tutorial=story to tutorial=tell-a-story

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -463,7 +463,7 @@
     {
         "name": "story-tutorial-redirect",
         "pattern": "^/story/?$",
-        "redirect": "/projects/editor/?tutorial=story"
+        "redirect": "/projects/editor/?tutorial=tell-a-story"
     },
     {
         "name": "pong-tutorial-redirect",


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2837

### Changes:

changes `scratch.mit.edu/story` redirect from `tutorial=story` to `tutorial=tell-a-story`.
