### PR TITLE
Add Boost and Vernier landing pages to the transifex configuration

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -144,6 +144,16 @@ source_file = src/views/microbit/l10n.json
 source_lang = en
 type = KEYVALUEJSON
 
+[scratch-website.boost-l10njson]
+source_file = src/views/boost/l10n.json
+source_lang = en
+type = KEYVALUEJSON
+
+[scratch-website.gdxfor-l10njson]
+source_file = src/views/gdxfor/l10n.json
+source_lang = en
+type = KEYVALUEJSON
+
 [scratch-website.search-l10njson]
 file_filter = localizations/search/<lang>.json
 source_file = src/views/search/l10n.json


### PR DESCRIPTION
The Boost and Vernier pages were never added to the transifex config, and never pushed to transifex for translation. This adds them to the config. I also ran `tx push -s` to push the latest version of everything to transifex.
