### PR TITLE
fix last instructions notes and credits alignment

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -487,7 +487,7 @@ const PreviewPresentation = ({
                                                     </Formsy>
                                                 )}
                                             </FormsyProjectUpdater> :
-                                            <div className="project-description last">
+                                            <div className="project-description">
                                                 {decorateText(projectInfo.description, {
                                                     usernames: true,
                                                     hashtags: true,

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -466,7 +466,7 @@ $stage-width: 480px;
         flex: 1;
     }
 
-    .project-description.last {
+    .project-description:last-of-type {
         margin-bottom: 0;
     }
 


### PR DESCRIPTION
### Resolves:

Fixes one remaining formatting issue from https://github.com/LLK/scratch-www/pull/2973 / https://github.com/LLK/scratch-www/issues/2603

### Changes:

Instead of hardcoding notes & credits section to be formatted as the "last" description setting, let that style apply to whichever of instructions and notes&credits is last.

Before:

![image](https://user-images.githubusercontent.com/3431616/58192081-f7bb7000-7c8d-11e9-853e-b4ab425eee75.png)

After: 

![image](https://user-images.githubusercontent.com/3431616/58192119-086be600-7c8e-11e9-9676-558df870cc72.png)
