### PR TITLE
Allow admins to delete comments without confirmation

### DIFF
--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -54,7 +54,11 @@ class Comment extends React.Component {
     }
 
     handleDelete () {
-        this.setState({deleting: true});
+        if (this.props.canDeleteWithoutConfirm) {
+            this.props.onDelete(this.props.id);
+        } else {
+            this.setState({deleting: true});
+        }
     }
 
     handleConfirmDelete () {
@@ -267,6 +271,7 @@ Comment.propTypes = {
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,
+    canDeleteWithoutConfirm: PropTypes.bool,
     canReply: PropTypes.bool,
     canReport: PropTypes.bool,
     canRestore: PropTypes.bool,

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -74,6 +74,7 @@ class TopLevelComment extends React.Component {
         const {
             author,
             canDelete,
+            canDeleteWithoutConfirm,
             canReply,
             canReport,
             canRestore,
@@ -103,6 +104,7 @@ class TopLevelComment extends React.Component {
                         content,
                         datetimeCreated,
                         canDelete,
+                        canDeleteWithoutConfirm,
                         canReply,
                         canReport,
                         canRestore,
@@ -126,6 +128,7 @@ class TopLevelComment extends React.Component {
                             <Comment
                                 author={reply.author}
                                 canDelete={canDelete}
+                                canDeleteWithoutConfirm={canDeleteWithoutConfirm}
                                 canReply={canReply}
                                 canReport={canReport}
                                 canRestore={canRestore && parentVisible}
@@ -168,6 +171,7 @@ TopLevelComment.propTypes = {
         username: PropTypes.string
     }),
     canDelete: PropTypes.bool,
+    canDeleteWithoutConfirm: PropTypes.bool,
     canReply: PropTypes.bool,
     canReport: PropTypes.bool,
     canRestore: PropTypes.bool,
@@ -190,6 +194,7 @@ TopLevelComment.propTypes = {
 };
 
 TopLevelComment.defaultProps = {
+    canDeleteWithoutConfirm: false,
     defaultExpanded: false,
     moreRepliesToLoad: false
 };

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -599,6 +599,7 @@ const PreviewPresentation = ({
                                             <TopLevelComment
                                                 author={comment.author}
                                                 canDelete={canDeleteComments}
+                                                canDeleteWithoutConfirm={isAdmin}
                                                 canReply={isLoggedIn && projectInfo.comments_allowed && isShared}
                                                 canReport={isLoggedIn}
                                                 canRestore={canRestoreComments}


### PR DESCRIPTION
Requested mod feature, do not show the "Are you sure you want to delete and not report?" modal for project comments if the user is an admin.