### PR TITLE
Put GUI version back to what it was originally for this release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190620154402",
+    "scratch-gui": "0.1.0-prerelease.20190619221447",
     "scratch-l10n": "latest",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
Essentially undo https://github.com/LLK/scratch-www/commit/edffa47f6586027a7a1363c2ba14d41706325042 since it wasn't the cause of any problems.

