### PR TITLE
make gender radio rows center themselves horizontally within the modal

### DIFF
--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -117,7 +117,7 @@
     height: 2.85rem;
     background-color: $ui-gray;
     border-radius: .5rem;
-    margin-bottom: 0.375rem;
+    margin: 0 auto 0.375rem;
     padding-left: 0.8125rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* use `margin: auto` to make gender radio rows center themselves horizontally within the modal

Before:

![image](https://user-images.githubusercontent.com/3431616/63416696-2fa69080-c400-11e9-99ae-acec9f4ca3be.png)

After:

![image](https://user-images.githubusercontent.com/3431616/63416699-3208ea80-c400-11e9-829c-7876e0384889.png)
