### PR TITLE
move info button down, and give its message a shadow

### DIFF
--- a/src/components/info-button/info-button.jsx
+++ b/src/components/info-button/info-button.jsx
@@ -26,7 +26,7 @@ class InfoButton extends React.Component {
     }
     render () {
         const messageJsx = this.state.visible && (
-            <div className="info-button-message">
+            <div className="info-button-message validation-info">
                 {this.props.message}
             </div>
         );

--- a/src/components/info-button/info-button.jsx
+++ b/src/components/info-button/info-button.jsx
@@ -26,7 +26,7 @@ class InfoButton extends React.Component {
     }
     render () {
         const messageJsx = this.state.visible && (
-            <div className="info-button-message validation-info">
+            <div className="info-button-message">
                 {this.props.message}
             </div>
         );

--- a/src/components/info-button/info-button.scss
+++ b/src/components/info-button/info-button.scss
@@ -11,7 +11,7 @@
     background-color: $ui-blue;
     background-image: url("/svgs/info-button/info-button.svg");
     background-size: cover;
-    top: .125rem;
+    top: .1875rem;
 }
 
 .info-button-message {

--- a/src/components/info-button/info-button.scss
+++ b/src/components/info-button/info-button.scss
@@ -26,6 +26,7 @@
     margin-left: $arrow-border-width;
     border: 1px solid $active-gray;
     border-radius: 5px;
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .15);
     padding: .75rem;
     overflow: visible;
     background-color: $ui-blue;
@@ -33,6 +34,7 @@
     line-height: 1.25rem;
     text-align: left;
     font-size: .875rem;
+    font-weight: 500;
     z-index: 2;
 
     &:before {


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

Shifts info button downwards to be more in line with text; extends the shadow that we added to the validation message when it is in "suggestion" mode, to the info rollover window
