### PR TITLE
Fix click not working on highlighted comment avatar

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -83,6 +83,13 @@
         width: calc(100% + 1rem);
         height: 100%;
         content: "";
+        
+        /* 
+            Because this :before is absolutely positioned, it will eat clicks
+            from non-absolute elements after it (like the author link).
+            Prevent this by explicitly disabling pointer events on this background element.
+        */
+        pointer-events: none;
     }
 
     .comment-top-row {


### PR DESCRIPTION
Fixes an issue where you cannot click on the user link on a comment when it is highlighted, for example when following a link from your messages.

The absolutely positioned :before highlight was eating clicks from the relatively positioned elements after it, like the avatar image. Disable pointer events to prevent this background element from receiving clicks.

This is due to a subtle issue with element ordering, even elements that are before other elements get automatically promoted above siblings that are relatively positioned. That is why the reply/delete buttons still work on highlighted comments (they are also absolutely positioned) but the avatar user link did not work.

