### PR TITLE
handle username validation errors states better

### DIFF
--- a/src/components/formik-forms/formik-input.jsx
+++ b/src/components/formik-forms/formik-input.jsx
@@ -5,9 +5,8 @@ import {Field} from 'formik';
 
 const ValidationMessage = require('../forms/validation-message.jsx');
 
-require('./input.scss');
-require('../forms/input.scss');
 require('../forms/row.scss');
+require('./formik-input.scss');
 
 const FormikInput = ({
     className,
@@ -27,6 +26,7 @@ const FormikInput = ({
         <Field
             className={classNames(
                 'input',
+                {fail: error},
                 className
             )}
             {...props}

--- a/src/components/formik-forms/formik-input.scss
+++ b/src/components/formik-forms/formik-input.scss
@@ -25,9 +25,4 @@
             outline: none;
         }
     }
-
-    /* IE10/11-specific style resets */
-    &::-ms-reveal, &::-ms-clear {
-        display: none;
-    }
 }

--- a/src/components/formik-forms/formik-input.scss
+++ b/src/components/formik-forms/formik-input.scss
@@ -1,0 +1,33 @@
+@import "../../colors";
+
+.input {
+    height: 2.75rem;
+    border-radius: .5rem;
+    background-color: $ui-white;
+    margin-bottom: .5rem;
+    transition: all .5s ease;
+    border: 1px solid $active-gray;
+    padding: 0 1rem;
+    color: $type-gray;
+    font-size: .875rem;
+
+    &:focus {
+        box-shadow: 0 0 0 .25rem $ui-blue-25percent;
+        outline: none;
+        border: 1px solid $ui-blue;
+    }
+
+    &.fail {
+        border: 1px solid $ui-orange;
+
+        &:focus {
+            box-shadow: 0 0 0 .25rem $ui-orange-25percent;
+            outline: none;
+        }
+    }
+
+    /* IE10/11-specific style resets */
+    &::-ms-reveal, &::-ms-clear {
+        display: none;
+    }
+}

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -47,9 +47,9 @@ class UsernameStep extends React.Component {
         }
         return this.props.intl.formatMessage({id: localResult.errMsgId});
     }
