### PR TITLE
fix firefox instructions height overflow issue

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -444,6 +444,12 @@ $stage-width: 480px;
         height: 100%;
         flex-direction: column;
         align-items: flex-start;
+        /*
+        necessary to fix flexbox sizing issue that caused instructions
+        to flow over the top and bottom of the project notes section.
+        see https://stackoverflow.com/a/36247448
+        */
+        min-height: 0;
     }
 
     .project-textlabel {


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3011

### Changes:

Adds back the `min-height: 0;` line to the `description-block` class, per this explanation: https://stackoverflow.com/a/36247448

### Test Coverage:

Tested in Mac Chrome, Firefox and Safari