### PR TITLE
make join flow steps' vertical size consistent, make vertical spacing more flexible

### DIFF
--- a/src/components/join-flow/birthdate-step.jsx
+++ b/src/components/join-flow/birthdate-step.jsx
@@ -89,6 +89,7 @@ class BirthDateStep extends React.Component {
                             description={this.props.intl.formatMessage({id: 'registration.private'})}
                             headerImgSrc="/images/hoc/getting-started.jpg"
                             infoMessage={this.props.intl.formatMessage({id: 'registration.birthDateStepInfo'})}
+                            innerClassName="join-flow-inner-birthdate-step"
                             title={this.props.intl.formatMessage({id: 'registration.birthDateStepTitle'})}
                             waiting={isSubmitting}
                             onSubmit={handleSubmit}

--- a/src/components/join-flow/country-step.jsx
+++ b/src/components/join-flow/country-step.jsx
@@ -69,6 +69,7 @@ class CountryStep extends React.Component {
                         <JoinFlowStep
                             description={this.props.intl.formatMessage({id: 'registration.countryStepDescription'})}
                             headerImgSrc="/images/hoc/getting-started.jpg"
+                            innerClassName="join-flow-inner-country-step"
                             title={this.props.intl.formatMessage({id: 'registration.countryStepTitle'})}
                             waiting={isSubmitting}
                             onSubmit={handleSubmit}

--- a/src/components/join-flow/email-step.jsx
+++ b/src/components/join-flow/email-step.jsx
@@ -73,7 +73,7 @@ class EmailStep extends React.Component {
                                 />
                             )}
                             headerImgSrc="/images/hoc/getting-started.jpg"
-                            innerContentClassName="modal-inner-content-email"
+                            innerClassName="join-flow-inner-email-step"
                             nextButton={this.props.intl.formatMessage({id: 'registration.createAccount'})}
                             title={this.props.intl.formatMessage({id: 'registration.emailStepTitle'})}
                             waiting={isSubmitting}

--- a/src/components/join-flow/gender-step.jsx
+++ b/src/components/join-flow/gender-step.jsx
@@ -80,9 +80,9 @@ class GenderStep extends React.Component {
                     } = props;
                     return (
                         <JoinFlowStep
-                            className="join-flow-gender-step"
                             description={this.props.intl.formatMessage({id: 'registration.genderStepDescription'})}
                             infoMessage={this.props.intl.formatMessage({id: 'registration.genderStepInfo'})}
+                            innerClassName="join-flow-inner-gender-step"
                             title={this.props.intl.formatMessage({id: 'registration.genderStepTitle'})}
                             waiting={isSubmitting}
                             onSubmit={handleSubmit}

--- a/src/components/join-flow/gender-step.jsx
+++ b/src/components/join-flow/gender-step.jsx
@@ -81,6 +81,7 @@ class GenderStep extends React.Component {
                     return (
                         <JoinFlowStep
                             description={this.props.intl.formatMessage({id: 'registration.genderStepDescription'})}
+                            descriptionClassName="join-flow-gender-description"
                             infoMessage={this.props.intl.formatMessage({id: 'registration.genderStepInfo'})}
                             innerClassName="join-flow-inner-gender-step"
                             title={this.props.intl.formatMessage({id: 'registration.genderStepTitle'})}

--- a/src/components/join-flow/join-flow-step.jsx
+++ b/src/components/join-flow/join-flow-step.jsx
@@ -11,68 +11,67 @@ require('./join-flow-step.scss');
 
 const JoinFlowStep = ({
     children,
-    className,
+    innerClassName,
     description,
     footerContent,
     headerImgSrc,
     infoMessage,
-    innerContentClassName,
     nextButton,
     onSubmit,
     title,
     waiting
 }) => (
     <form onSubmit={onSubmit}>
-        {headerImgSrc && (
-            <div className="join-flow-header-image">
-                <img src={headerImgSrc} />
+        <div className="join-flow-outer-content">
+            {headerImgSrc && (
+                <div className="join-flow-header-image">
+                    <img src={headerImgSrc} />
+                </div>
+            )}
+            <div>
+                <ModalInnerContent
+                    className={classNames(
+                        'join-flow-inner-content',
+                        innerClassName
+                    )}
+                >
+                    {title && (
+                        <ModalTitle
+                            className="join-flow-title"
+                            title={title}
+                        />
+                    )}
+                    {description && (
+                        <div className="join-flow-description">
+                            {description}
+                            {infoMessage && (
+                                <InfoButton message={infoMessage} />
+                            )}
+                        </div>
+                    )}
+                    {children}
+                </ModalInnerContent>
             </div>
-        )}
-        <div>
-            <ModalInnerContent
-                className={classNames(
-                    'join-flow-inner-content',
-                    className,
-                    innerContentClassName
-                )}
-            >
-                {title && (
-                    <ModalTitle
-                        className="join-flow-title"
-                        title={title}
-                    />
-                )}
-                {description && (
-                    <div className="join-flow-description">
-                        {description}
-                        {infoMessage && (
-                            <InfoButton message={infoMessage} />
-                        )}
-                    </div>
-                )}
-                {children}
-            </ModalInnerContent>
+            {footerContent && (
+                <div className="join-flow-footer-message">
+                    {footerContent}
+                </div>
+            )}
+            <NextStepButton
+                content={nextButton}
+                waiting={waiting}
+            />
         </div>
-        {footerContent && (
-            <div className="join-flow-footer-message">
-                {footerContent}
-            </div>
-        )}
-        <NextStepButton
-            content={nextButton}
-            waiting={waiting}
-        />
     </form>
 );
 
 JoinFlowStep.propTypes = {
     children: PropTypes.node,
-    className: PropTypes.string,
     description: PropTypes.string,
     footerContent: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     headerImgSrc: PropTypes.string,
     infoMessage: PropTypes.string,
-    innerContentClassName: PropTypes.string,
+    innerClassName: PropTypes.string,
     nextButton: PropTypes.node,
     onSubmit: PropTypes.func,
     title: PropTypes.string,

--- a/src/components/join-flow/join-flow-step.jsx
+++ b/src/components/join-flow/join-flow-step.jsx
@@ -13,6 +13,7 @@ const JoinFlowStep = ({
     children,
     innerClassName,
     description,
+    descriptionClassName,
     footerContent,
     headerImgSrc,
     infoMessage,
@@ -42,7 +43,12 @@ const JoinFlowStep = ({
                         />
                     )}
                     {description && (
-                        <div className="join-flow-description">
+                        <div
+                            className={classNames(
+                                'join-flow-description',
+                                descriptionClassName
+                            )}
+                        >
                             {description}
                             {infoMessage && (
                                 <InfoButton message={infoMessage} />
@@ -68,6 +74,7 @@ const JoinFlowStep = ({
 JoinFlowStep.propTypes = {
     children: PropTypes.node,
     description: PropTypes.string,
+    descriptionClassName: PropTypes.string,
     footerContent: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     headerImgSrc: PropTypes.string,
     infoMessage: PropTypes.string,

--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -1,6 +1,19 @@
 @import "../../colors";
 @import "../../frameless";
 
+.join-flow-outer-content {
+    height: 32.5rem;
+}
+
+.join-flow-inner-content {
+    box-shadow: none;
+    width: calc(100% - 5.875rem);
+    /* must use padding for top, rather than margin, because margins will collapse */
+    margin: 0 auto;
+    padding: 2.3125rem 0 2.5rem;
+    font-size: .875rem;
+}
+
 .join-flow-title {
     color: $type-gray;
     font-size: 1.875rem;
@@ -13,15 +26,6 @@
     margin-top: 0.78125rem;
     margin-bottom: 1.875rem;
     text-align: center;
-}
-
-.join-flow-inner-content {
-    box-shadow: none;
-    width: calc(100% - 5.875rem);
-    /* must use padding for top, rather than margin, because margins will collapse */
-    margin: 0 auto;
-    padding: 2.3125rem 0 2.5rem;
-    font-size: .875rem;
 }
 
 /* overflow will only work if this class is set on parent of img, not img itself */

--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -2,7 +2,11 @@
 @import "../../frameless";
 
 .join-flow-outer-content {
-    height: 32.5rem;
+    /* hopefully this lets text expand the height of the modal, if need be */
+    min-height: 32.5rem;
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
 }
 
 .join-flow-inner-content {

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -129,10 +129,6 @@
     margin-left: .5rem;
 }
 
-.modal-inner-content-email {
-    padding-top: 2.9rem;
-}
-
 a.join-flow-link:link, a.join-flow-link:visited, a.join-flow-link:active {
     text-decoration: underline;
 }

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -74,8 +74,29 @@
     margin: 0 auto;
 }
 
-.join-flow-gender-step {
+.join-flow-inner-username-step {
+    padding-top: 2.75rem;
+}
+
+.join-flow-inner-birthdate-step {
+    padding-top: 3.5rem;
+}
+
+.join-flow-inner-gender-step {
+    /* need height so that flex will adjust children proportionately */
     height: 27.375rem;
+    padding-top: 2.5rem;
+}
+
+.join-flow-inner-country-step {
+    padding-top: 3.25rem;
+}
+
+.join-flow-inner-email-step {
+    padding-top: 3rem;
+}
+
+.join-flow-inner-welcome-step {
     padding-top: 3rem;
 }
 

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -84,9 +84,9 @@
 
 .join-flow-inner-gender-step {
     /* need height so that flex will adjust children proportionately */
-    height: 27.375rem;
-    padding-top: 2.5rem;
-    padding-bottom: 1.5rem;
+    height: 27.25rem;
+    padding-top: 2.625rem;
+    padding-bottom: 1rem;
 }
 
 .join-flow-inner-country-step {

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -86,6 +86,7 @@
     /* need height so that flex will adjust children proportionately */
     height: 27.375rem;
     padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
 }
 
 .join-flow-inner-country-step {
@@ -98,6 +99,11 @@
 
 .join-flow-inner-welcome-step {
     padding-top: 3rem;
+}
+
+.join-flow-gender-description {
+    margin-top: .625rem;
+    margin-bottom: 1.25rem;
 }
 
 .gender-radio-row {

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -118,6 +118,7 @@ class UsernameStep extends React.Component {
                             description={this.props.intl.formatMessage({
                                 id: 'registration.usernameStepDescriptionNonEducator'
                             })}
+                            innerClassName="join-flow-inner-username-step"
                             title={this.props.intl.formatMessage({id: 'general.joinScratch'})}
                             waiting={isSubmitting}
                             onSubmit={handleSubmit}

--- a/src/components/join-flow/welcome-step.jsx
+++ b/src/components/join-flow/welcome-step.jsx
@@ -45,6 +45,7 @@ class WelcomeStep extends React.Component {
                                 id: 'registration.welcomeStepDescriptionNonEducator'
                             })}
                             headerImgSrc="/images/hoc/getting-started.jpg"
+                            innerClassName="join-flow-inner-welcome-step"
                             nextButton={
                                 <React.Fragment>
                                     <FormattedMessage id="registration.makeProject" />


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* add join-flow-outer-content class, to make step heights consistent
* allow custom padding above join flow titles, to adjust for whitespace balance
* join-flow-step accepts a descriptionClassName which formats description; gender uses this
* allow steps to expand vertically as content is introduced, or translations run long
