### PR TITLE
added missing slash to images link, to fix intermittent CDN issue

### DIFF
--- a/src/views/teachers/landing/landing.jsx
+++ b/src/views/teachers/landing/landing.jsx
@@ -72,7 +72,7 @@ const Landing = props => (
                 <section id="sip">
                     <FlexRow className="educators-using">
                         <div className="using-scratch-image">
-                            <img src="images/teachers/makey-activity.png" />
+                            <img src="/images/teachers/makey-activity.png" />
                         </div>
                         <div className="sip-info">
                             <h2><FormattedMessage id="teacherlanding.howUsingScratch" /></h2>


### PR DESCRIPTION

### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2996

### Changes:

added missing slash to start of images link, to fix intermittent CDN issue

### Test Coverage:

None. Unclear how to test this, since various methods of providing a string value to `<img src=...>` are possible. 