### PR TITLE
Include canonical link in project meta tags

### DIFF
--- a/src/views/preview/meta.jsx
+++ b/src/views/preview/meta.jsx
@@ -30,8 +30,8 @@ const Meta = props => {
                 property="og:description"
             />
             <link
-                rel="canonical"
                 href={`https://scratch.mit.edu/projects/${id}`}
+                rel="canonical"
             />
         </Helmet>
     );

--- a/src/views/preview/meta.jsx
+++ b/src/views/preview/meta.jsx
@@ -4,7 +4,7 @@ const Helmet = require('react-helmet').default;
 const projectShape = require('./projectshape.jsx').projectShape;
 
 const Meta = props => {
-    const {title, instructions, author} = props.projectInfo;
+    const {id, title, instructions, author} = props.projectInfo;
 
     // Do not want to render any meta tags unless all the info is loaded
     // Check only author (object) because it is ok to have empty string instructions
@@ -28,6 +28,10 @@ const Meta = props => {
             <meta
                 content={truncatedInstructions}
                 property="og:description"
+            />
+            <link
+                rel="canonical"
+                href={`https://scratch.mit.edu/projects/${id}`}
             />
         </Helmet>
     );


### PR DESCRIPTION
This will tell crawlers that this page and all its exact duplicates (/fullscreen, /editor, /embed, etc...) should be considered the same and use the project page as the canonical crawled page. We had an issue before where by not selected a canonical, google was considering all the project pages duplicates :(

### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Hopefully resolves a problem with public scratch projects not showing up on google.

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Add a canonical link to the project page template

/cc @rschamp we do not use a variable for the root url, so this won't be quite right in staging, but that isn't crawled anyway ;)