### PR TITLE
better validation positioning on birthdate step

### DIFF
--- a/src/components/formik-forms/formik-select.jsx
+++ b/src/components/formik-forms/formik-select.jsx
@@ -24,7 +24,7 @@ const FormikSelect = ({
         </option>
     ));
     return (
-        <div className="select">
+        <div className="select row-with-tooltip">
             <Field
                 className={classNames(
                     className

--- a/src/components/forms/validation-message.scss
+++ b/src/components/forms/validation-message.scss
@@ -17,6 +17,7 @@
     min-height: 1rem;
     overflow: visible;
     color: $type-white;
+    z-index: 1;
 
     &:before {
         display: block;

--- a/src/components/join-flow/birthdate-step.jsx
+++ b/src/components/join-flow/birthdate-step.jsx
@@ -110,7 +110,7 @@ class BirthDateStep extends React.Component {
                                     name="birth_month"
                                     options={birthMonthOptions}
                                     validate={this.validateSelect}
-                                    validationClassName="validation-full-width-input"
+                                    validationClassName="validation-birthdate-input"
                                 />
                                 <FormikSelect
                                     className={classNames(
@@ -122,7 +122,7 @@ class BirthDateStep extends React.Component {
                                     name="birth_year"
                                     options={birthYearOptions}
                                     validate={this.validateSelect}
-                                    validationClassName="validation-full-width-input"
+                                    validationClassName="validation-birthdate-input"
                                 />
                             </div>
                         </JoinFlowStep>

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -22,6 +22,23 @@
     transform: translate(21.5625rem, 0);
 }
 
+.validation-birthdate-input {
+    transform: translate(8.75rem, .25rem);
+    width: 7.25rem;
+}
+
+@media #{$intermediate-and-smaller} {
+    .validation-full-width-input {
+        transform: unset;
+        margin-bottom: .75rem;
+    }
+
+    .validation-birthdate-input {
+        transform: unset;
+        width: 8rem;
+    }
+}
+
 .select .join-flow-select {
     width: 9.125rem;
 }


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* use `row-with-tooltip` class in formik-select component, so validations will be correctly positioned
* tweak css transform in validations so they are positioned in a way that will correspond to the select elements they refer to, without blocking user from clicking on the selects
* tweak css classes when window is narrow, so validations are no longer transformed to the right

### Before:

when window is wide:

![image](https://user-images.githubusercontent.com/3431616/61980859-e82a1180-afc5-11e9-9b2c-93cd6887f109.png)

when window is narrow:

![image](https://user-images.githubusercontent.com/3431616/61980866-f415d380-afc5-11e9-8cf4-51a1f28308a6.png)

### After:

![image](https://user-images.githubusercontent.com/3431616/61980893-06900d00-afc6-11e9-9c61-6f441fb8b82c.png)

![image](https://user-images.githubusercontent.com/3431616/61980900-0a239400-afc6-11e9-86c7-1a971bc7e37d.png)

![image](https://user-images.githubusercontent.com/3431616/61980902-0d1e8480-afc6-11e9-9e25-0de6329d7120.png)

