### PR TITLE
add ModalInnerContent component, use it in modals

### DIFF
--- a/src/components/modal/addtostudio/presentation.jsx
+++ b/src/components/modal/addtostudio/presentation.jsx
@@ -11,6 +11,7 @@ const Spinner = require('../../spinner/spinner.jsx');
 const FlexRow = require('../../flex-row/flex-row.jsx');
 const StudioButton = require('./studio-button.jsx');
 const ModalTitle = require('../base/modal-title.jsx');
+const ModalInnerContent = require('../base/modal-inner-content.jsx');
 
 require('../../forms/button.scss');
 require('./modal.scss');
@@ -49,7 +50,7 @@ const AddToStudioModalPresentation = ({
             <div className="addToStudio-modal-header modal-header">
                 <ModalTitle title={contentLabel} />
             </div>
-            <div className="addToStudio-modal-content modal-content">
+            <ModalInnerContent className="addToStudio-modal-content">
                 <div className="studio-list-outer-scrollbox">
                     <div className="studio-list-inner-scrollbox">
                         <div className="studio-list-container">
@@ -101,7 +102,7 @@ const AddToStudioModalPresentation = ({
                         ]}
                     </FlexRow>
                 </Form>
-            </div>
+            </ModalInnerContent>
         </Modal>
     );
 };

--- a/src/components/modal/base/modal-inner-content.jsx
+++ b/src/components/modal/base/modal-inner-content.jsx
@@ -1,0 +1,26 @@
+const classNames = require('classnames');
+const PropTypes = require('prop-types');
+const React = require('react');
+
+require('./modal-inner-content.scss');
+
+const ModalInnerContent = ({
+    children,
+    className
+}) => (
+    <div
+        className={classNames(
+            'modal-inner-content',
+            className
+        )}
+    >
+        {children}
+    </div>
+);
+
+ModalInnerContent.propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string
+};
+
+module.exports = ModalInnerContent;

--- a/src/components/modal/base/modal-inner-content.jsx
+++ b/src/components/modal/base/modal-inner-content.jsx
@@ -8,13 +8,15 @@ const ModalInnerContent = ({
     children,
     className
 }) => (
-    <div
-        className={classNames(
-            'modal-inner-content',
-            className
-        )}
-    >
-        {children}
+    <div className="modal-inner-clear">
+        <div
+            className={classNames(
+                'modal-inner-content',
+                className
+            )}
+        >
+            {children}
+        </div>
     </div>
 );
 

--- a/src/components/modal/base/modal-inner-content.scss
+++ b/src/components/modal/base/modal-inner-content.scss
@@ -1,0 +1,9 @@
+@import "../../../colors";
+@import "../../../frameless";
+
+.modal-inner-content { /* content inside of content */
+    box-sizing: border-box;
+    display: flex;
+    border-radius: 0;
+    flex-direction: column;
+}

--- a/src/components/modal/base/modal-inner-content.scss
+++ b/src/components/modal/base/modal-inner-content.scss
@@ -1,7 +1,15 @@
 @import "../../../colors";
 @import "../../../frameless";
 
-.modal-inner-content { /* content inside of content */
+/*
+necessary to prevent modal-inner-content's margins from
+unexpectedly collapsing with a parent
+*/
+.modal-inner-clear {
+    overflow: auto;
+}
+
+.modal-inner-content {
     box-sizing: border-box;
     display: flex;
     border-radius: 0;

--- a/src/components/modal/base/modal.scss
+++ b/src/components/modal/base/modal.scss
@@ -16,12 +16,6 @@
     padding: 0;
     width: 48.75rem;
 
-    .modal-content { /* content inside of content */
-        display: flex;
-        border-radius: 0;
-        flex-direction: column;
-    }
-
     &:focus {
         outline: none;
     }

--- a/src/components/modal/report/modal.jsx
+++ b/src/components/modal/report/modal.jsx
@@ -9,6 +9,7 @@ const Modal = require('../base/modal.jsx');
 const classNames = require('classnames');
 
 const ModalTitle = require('../base/modal-title.jsx');
+const ModalInnerContent = require('../base/modal-inner-content.jsx');
 const Form = require('../../forms/form.jsx');
 const Button = require('../../forms/button.jsx');
 const Select = require('../../forms/select.jsx');
@@ -130,7 +131,7 @@ class ReportModal extends React.Component {
                         onValid={this.handleValid}
                         onValidSubmit={onReport}
                     >
-                        <div className="report-modal-content modal-content">
+                        <ModalInnerContent className="report-modal-content">
                             {isConfirmed ? (
                                 <div className="received">
                                     <div className="received-header">
@@ -198,7 +199,7 @@ class ReportModal extends React.Component {
                                     <FormattedMessage id="report.error" />
                                 </div>
                             )}
-                        </div>
+                        </ModalInnerContent>
                         <FlexRow className="action-buttons">
                             <div className="action-buttons-overflow-fix">
                                 {isConfirmed ? (

--- a/src/components/modal/social/presentation.jsx
+++ b/src/components/modal/social/presentation.jsx
@@ -6,6 +6,8 @@ const classNames = require('classnames');
 
 const Modal = require('../base/modal.jsx');
 const ModalTitle = require('../base/modal-title.jsx');
+const ModalInnerContent = require('../base/modal-inner-content.jsx');
+
 const FlexRow = require('../../flex-row/flex-row.jsx');
 
 require('../../forms/button.scss');
@@ -37,7 +39,7 @@ const SocialModalPresentation = ({
             <div className="social-modal-header modal-header">
                 <ModalTitle title={intl.formatMessage({id: 'general.copyLink'})} />
             </div>
-            <div className="modal-content social-modal-content">
+            <ModalInnerContent className="social-modal-content">
 
                 {/* top row: link */}
                 <div className="link-section">
@@ -111,7 +113,7 @@ const SocialModalPresentation = ({
                     </FlexRow>
                 </div>
 
-            </div>
+            </ModalInnerContent>
         </Modal>
     );
 };


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3112

### Changes:

* renames the `.modal-content` style when it is used inside another `.modal-content` style; now we'll call that inside one `.modal-inner-content`.
* refactors uses of that inner modal-content style, so they use a component instead of using the style out of scope.
