### PR TITLE
[Master] Hotfix for asset saving errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190626180304",
+    "scratch-gui": "0.1.0-prerelease.20190702183821",
     "scratch-l10n": "latest",
     "slick-carousel": "1.6.0",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
This is the hotfix associated with https://github.com/LLK/scratch-gui/pull/4962, that should prevent it appearing that your project has saved even when we are getting errors from the server.