-    validatePasswordIfPresent (password) {
+    validatePasswordIfPresent (password, username) {
         if (!password) return null; // skip validation if password is blank; null indicates valid
-        const localResult = validate.validatePassword(password);
+        const localResult = validate.validatePassword(password, username);
         if (localResult.valid) return null;
         return this.props.intl.formatMessage({id: localResult.errMsgId});
     }
@@ -69,12 +69,9 @@ class UsernameStep extends React.Component {
         if (!usernameResult.valid) {
             errors.username = this.props.intl.formatMessage({id: usernameResult.errMsgId});
         }
-        const passwordResult = validate.validatePassword(values.password);
+        const passwordResult = validate.validatePassword(values.password, values.username);
         if (!passwordResult.valid) {
             errors.password = this.props.intl.formatMessage({id: passwordResult.errMsgId});
-        }
-        if (values.password === values.username) {
-            errors.password = this.props.intl.formatMessage({id: 'registration.validationPasswordNotUsername'});
         }
         const passwordConfirmResult = validate.validatePasswordConfirm(values.password, values.passwordConfirm);
         if (!passwordConfirmResult.valid) {
@@ -105,6 +102,7 @@ class UsernameStep extends React.Component {
                         errors,
                         handleSubmit,
                         isSubmitting,
+                        setFieldError,
                         validateField,
                         values
                     } = props;
@@ -123,15 +121,17 @@ class UsernameStep extends React.Component {
                                 </div>
                                 <FormikInput
                                     className={classNames(
-                                        'join-flow-input',
-                                        {fail: errors.username}
+                                        'join-flow-input'
                                     )}
                                     error={errors.username}
                                     id="username"
                                     name="username"
                                     validate={this.validateUsernameIfPresent}
                                     validationClassName="validation-full-width-input"
-                                    onBlur={() => validateField('username')} // eslint-disable-line react/jsx-no-bind
+                                    /* eslint-disable react/jsx-no-bind */
+                                    onBlur={() => validateField('username')}
+                                    onFocus={() => setFieldError('username', null)}
+                                    /* eslint-enable react/jsx-no-bind */
                                 />
                                 <div className="join-flow-password-section">
                                     <div className="join-flow-input-title">
@@ -139,23 +139,22 @@ class UsernameStep extends React.Component {
                                     </div>
                                     <FormikInput
                                         className={classNames(
-                                            'join-flow-input',
-                                            {fail: errors.password}
+                                            'join-flow-input'
                                         )}
                                         error={errors.password}
                                         id="password"
                                         name="password"
                                         type={this.state.showPassword ? 'text' : 'password'}
-                                        validate={this.validatePasswordIfPresent}
-                                        validationClassName="validation-full-width-input"
                                         /* eslint-disable react/jsx-no-bind */
+                                        validate={password => this.validatePasswordIfPresent(password, values.username)}
+                                        validationClassName="validation-full-width-input"
                                         onBlur={() => validateField('password')}
+                                        onFocus={() => setFieldError('password', null)}
                                         /* eslint-enable react/jsx-no-bind */
                                     />
                                     <FormikInput
                                         className={classNames(
-                                            'join-flow-input',
-                                            {fail: errors.passwordConfirm}
+                                            'join-flow-input'
                                         )}
                                         error={errors.passwordConfirm}
                                         id="passwordConfirm"
@@ -170,6 +169,7 @@ class UsernameStep extends React.Component {
                                         onBlur={() =>
                                             validateField('passwordConfirm')
                                         }
+                                        onFocus={() => setFieldError('passwordConfirm', null)}
                                         /* eslint-enable react/jsx-no-bind */
                                     />
                                     <div className="join-flow-input-title">

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -40,13 +40,21 @@ module.exports.validateUsernameRemotely = username => (
     })
 );
 
-module.exports.validatePassword = password => {
+/**
+ * Validate password value, optionally also considering username value
+ * @param  {string} password     password value to validate
+ * @param  {string} username     username value to compare
+ * @return {object}              {valid: boolean, errMsgId: string}
+ */
+module.exports.validatePassword = (password, username) => {
     if (!password) {
         return {valid: false, errMsgId: 'form.validationRequired'};
     } else if (password.length < 6) {
         return {valid: false, errMsgId: 'registration.validationPasswordLength'};
     } else if (password === 'password') {
         return {valid: false, errMsgId: 'registration.validationPasswordNotEquals'};
+    } else if (username && password === username) {
+        return {valid: false, errMsgId: 'registration.validationPasswordNotUsername'};
     }
     return {valid: true};
 };

--- a/test/unit/lib/validate.test.js
+++ b/test/unit/lib/validate.test.js
@@ -39,6 +39,10 @@ describe('unit test lib/validate.js', () => {
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordLength'});
         response = validate.validatePassword('password');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordNotEquals'});
+        response = validate.validatePassword('abcdefg', 'abcdefg');
+        expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordNotUsername'});
+        response = validate.validatePassword('abcdefg', 'abcdefG');
+        expect(response).toEqual({valid: true});
     });
 
     test('validate password confirm', () => {


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* Focusing on a field clears the error (until field is blurred again)
* If username and password are the same, password field reports error right away (instead of waiting for user to click "Next")
* Design of inputs with an error that are focused on are no longer a weird combination of blue and orange borders!

### Screenshots

Focusing on a field clears the error (until field is blurred again):

![clearerror](https://user-images.githubusercontent.com/3431616/62816787-86f05b00-bafa-11e9-9c1b-06e6a14f7d21.gif)

If username and password are the same, password field reports error right away (instead of waiting for user to click "Next"):

![errorrightaway](https://user-images.githubusercontent.com/3431616/62816799-996a9480-bafa-11e9-8b43-26f979cf4388.gif)
