### PR TITLE
Make Add to studio test in test-my-stuff integration test look in shared projects

### DIFF
--- a/test/integration/smoke-testing/test-my-stuff.js
+++ b/test/integration/smoke-testing/test-my-stuff.js
@@ -101,6 +101,7 @@ test('clicking a project title should take you to the project page', t => {
 
 test('Add To button should bring up a list of studios', t => {
     clickXpath('//a[contains(@class, "mystuff-icon")]')
+        .then(() => clickXpath('//div[@id="sidebar"]/ul/li[@data-tab="shared"]'))
         .then(() => findByXpath('//div[@data-control="add-to"]'))
         .then((element) => element.getText('span'))
         .then((text) => t.equal(text, 'Add to', 'there should be an "Add to" button'))


### PR DESCRIPTION
### Resolves:

Integration tests fail periodically because they create projects whenever they are run but don't share them.  Eventually, the first page of "My Stuff" will not have any shared projects so the "Add To" test (add to studio) fails.  Previously I would have to manually delete projects to allow the tests to pass.

### Changes:

Before looking for the button, the test now clicks the "shared projects" button, guaranteeing a shared project will be visible.
