### PR TITLE
Join flow standalone page

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -162,6 +162,13 @@
         "title": "Community Moderator"
     },
     {
+        "name": "join",
+        "pattern": "^/join/?$",
+        "routeAlias": "/join/?$",
+        "view": "join/join",
+        "title": "Join Scratch"
+    },
+    {
         "name": "messages",
         "pattern": "^/messages/?$",
         "routeAlias": "/messages(?!/ajax)",

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const render = require('../../lib/render.jsx');
 const JoinModal = require('../../components/modal/join/modal.jsx');
 const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx');
+// Require this even though we don't use it because, without it, webpack runs out of memory...
 const Page = require('../../components/page/www/page.jsx'); // eslint-disable-line no-unused-vars
 
 const openModal = true;

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -1,0 +1,15 @@
+const React = require('react');
+const render = require('../../lib/render.jsx');
+const JoinModal = require('../../components/modal/join/modal.jsx');
+const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx');
+
+const openModal = true;
+const Register = () => (
+    <ErrorBoundary>
+        <JoinModal
+            isOpen={openModal}
+            key="scratch3registration"
+        />
+    </ErrorBoundary>
+);
+render(<Register />, document.getElementById('app'));

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const render = require('../../lib/render.jsx');
 const JoinModal = require('../../components/modal/join/modal.jsx');
 const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx');
+const Page = require('../../components/page/www/page.jsx'); // eslint-disable-line no-unused-vars
 
 const openModal = true;
 const Register = () => (


### PR DESCRIPTION
Add a standalone page for the new join flow. It just includes the modal.  
WEIRD THING: The Page component is required but not used. Without that, webpack runs out of memory during UglifyJsPlugin step.