### PR TITLE
added placeholders to username step

### DIFF
--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -133,6 +133,7 @@ class UsernameStep extends React.Component {
                                     error={errors.username}
                                     id="username"
                                     name="username"
+                                    placeholder={this.props.intl.formatMessage({id: 'general.username'})}
                                     validate={this.validateUsernameIfPresent}
                                     validationClassName="validation-full-width-input"
                                     /* eslint-disable react/jsx-no-bind */
@@ -154,6 +155,7 @@ class UsernameStep extends React.Component {
                                         error={errors.password}
                                         id="password"
                                         name="password"
+                                        placeholder={this.props.intl.formatMessage({id: 'general.password'})}
                                         type={values.showPassword ? 'text' : 'password'}
                                         /* eslint-disable react/jsx-no-bind */
                                         validate={password => this.validatePasswordIfPresent(password, values.username)}
@@ -174,6 +176,9 @@ class UsernameStep extends React.Component {
                                         error={errors.passwordConfirm}
                                         id="passwordConfirm"
                                         name="passwordConfirm"
+                                        placeholder={this.props.intl.formatMessage({
+                                            id: 'registration.confirmPasswordInstruction'
+                                        })}
                                         type={values.showPassword ? 'text' : 'password'}
                                         /* eslint-disable react/jsx-no-bind */
                                         validate={() =>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -157,6 +157,7 @@
     "registration.generalError": "Sorry, an unexpected error occurred.",
     "registration.classroomInviteExistingStudentStepDescription": "you have been invited to join the class:",
     "registration.classroomInviteNewStudentStepDescription": "Your teacher has invited you to join a class:",
+    "registration.confirmPasswordInstruction": "Type password again",
     "registration.confirmYourEmail": "Confirm Your Email",
     "registration.confirmYourEmailDescription": "If you haven't already, please click the link in the confirmation email sent to:",
     "registration.createAccount": "Create Account",


### PR DESCRIPTION
Note: styling depends on https://github.com/LLK/scratch-www/pull/3265 being merged first.

### Resolves:

Step towards resolving #3053

### Changes:

Adds placeholders to username, password and passwordConfirm fields.

Note that these won't be formatted correctly until https://github.com/LLK/scratch-www/pull/3265 is merged.

