### PR TITLE
pass owner username and token to comment endpoints

### DIFF
--- a/src/redux/preview.js
+++ b/src/redux/preview.js
@@ -462,26 +462,26 @@ module.exports.getFavedStatus = (id, username, token) => (dispatch => {
     });
 });
 
-module.exports.getTopLevelComments = (id, offset, isAdmin, token) => (dispatch => {
+module.exports.getTopLevelComments = (id, offset, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHING));
     api({
-        uri: `${isAdmin ? '/admin' : ''}/projects/${id}/comments`,
-        authentication: isAdmin ? token : null,
+        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${id}/comments`,
+        authentication: token ? token : null,
         params: {offset: offset || 0, limit: COMMENT_LIMIT}
-    }, (err, body) => {
+    }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('comments', module.exports.Status.ERROR));
             dispatch(module.exports.setError(err));
             return;
         }
-        if (typeof body === 'undefined') {
+        if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
             dispatch(module.exports.setFetchStatus('comments', module.exports.Status.ERROR));
             dispatch(module.exports.setError('No comment info'));
             return;
         }
         dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHED));
         dispatch(module.exports.setComments(body));
-        dispatch(module.exports.getReplies(id, body.map(comment => comment.id), 0, isAdmin, token));
+        dispatch(module.exports.getReplies(id, body.map(comment => comment.id), 0, ownerUsername, isAdmin, token));
 
         // If we loaded a full page of comments, assume there are more to load.
         // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
@@ -492,18 +492,18 @@ module.exports.getTopLevelComments = (id, offset, isAdmin, token) => (dispatch =
     });
 });
 
-module.exports.getCommentById = (projectId, commentId, isAdmin, token) => (dispatch => {
+module.exports.getCommentById = (projectId, commentId, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHING));
     api({
-        uri: `${isAdmin ? '/admin' : ''}/projects/${projectId}/comments/${commentId}`,
-        authentication: isAdmin ? token : null
-    }, (err, body) => {
+        uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${projectId}/comments/${commentId}`,
+        authentication: token ? token : null
+    }, (err, body, res) => {
         if (err) {
             dispatch(module.exports.setFetchStatus('comments', module.exports.Status.ERROR));
             dispatch(module.exports.setError(err));
             return;
         }
-        if (!body) {
+        if (!body || res.statusCode >= 400) { // NotFound
             dispatch(module.exports.setFetchStatus('comments', module.exports.Status.ERROR));
             dispatch(module.exports.setError('No comment info'));
             return;
@@ -511,29 +511,29 @@ module.exports.getCommentById = (projectId, commentId, isAdmin, token) => (dispa
 
         if (body.parent_id) {
             // If the comment is a reply, load the parent
-            return dispatch(module.exports.getCommentById(projectId, body.parent_id, isAdmin, token));
+            return dispatch(module.exports.getCommentById(projectId, body.parent_id, ownerUsername, isAdmin, token));
         }
 
         // If the comment is not a reply, show it as top level and load replies
         dispatch(module.exports.setFetchStatus('comments', module.exports.Status.FETCHED));
         dispatch(module.exports.setComments([body]));
-        dispatch(module.exports.getReplies(projectId, [body.id], 0, isAdmin, token));
+        dispatch(module.exports.getReplies(projectId, [body.id], 0, ownerUsername, isAdmin, token));
     });
 });
 
-module.exports.getReplies = (projectId, commentIds, offset, isAdmin, token) => (dispatch => {
+module.exports.getReplies = (projectId, commentIds, offset, ownerUsername, isAdmin, token) => (dispatch => {
     dispatch(module.exports.setFetchStatus('replies', module.exports.Status.FETCHING));
     const fetchedReplies = {};
     async.eachLimit(commentIds, 10, (parentId, callback) => {
         api({
-            uri: `${isAdmin ? '/admin' : ''}/projects/${projectId}/comments/${parentId}/replies`,
-            authentication: isAdmin ? token : null,
+            uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${projectId}/comments/${parentId}/replies`,
+            authentication: token ? token : null,
             params: {offset: offset || 0, limit: COMMENT_LIMIT}
-        }, (err, body) => {
+        }, (err, body, res) => {
             if (err) {
                 return callback(`Error fetching comment replies: ${err}`);
             }
-            if (typeof body === 'undefined') {
+            if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
                 return callback('No comment reply information');
             }
             fetchedReplies[parentId] = body;

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -172,6 +172,13 @@ class Preview extends React.Component {
                 ) {
                     this.props.getOriginalInfo(this.props.projectInfo.remix.root);
                 }
+                if (this.state.singleCommentId) {
+                    this.props.getCommentById(this.state.projectId, this.state.singleCommentId,
+                        this.props.authorUsername, this.props.isAdmin, token);
+                } else {
+                    this.props.getTopLevelComments(this.state.projectId, this.props.comments.length,
+                        this.props.authorUsername, this.props.isAdmin, token);
+                }
             }
         }
         if (this.props.faved !== prevProps.faved || this.props.loved !== prevProps.loved) {
@@ -210,24 +217,12 @@ class Preview extends React.Component {
         if (this.props.userPresent) {
             const username = this.props.user.username;
             const token = this.props.user.token;
-            if (this.state.singleCommentId) {
-                this.props.getCommentById(this.state.projectId, this.state.singleCommentId,
-                    this.props.isAdmin, token);
-            } else {
-                this.props.getTopLevelComments(this.state.projectId, this.props.comments.length,
-                    this.props.isAdmin, token);
-            }
             this.props.getProjectInfo(this.state.projectId, token);
             this.props.getRemixes(this.state.projectId, token);
             this.props.getCuratedStudios(username);
             this.props.getFavedStatus(this.state.projectId, username, token);
             this.props.getLovedStatus(this.state.projectId, username, token);
         } else {
-            if (this.state.singleCommentId) {
-                this.props.getCommentById(this.state.projectId, this.state.singleCommentId);
-            } else {
-                this.props.getTopLevelComments(this.state.projectId, this.props.comments.length);
-            }
             this.props.getProjectInfo(this.state.projectId);
             this.props.getRemixes(this.state.projectId);
         }
@@ -998,14 +993,14 @@ const mapDispatchToProps = dispatch => ({
             dispatch(previewActions.leaveStudio(studioId, id, token));
         }
     },
-    getTopLevelComments: (id, offset, isAdmin, token) => {
-        dispatch(previewActions.getTopLevelComments(id, offset, isAdmin, token));
+    getTopLevelComments: (id, offset, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getTopLevelComments(id, offset, ownerUsername, isAdmin, token));
     },
-    getCommentById: (projectId, commentId, isAdmin, token) => {
-        dispatch(previewActions.getCommentById(projectId, commentId, isAdmin, token));
+    getCommentById: (projectId, commentId, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getCommentById(projectId, commentId, ownerUsername, isAdmin, token));
     },
-    getMoreReplies: (projectId, commentId, offset, isAdmin, token) => {
-        dispatch(previewActions.getReplies(projectId, [commentId], offset, isAdmin, token));
+    getMoreReplies: (projectId, commentId, offset, ownerUsername, isAdmin, token) => {
+        dispatch(previewActions.getReplies(projectId, [commentId], offset, ownerUsername, isAdmin, token));
     },
     getFavedStatus: (id, username, token) => {
         dispatch(previewActions.getFavedStatus(id, username, token));


### PR DESCRIPTION
### Resolves:

Together with api counterpart https://github.com/LLK/scratch-api/pull/851, resolves https://github.com/LLK/scratch-api/issues/755 . 

A redo of pieces of reverted PRs https://github.com/LLK/scratch-www/pull/2871, https://github.com/LLK/scratch-www/pull/2859, and https://github.com/LLK/scratch-www/pull/2858.

### Changes:

passes owner username and token (if any is present) to comment endpoints, so API can verify that this user should have access to the comments. 
