### PR TITLE
put back missing refreshSession() call

### DIFF
--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -96,6 +96,7 @@ module.exports.handleCompleteRegistration = createProject => (dispatch => {
     if (createProject) {
         window.location = '/projects/editor/?tutorial=getStarted';
     } else {
+        dispatch(sessionActions.refreshSession());
         dispatch(module.exports.setRegistrationOpen(false));
     }
 });


### PR DESCRIPTION
### Changes:

https://github.com/LLK/scratch-www/pull/3297 erroneously removed a call to `dispatch(sessionActions.refreshSession());`. This replaces it.

