### PR TITLE
[Master] Fix project thumbnails for reporting

### DIFF
--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -388,7 +388,10 @@ class Preview extends React.Component {
         const submit = data => this.props.reportProject(this.state.projectId, data, this.props.user.token);
         if (this.getProjectThumbnail) {
             this.getProjectThumbnail(thumbnail => {
-                const data = Object.assign({}, formData, {thumbnail});
+                const data = Object.assign({}, formData, {
+                    // Strip the data:image prefix, server just wants the b64 encoded image
+                    thumbnail: thumbnail.replace('data:image/png;base64,', '')
+                });
                 submit(data);
             });
         } else {


### PR DESCRIPTION
Fixes #2550,  the issue where project reports did not correctly include the thumbnail

From that comment:

> from looking at the default thumbnail data we include in the reportProject reducer action https://github.com/LLK/scratch-www/blob/develop/src/redux/preview.js#L964-L967 it seems like maybe the problem is that we are including the data:image prefix in the POST instead of just the b64 encoded image. That is, we might be able to fix just by stripping data:image/png;base64, from the thumbnail we get back from the GUI.