### PR TITLE
Revert "Pull in latest scratch-gui"

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-responsive": "3.0.0",
     "react-slick": "0.16.0",
     "react-string-replace": "0.4.1",
-    "scratch-gui": "0.1.0-prerelease.20190619014402",
+    "scratch-gui": "0.1.0-prerelease.20190612160757",
     "react-telephone-input": "4.3.4",
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",


### PR DESCRIPTION
Reverts LLK/scratch-www#3055

-- npm failed to publish the gui version actually mentioned in this PR.