### PR TITLE
update download links for Scratch Desktop 3.4.0

### DIFF
--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -114,8 +114,8 @@ class Download extends React.Component {
                                             className="download-button"
                                             href={
                                                 this.state.OS === OS_ENUM.WINDOWS ?
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.3.0.exe' :
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.3.0.dmg'
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.4.0.exe' :
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.4.0.dmg'
                                             }
                                         >
                                             <FormattedMessage id="download.downloadButton" />


### PR DESCRIPTION
### Resolves:

Scratch Desktop 3.4.0 release

### Changes:

This PR updates the version number in the Scratch Desktop direct-download links. Note that the linked files are already in place.

CC @BryceLTaylor