### PR TITLE
restore default orange background color for validation tooltips

### DIFF
--- a/src/components/forms/validation-message.scss
+++ b/src/components/forms/validation-message.scss
@@ -11,6 +11,7 @@
     margin-left: $arrow-border-width;
     border: 1px solid $active-gray;
     border-radius: 5px;
+    background-color: $ui-orange;
     padding: 1rem;
     max-width: 18.75rem;
     min-height: 1rem;
@@ -30,6 +31,7 @@
         border-left: 1px solid $active-gray;
         border-radius: 5px;
 
+        background-color: $ui-orange;
         width: $arrow-border-width;
         height: $arrow-border-width;
 


### PR DESCRIPTION
### Changes:

Replaces a css style that was erroneously removed in #3251. 

### Before this change:

![image](https://user-images.githubusercontent.com/3431616/63822787-88ee5280-c91f-11e9-906d-3e9cdba19787.png)

### After this change:

![image](https://user-images.githubusercontent.com/3431616/63822794-8db30680-c91f-11e9-8c87-eff1aec5f829.png)
