### PR TITLE
set min-height of remix credit to max-content

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -425,6 +425,11 @@ $stage-width: 480px;
         flex-wrap: nowrap;
         align-items: center;
         justify-content: flex-start;
+        /*
+        Necessary to force Mac Safari to apply padding to the height of the
+        child elements. See https://stackoverflow.com/a/52273082/2308190
+        */
+        min-height: max-content;
 
         @media #{$medium-and-smaller} {
             flex-direction: row;


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3013

### Changes:

Uses the relatively new `min-height: max-content` css setting for `remix-credit`, to make parent expand height to encapsulate children. Don't really understand why this is necessary! 

Before:

![image](https://user-images.githubusercontent.com/3431616/58370808-d1d5db80-7ed8-11e9-8d99-96832221babe.png)

After:

![image](https://user-images.githubusercontent.com/3431616/58370807-cd112780-7ed8-11e9-8a79-2488aa0a28a9.png)


### Test Coverage:

Tested in Mac Chrome, Firefox, and Safari