### PR TITLE
chore(package): update scratch-gui to version 0.1.0-prerelease.201905…

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-responsive": "3.0.0",
     "react-slick": "0.16.0",
     "react-string-replace": "0.4.1",
-    "scratch-gui": "0.1.0-prerelease.20190516172446",
+    "scratch-gui": "0.1.0-prerelease.20190522193014",
     "react-telephone-input": "4.3.4",
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",


### PR DESCRIPTION
…22193014

Closes #2995

Updates to GUI release as of 4pm ET on 5/22/19