### PR TITLE
FormsyProjectUpdater listens for changes to its props

### DIFF
--- a/src/views/preview/formsy-project-updater.jsx
+++ b/src/views/preview/formsy-project-updater.jsx
@@ -20,7 +20,13 @@ class FormsyProjectUpdater extends React.Component {
             error: false
         };
     }
-    componentDidUpdate () {
+    componentDidUpdate (prevProps) {
+        // listen for changes to initialValue; incoming changes override state.value
+        // NOTE: the problem is that on a slow connection, it can override your typing!!!!!!
+        if (this.props.initialValue != prevProps.initialValue &&
+            this.props.initialValue != this.state.value) {
+            this.setState({value: this.props.initialValue});
+        }
         if (this.state.error !== false) {
             const errorMessageId = this.state.error === 400 ?
                 'project.inappropriateUpdate' : 'general.notAvailableHeadline';


### PR DESCRIPTION
### Resolves:

Attempt to resolve https://github.com/LLK/scratch-www/issues/3349 . It does resolve that problem, but it introduces another problem, so I DON'T think this should be merged without further discussion.

### Changes:

In FormsyProjectUpdater, which handles updates for the project page's title, instructions and credits fields, this adds a test to see if the field's `initialValue` prop has changed; if so, it changes the field's current value to match.

My reasoning is:
* the overall source of truth for the field's value should be coming from outside the field; in this case, it is already coming from `projectInfo`, which is fetched from the backend
* we must deviate from that source temporarily while the user is editing the field; on blur, we submit the change to the backend
* usually that works out fine, because we assume the backend will eventually agree with the new text in the field. So the changed field matches the value of the field's outside source of truth.
* BUT there may be other actions that also change the source's value -- such as the title field in the editor.
* If the source's value changes without the field knowing about it, the field's value will become out of date.
* we need a mechanism to realize that the source's value has changed, or else we can get into a state with the wrong title in place.

Why this is tricky:

We can get into a state where the user's latest input is out of step with the source of truth. In that case, what should the field show?

### Before

The problem was that the project page title field would be completely wrong

![titleissue](https://user-images.githubusercontent.com/3431616/64921643-ab8fc080-d793-11e9-9a4c-d4a052115086.gif)

### After

The https://github.com/LLK/scratch-www/issues/3349 problem is fixed...

![whodis](https://user-images.githubusercontent.com/3431616/64921689-22c55480-d794-11e9-8660-1632a8888da6.gif)

...but now we have a new problem. If the user's connection is slow, the field can appear to suddenly reset itself to a prior value:

![Sep-15-2019 08-24-21](https://user-images.githubusercontent.com/3431616/64921646-b4809200-d793-11e9-9399-c80a946c5345.gif)

