### PR TITLE
on complete join flow, take user to new project

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -217,6 +217,7 @@ class Navigation extends React.Component {
                     {this.props.registrationOpen && (
                         this.props.useScratch3Registration ? (
                             <Scratch3Registration
+                                createProjectOnComplete
                                 isOpen
                                 key="scratch3registration"
                             />

--- a/src/components/registration/scratch3-registration.jsx
+++ b/src/components/registration/scratch3-registration.jsx
@@ -23,17 +23,22 @@ const Registration = ({
 );
 
 Registration.propTypes = {
+    createProjectOnComplete: PropTypes.bool,
     handleCloseRegistration: PropTypes.func,
     handleCompleteRegistration: PropTypes.func,
     isOpen: PropTypes.bool
 };
 
-const mapDispatchToProps = dispatch => ({
+Registration.defaultProps = {
+    createProjectOnComplete: false
+};
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
     handleCloseRegistration: () => {
         dispatch(navigationActions.setRegistrationOpen(false));
     },
     handleCompleteRegistration: () => {
-        dispatch(navigationActions.handleCompleteRegistration());
+        dispatch(navigationActions.handleCompleteRegistration(ownProps.createProjectOnComplete));
     }
 });
 

--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -92,9 +92,10 @@ module.exports.setSearchTerm = searchTerm => ({
     searchTerm: searchTerm
 });
 
-module.exports.handleCompleteRegistration = () => (dispatch => {
+module.exports.handleCompleteRegistration = createProject => (dispatch => {
     dispatch(sessionActions.refreshSession());
     dispatch(module.exports.setRegistrationOpen(false));
+    if (createProject) window.location = '/projects/editor/?tutorial=getStarted';
 });
 
 module.exports.handleLogIn = (formData, callback) => (dispatch => {


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* adds prop to new join flow called `createProjectOnComplete`
* when `createProjectOnComplete` is true, on completing join flow, user will be redirected to the `/projects/editor/?tutorial=getStarted` page

### Test Coverage:

none