### PR TITLE
[Develop] Release/2019-05-29 

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-responsive": "3.0.0",
     "react-slick": "0.16.0",
     "react-string-replace": "0.4.1",
-    "scratch-gui": "0.1.0-prerelease.20190529191233",
+    "scratch-gui": "0.1.0-prerelease.20190530164635",
     "react-telephone-input": "4.3.4",
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-responsive": "3.0.0",
     "react-slick": "0.16.0",
     "react-string-replace": "0.4.1",
-    "scratch-gui": "0.1.0-prerelease.20190530164635",
+    "scratch-gui": "0.1.0-prerelease.20190530174801",
     "react-telephone-input": "4.3.4",
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",


### PR DESCRIPTION
Release notes:
  - May Translations update LLK/scratch-blocks/pull/1946
    - zu
    - fa (lots)
    - pt-br
    - nb
    - rap
  - Sort list variables in context menu LLK/scratch-blocks/pull/1929
  - Playground improvements LLK/scratch-render/pull/426
  - ~Tweak scalingVector to make dots appear to be more circular LLK/scratch-render/pull/423~ LLK/scratch-render/pull/466
  - Implement canvas-based TextBubbleSkin LLK/scratch-render/pull/451
  - Update the built-in SVG assets for the default project LLK/scratch-gui/pull/4846
  - ~Pause video on tutorial window shrink LLK/scratch-gui/pull/4835~ LLK/scratch-gui/pull/4877
  - add timeouts & messages to all driver.wait calls LLK/scratch-gui/pull/4841
  - ~Delay loading and rendering gui LLK/scratch-gui/pull/4800~ LLK/scratch-gui/pull/4874, LLK/scratch-gui/pull/4873
  - Stabilize integration tests LLK/scratch-gui/pull/4871
  - When converting to bitmap, call inlineSvgFonts() on SVG string instead of SVG element LLK/scratch-paint/pull/842
  - Throw an error if inlineSvgFonts is called on a non-string LLK/scratch-svg-renderer/pull/92
  - Fix firefox instructions height overflow LLK/scratch-www/pull/3012
  - set min-height of remix credit to max-content LLK/scratch-www/pull/3014