### PR TITLE
[master] Add troubleshooting item for boost firmware update

### DIFF
--- a/src/views/boost/boost.jsx
+++ b/src/views/boost/boost.jsx
@@ -208,6 +208,10 @@ class Boost extends ExtensionLanding {
                 </ExtensionSection>
                 <ExtensionSection className="faq">
                     <h2><FormattedMessage id="boost.troubleshootingTitle" /></h2>
+                    <h3 className="faq-title"><FormattedMessage id="boost.avoidFirmwareUpdateTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="boost.avoidFirmwareUpdateText" />
+                    </p>
                     <h3 className="faq-title"><FormattedMessage id="boost.checkOSVersionTitle" /></h3>
                     <p>
                         <FormattedMessage

--- a/src/views/boost/l10n.json
+++ b/src/views/boost/l10n.json
@@ -12,6 +12,8 @@
     "boost.connectALegoBeam": "Connect a LEGO beam with an axle to motor A and click the block again to make it spin.",
     "boost.starterProjects": "Starter Projects",
     "boost.troubleshootingTitle": "Troubleshooting",
+    "boost.avoidFirmwareUpdateTitle": "Having trouble connecting or using motor blocks?",
+    "boost.avoidFirmwareUpdateText": "We suggest you avoid updating the firmware on your BOOST for now. We are working on a fix with the team at LEGO for users who have already updated their firmware. Stay tuned! We hope to have a fix released soon.",
     "boost.checkOSVersionTitle": "Make sure your operating system is compatible with Scratch Link",
     "boost.checkOSVersionText": "The minimum operating system versions are listed at the top of this page. See instructions for checking your version of {winOSVersionLink} or {macOSVersionLink}.",
     "boost.winOSVersionLinkText": "Windows",


### PR DESCRIPTION
Add a troubleshooting item to the LEGO BOOST extension landing page to address the recent firmware update.