### PR TITLE
improve top and bottom positioning for multiple steps

### DIFF
--- a/src/components/join-flow/country-step.jsx
+++ b/src/components/join-flow/country-step.jsx
@@ -68,6 +68,7 @@ class CountryStep extends React.Component {
                     return (
                         <JoinFlowStep
                             description={this.props.intl.formatMessage({id: 'registration.countryStepDescription'})}
+                            descriptionClassName="join-flow-country-description"
                             headerImgSrc="/images/join-flow/country-header.png"
                             innerClassName="join-flow-inner-country-step"
                             title={this.props.intl.formatMessage({id: 'registration.countryStepTitle'})}

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -79,7 +79,8 @@
 }
 
 .join-flow-inner-birthdate-step {
-    padding-top: 3.5rem;
+    padding-top: 1rem;
+    padding-bottom: 2.25rem;
 }
 
 .join-flow-inner-gender-step {
@@ -90,7 +91,8 @@
 }
 
 .join-flow-inner-country-step {
-    padding-top: 3.25rem;
+    padding-top: 1rem;
+    padding-bottom: 2rem;
 }
 
 .join-flow-inner-email-step {
@@ -102,13 +104,19 @@
 }
 
 .join-flow-birthdate-description {
-    margin-left: -.5rem;
+    margin-top: 1.25rem;
     margin-right: -.5rem;
+    margin-bottom: 2rem;
+    margin-left: -.5rem;
 }
 
 .join-flow-gender-description {
     margin-top: .625rem;
     margin-bottom: 1.25rem;
+}
+
+.join-flow-country-description {
+    margin-top: 1rem;
 }
 
 .gender-radio-row {


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* Adjusts vertical padding for the birthdate and country steps, including spacing around description
* Adjusts width of birthdate message, so info button won't wrap in English

### Screenshots:

#### Before:

![image](https://user-images.githubusercontent.com/3431616/63417138-fcb0cc80-c400-11e9-9c7b-63db9670ed0c.png)

![image](https://user-images.githubusercontent.com/3431616/63417144-ff132680-c400-11e9-9335-70f49b5e509d.png)


#### After:

![image](https://user-images.githubusercontent.com/3431616/63417150-00dcea00-c401-11e9-9784-95f08798e4d0.png)

![image](https://user-images.githubusercontent.com/3431616/63417698-0f77d100-c402-11e9-978b-831ca6a9f4f2.png)
