### PR TITLE
Release Scratch Desktop 3.6.0

### DIFF
--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -114,8 +114,8 @@ class Download extends React.Component {
                                             className="download-button"
                                             href={
                                                 this.state.OS === OS_ENUM.WINDOWS ?
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.5.0.exe' :
-                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.5.0.dmg'
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.6.0.exe' :
+                                                    'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.6.0.dmg'
                                             }
                                         >
                                             <FormattedMessage id="download.downloadButton" />


### PR DESCRIPTION
### Changes:

Update Scratch Desktop download links for version 3.6.0

Closes #3344 
