### PR TITLE
[Master] Hotfix: update scratch-desktop link

### DIFF
--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -114,8 +114,8 @@ class Download extends React.Component {
                                             className="download-button"
                                             href={
                                                 this.state.OS === OS_ENUM.WINDOWS ?
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%201.2.1.exe' :
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-1.2.1.dmg'
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.3.0.exe' :
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.3.0.dmg'
                                             }
                                         >
                                             <FormattedMessage id="download.downloadButton" />


### PR DESCRIPTION
Points `download.jsx` to new scratch-desktop file on S3