### PR TITLE
make password font size large, if password hidden

### DIFF
--- a/src/components/formik-forms/formik-input.scss
+++ b/src/components/formik-forms/formik-input.scss
@@ -5,7 +5,7 @@
     border-radius: .5rem;
     background-color: $ui-white;
     margin-bottom: .5rem;
-    transition: all .5s ease;
+    transition: all .5s ease, font-size 0s;
     border: 1px solid $active-gray;
     padding: 0 1rem;
     color: $type-gray;
@@ -15,6 +15,7 @@
         box-shadow: 0 0 0 .25rem $ui-blue-25percent;
         outline: none;
         border: 1px solid $ui-blue;
+        transition: all .5s ease, font-size 0s;
     }
 
     &.fail {

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -13,6 +13,10 @@
     }
 }
 
+.join-flow-input-password {
+    font-size: 1.5rem;
+}
+
 .join-flow-password-confirm {
     margin-bottom: .6875rem;
 }

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -176,7 +176,9 @@ class UsernameStep extends React.Component {
                                     </div>
                                     <FormikInput
                                         className={classNames(
-                                            'join-flow-input'
+                                            'join-flow-input',
+                                            {'join-flow-input-password':
+                                                !values.showPassword && values.password.length > 0}
                                         )}
                                         error={errors.password}
                                         id="password"
@@ -201,7 +203,11 @@ class UsernameStep extends React.Component {
                                         className={classNames(
                                             'join-flow-input',
                                             'join-flow-password-confirm',
-                                            {fail: errors.passwordConfirm}
+                                            {
+                                                'join-flow-input-password':
+                                                    !values.showPassword && values.passwordConfirm.length > 0,
+                                                'fail': errors.passwordConfirm
+                                            }
                                         )}
                                         error={errors.passwordConfirm}
                                         id="passwordConfirm"


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

* makes font size of password inputs 1.5rem, if and only if password is hidden/masked
* makes exception to css transition for font-size changes, so change is not animated

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/3431616/63804366-047ede00-c8e5-11e9-8237-a94ac7d7dd4a.png)

After:

![image](https://user-images.githubusercontent.com/3431616/63804352-fa5cdf80-c8e4-11e9-839c-f58a8997fe6c.png)

Plaintext:

![image](https://user-images.githubusercontent.com/3431616/63804345-f6c95880-c8e4-11e9-826b-b7a310d41953.png)

