### PR TITLE
update package-lock.json with newer google-libphonenumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5438,9 +5438,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-1.0.21.tgz",
-      "integrity": "sha1-ZSscDp9c6Tq9A+SDAKqoJgHDurE=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.3.tgz",
+      "integrity": "sha512-8n4JyRptifaIRlHANKRlfqLR8fANm7+Q+1qvDuUsUeStSLtLGTVsZWe1llWDfgWTm1y07cEUyiRuNIv6cs2ovg==",
       "dev": true
     },
     "graceful-fs": {


### PR DESCRIPTION
Follow-on to https://github.com/LLK/scratch-www/pull/3094

Question about PRs like https://github.com/LLK/scratch-www/pull/3094, and this:

Now that we have package-lock.json tracked/checked in, if we make an update to a package.json line via greenkeeper, should we also make an update to package-lock.json?

If so, does that mean that the process of merging in greenkeeper PRs is more complicated now -- check out locally, npm install, maybe test the change, add package-lock.json changes, push to origin, merge? For ones that we don't typically test locally, will we still need to do all this, minus the local testing?
