### PR TITLE
use padding to avoid margin collapse; drop approach that used `overflow: auto`

### DIFF
--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -9,6 +9,8 @@
 .join-flow-inner-content {
     box-shadow: none;
     width: calc(100% - 5.875rem);
-    margin: 2.3125rem auto 2.5rem;
+    /* must use padding for top, rather than margin, because margins will collapse */
+    margin: 0 auto;
+    padding: 2.3125rem 0 2.5rem;
     font-size: .875rem;
 }

--- a/src/components/modal/base/modal-inner-content.jsx
+++ b/src/components/modal/base/modal-inner-content.jsx
@@ -8,15 +8,13 @@ const ModalInnerContent = ({
     children,
     className
 }) => (
-    <div className="modal-inner-clear">
-        <div
-            className={classNames(
-                'modal-inner-content',
-                className
-            )}
-        >
-            {children}
-        </div>
+    <div
+        className={classNames(
+            'modal-inner-content',
+            className
+        )}
+    >
+        {children}
     </div>
 );
 

--- a/src/components/modal/base/modal-inner-content.scss
+++ b/src/components/modal/base/modal-inner-content.scss
@@ -1,15 +1,6 @@
 @import "../../../colors";
 @import "../../../frameless";
 
-/*
-necessary to prevent modal-inner-content's margins from
-unexpectedly collapsing with a parent
-*/
-.modal-inner-clear {
-    overflow: auto;
-    height: 100%;
-}
-
 .modal-inner-content {
     box-sizing: border-box;
     display: flex;


### PR DESCRIPTION

### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3139

### Changes:

In modal styling:
* use padding to avoid margin collapse
* drop previous approach, which used `overflow: auto`

