### PR TITLE
restyle next button to remove border, add hover color

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -8,7 +8,7 @@ $ui-orange: hsla(38, 100, 55, 1); // #FFAB19 Control Primary
 $ui-orange-high-contrast: hsla(30, 100, 55, 1); // #FFAB19 Control Primary
 $ui-orange-10percent: hsla(35, 90, 55, .1);
 $ui-orange-25percent: hsla(35, 90, 55, .25);
-$ui-orange-75percent: hsla(38, 100, 55, .75);
+$ui-orange-90percent: hsla(38, 100, 55, .9);
 
 $ui-dark-orange: hsla(30, 100, 55, 1); // ##FF8C1A Variables Primary
 

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -8,6 +8,7 @@ $ui-orange: hsla(38, 100, 55, 1); // #FFAB19 Control Primary
 $ui-orange-high-contrast: hsla(30, 100, 55, 1); // #FFAB19 Control Primary
 $ui-orange-10percent: hsla(35, 90, 55, .1);
 $ui-orange-25percent: hsla(35, 90, 55, .25);
+$ui-orange-75percent: hsla(38, 100, 55, .75);
 
 $ui-dark-orange: hsla(30, 100, 55, 1); // ##FF8C1A Variables Primary
 

--- a/src/components/join-flow/next-step-button.scss
+++ b/src/components/join-flow/next-step-button.scss
@@ -4,10 +4,15 @@
 .modal-flush-bottom-button {
     margin: 0;
     width: 100%;
+    border: none;
     border-bottom-left-radius: 1rem;
     border-bottom-right-radius: 1rem;
     height: 5.1875rem;
     background-color: $ui-orange;
+
+    &:hover {
+        background-color: $ui-orange-75percent;
+    }
 }
 
 .next-step-title {

--- a/src/components/join-flow/next-step-button.scss
+++ b/src/components/join-flow/next-step-button.scss
@@ -11,7 +11,8 @@
     background-color: $ui-orange;
 
     &:hover {
-        background-color: $ui-orange-75percent;
+        transition: background-color .25s ease;
+        background-color: $ui-orange-90percent;
     }
 }
 


### PR DESCRIPTION
### Resolves:

Step towards resolving #3053

### Changes:

restyles next button to:
* remove border
* add hover color

My only questions are for @kathymakes:
1. what do you think of the hover color? 
2. do you think this merits adding a color to _colors.scss?

Note that in _colors.scss, there are actually two different hue/saturation values both called "orange" -- I'm not sure what the intention was with the 25 percent and 10 percent values.

No hover:

![image](https://user-images.githubusercontent.com/3431616/63864596-20828e00-c97e-11e9-9889-d03805e74d8e.png)

Yes hover:

![image](https://user-images.githubusercontent.com/3431616/63864605-22e4e800-c97e-11e9-9f0f-51626cc49ad8.png)

