### PR TITLE
use media queries to make info message responsive

### DIFF
--- a/src/components/info-button/info-button.jsx
+++ b/src/components/info-button/info-button.jsx
@@ -1,6 +1,9 @@
 const bindAll = require('lodash.bindall');
 const PropTypes = require('prop-types');
 const React = require('react');
+const MediaQuery = require('react-responsive').default;
+
+const frameless = require('../../lib/frameless');
 
 require('./info-button.scss');
 
@@ -22,25 +25,38 @@ class InfoButton extends React.Component {
         this.setState({visible: true});
     }
     render () {
-        return (
-            <div
-                className="info-button"
-                onClick={this.handleShowMessage}
-                onMouseOut={this.handleHideMessage}
-                onMouseOver={this.handleShowMessage}
-            >
-                {this.state.visible && (
-                    <div className="info-button-message">
-                        {this.props.message}
-                    </div>
-                )}
+        const messageJsx = this.state.visible && (
+            <div className="info-button-message">
+                {this.props.message}
             </div>
+        );
+        return (
+            <React.Fragment>
+                <div
+                    className="info-button"
+                    onClick={this.handleShowMessage}
+                    onMouseOut={this.handleHideMessage}
+                    onMouseOver={this.handleShowMessage}
+                >
+                    <MediaQuery minWidth={frameless.desktop}>
+                        {messageJsx}
+                    </MediaQuery>
+                </div>
+                {/* for small screens, add additional position: relative element,
+                    so info message can position itself relative to the width which
+                    encloses info-button -- rather than relative to info-button itself */}
+                <MediaQuery maxWidth={frameless.desktop - 1}>
+                    <div style={{position: 'relative'}}>
+                        {messageJsx}
+                    </div>
+                </MediaQuery>
+            </React.Fragment>
         );
     }
 }
 
 InfoButton.propTypes = {
-    message: PropTypes.string
+    message: PropTypes.string.isRequired
 };
 
 module.exports = InfoButton;

--- a/src/components/info-button/info-button.scss
+++ b/src/components/info-button/info-button.scss
@@ -65,11 +65,12 @@
 
 @media #{$intermediate-and-smaller} {
     .info-button-message {
-        position: relative;
+        position: absolute;
         transform: none;
-        margin: inherit;
-        width: 100%;
-        height: inherit;
+        /* since we're positioning message relative to info-button's parent,
+        we need to center this element within its width. */
+        margin: 0 calc((100% - 16.5rem) / 2);;
+        top: .125rem;
 
         &:before {
             display: none;

--- a/test/__mocks__/react-responsive.js
+++ b/test/__mocks__/react-responsive.js
@@ -1,0 +1,5 @@
+// __mocks__/react-responsive.js
+
+const MediaQuery = ({children}) => children;
+
+export default MediaQuery;

--- a/test/unit/components/info-button.test.jsx
+++ b/test/unit/components/info-button.test.jsx
@@ -11,6 +11,15 @@ describe('InfoButton', () => {
         );
         expect(component.find('div.info-button-message').exists()).toEqual(false);
     });
+    test('mouseOver on info button makes info message visible', () => {
+        const component = mountWithIntl(
+            <InfoButton
+                message="Here is some info about something!"
+            />
+        );
+        component.find('div.info-button').simulate('mouseOver');
+        expect(component.find('div.info-button-message').exists()).toEqual(true);
+    });
     test('clicking on info button makes info message visible', () => {
         const component = mountWithIntl(
             <InfoButton
@@ -26,7 +35,7 @@ describe('InfoButton', () => {
                 message="Here is some info about something!"
             />
         );
-        component.find('div.info-button').simulate('click');
+        component.find('div.info-button').simulate('mouseOver');
         expect(component.find('div.info-button-message').exists()).toEqual(true);
         component.find('div.info-button').simulate('mouseOut');
         expect(component.find('div.info-button-message').exists()).toEqual(false);


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* uses media queries in both jsx and sass to handle info button differently in small screen sizes

For small screen sizes, we keep the info message absolutely positioned, but instead of the reference parent element with `position: relative` being the info icon itself, we make a new div, a sibling to the icon, with `position: relative`.

This creates a new row, which is where the info message positions itself.

Since the message is absolutely positioned, it overlaps content below (rather than causing the enclosing modal or other element to have to change form).

### Screenshots

wide window/screen (>= 942px):

![image](https://user-images.githubusercontent.com/3431616/63219181-b04d5e80-c16c-11e9-9e90-45a99187d4b0.png)

small window/screen (< 942px):

![image](https://user-images.githubusercontent.com/3431616/63219190-d246e100-c16c-11e9-8b6e-9cd5d752c9d3.png)
