### PR TITLE
Join flow handle text overflow more flexibly

### DIFF
--- a/src/components/info-button/info-button.scss
+++ b/src/components/info-button/info-button.scss
@@ -7,6 +7,7 @@
     width: 1rem;
     height: 1rem;
     margin-left: .375rem;
+    margin-top: -.25rem;
     border-radius: 50%;
     background-color: $type-gray-60percent;
     background-image: url("/svgs/info-button/info-button.svg");

--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -27,7 +27,7 @@
 .join-flow-description {
     font-size: .875rem;
     font-weight: bold;
-    line-height: 1.37500rem;
+    line-height: 1.125rem;
     margin-top: 0.78125rem;
     margin-bottom: 1.875rem;
     text-align: center;

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -114,8 +114,6 @@
 }
 
 .join-flow-inner-gender-step {
-    /* need height so that flex will adjust children proportionately */
-    height: 27.25rem;
     padding-top: 2.625rem;
     padding-bottom: 1rem;
 }
@@ -177,7 +175,7 @@
 .gender-radio-row {
     transition: all .125s ease;
     width: 20.875rem;
-    height: 2.85rem;
+    min-height: 2.85rem;
     background-color: $ui-gray;
     border-radius: .5rem;
     margin: 0 auto 0.375rem;


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

CSS tweaks to make text appear more natural when it's longer than the strings we're defaulting to, e.g. for internationalization

Make info button not affect text line height

### Screenshots:

![image](https://user-images.githubusercontent.com/3431616/65360785-4131b280-dbcf-11e9-9b0b-ebc98155d6e1.png)

![image](https://user-images.githubusercontent.com/3431616/65360792-4bec4780-dbcf-11e9-815b-ffe22b7deb2d.png)

![image](https://user-images.githubusercontent.com/3431616/65360801-51e22880-dbcf-11e9-981c-cb1d3c1f02e8.png)

![image](https://user-images.githubusercontent.com/3431616/65360811-573f7300-dbcf-11e9-8025-e58d82cf7eda.png)

![image](https://user-images.githubusercontent.com/3431616/65360819-60304480-dbcf-11e9-94f5-4274c2287687.png)

![image](https://user-images.githubusercontent.com/3431616/65362151-5bba5a80-dbd4-11e9-80f3-fc0c7186f96c.png)
