### PR TITLE
fix add-to-studio modal height, gradient interference

### DIFF
--- a/src/components/modal/addtostudio/modal.scss
+++ b/src/components/modal/addtostudio/modal.scss
@@ -3,15 +3,17 @@
 
 .mod-addToStudio {
     min-height: 15rem;
-    max-height: calc(100% - 8rem);
+    max-height: calc(100% - 5rem);
 
     /* Some value for height must be set for scrolling to work */
-    height: 100%;
+    height: 28rem;
 
     overflow: hidden;
 
     @media #{$small}, #{$small-height} {
         overflow: hidden;
+        height: 100%;
+        max-height: 100%;
     }
 }
 
@@ -70,6 +72,12 @@
 /* NOTE: force scrolling: add to above:
     min-height: 30rem;
 */
+
+/* provides buffer at bottom of list, so that bottommost items
+are not obscured by gradient overlay */
+.studio-list-footer-spacer {
+    height: 1.5rem;
+}
 
 .studio-list-bottom-gradient {
     position: absolute;

--- a/src/components/modal/addtostudio/presentation.jsx
+++ b/src/components/modal/addtostudio/presentation.jsx
@@ -56,6 +56,7 @@ const AddToStudioModalPresentation = ({
                         <div className="studio-list-container">
                             {studioButtons}
                         </div>
+                        <div className="studio-list-footer-spacer" />
                         <div className="studio-list-bottom-gradient" />
                     </div>
                 </div>


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2472 AddToStudio modal can be weirdly tall
Resolves https://github.com/LLK/scratch-www/issues/2685 When add to studio modal has many studios, the ones on bottom have fade out overlay

### Changes:

* use fixed height, rather than 100%, for preferred height of add to studio modal; this is the main fix
* increase the max-height of add to studio modal, so that when the window is short, it is taller than it was before
* override height and max-height when window becomes too short, so it becomes flush with top and bottom of window
* add div with class `studio-list-footer-spacer` to the list of studios, so that when you scroll the list to the bottom, the bottommost studios are clear of the gradient overlay (this might be a nice fix to bring in to the sprite, costume and sounds scrolling areas). When the list does not scroll, it is not visible.

### Test Coverage:

Don't know how to test any of this?