### PR TITLE
formik-select handles fail state with orange border

### DIFF
--- a/src/components/formik-forms/formik-select.jsx
+++ b/src/components/formik-forms/formik-select.jsx
@@ -1,4 +1,3 @@
-const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
 import {Field} from 'formik';
@@ -7,6 +6,7 @@ const ValidationMessage = require('../forms/validation-message.jsx');
 
 require('../forms/select.scss');
 require('../forms/row.scss');
+require('./formik-select.scss');
 
 const FormikSelect = ({
     className,
@@ -27,9 +27,7 @@ const FormikSelect = ({
     return (
         <div className="select row-with-tooltip">
             <Field
-                className={classNames(
-                    className
-                )}
+                className={className}
                 component="select"
                 {...props}
             >

--- a/src/components/formik-forms/formik-select.scss
+++ b/src/components/formik-forms/formik-select.scss
@@ -1,0 +1,12 @@
+@import "../../colors";
+
+.select {
+    .fail {
+        border: 1px solid $ui-orange;
+
+        &:focus {
+            box-shadow: 0 0 0 .25rem $ui-orange-25percent;
+            outline: none;
+        }
+    }
+}


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* creates `formik-select.scss` file which contains orange fail state
* simplifies a few lines of `formik-select.jsx` where className is handled

![image](https://user-images.githubusercontent.com/3431616/63427031-77371780-c414-11e9-9f44-c499b018c62a.png)
