### PR TITLE
Greenkeeper/scratch gui 0.1.0 prerelease.20190723203336

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15084,9 +15084,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20190722181739",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20190722181739.tgz",
-      "integrity": "sha512-lVSP9nmdH7LNM6Al4VgNycCmfj0YppcynhwnmIeVKk3rqfQE9op660T4+LFXqpv/bCRz8GUBLhN8XLgu8dYNNw==",
+      "version": "0.1.0-prerelease.20190723203336",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20190723203336.tgz",
+      "integrity": "sha512-9UcI8QTcu2QpBRgp5J/x9mrguOmP7g5pvLFHq4/jHl1c69lhFfwI2SbfjWyp48JjC+BriQ4vfYeIQ6358mHLSA==",
       "dev": true
     },
     "scratch-l10n": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "redux": "3.5.2",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20190722181739",
+    "scratch-gui": "0.1.0-prerelease.20190723203336",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Update GUI to the version that includes https://github.com/LLK/scratch-gui/pull/4960