### PR TITLE
scratch3 join flow redirects to /join, outside editor

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -18,7 +18,6 @@ const LoginDropdown = require('../../login/login-dropdown.jsx');
 const CanceledDeletionModal = require('../../login/canceled-deletion-modal.jsx');
 const NavigationBox = require('../base/navigation.jsx');
 const Registration = require('../../registration/registration.jsx');
-const Scratch3Registration = require('../../registration/scratch3-registration.jsx');
 const AccountNav = require('./accountnav.jsx');
 
 require('./navigation.scss');
@@ -28,6 +27,7 @@ class Navigation extends React.Component {
         super(props);
         bindAll(this, [
             'getProfileUrl',
+            'handleClickRegistration',
             'handleSearchSubmit'
         ]);
         this.state = {
@@ -77,6 +77,13 @@ class Navigation extends React.Component {
     getProfileUrl () {
         if (!this.props.user) return;
         return `/users/${this.props.user.username}/`;
+    }
+    handleClickRegistration (event) {
+        if (this.props.useScratch3Registration) {
+            this.props.navigateToRegistration(event);
+        } else {
+            this.props.handleOpenRegistration(event);
+        }
     }
     handleSearchSubmit (formData) {
         let targetUrl = '/search/projects';
@@ -191,7 +198,7 @@ class Navigation extends React.Component {
                             >
                                 <a
                                     href="#"
-                                    onClick={this.props.handleOpenRegistration}
+                                    onClick={this.handleClickRegistration}
                                 >
                                     <FormattedMessage id="general.joinScratch" />
                                 </a>
@@ -214,18 +221,10 @@ class Navigation extends React.Component {
                             </li>
                         ]) : []
                     }
-                    {this.props.registrationOpen && (
-                        this.props.useScratch3Registration ? (
-                            <Scratch3Registration
-                                createProjectOnComplete
-                                isOpen
-                                key="scratch3registration"
-                            />
-                        ) : (
-                            <Registration
-                                key="registration"
-                            />
-                        )
+                    {this.props.registrationOpen && !this.props.useScratch3Registration && (
+                        <Registration
+                            key="registration"
+                        />
                     )}
                 </ul>
                 <CanceledDeletionModal />
@@ -243,6 +242,7 @@ Navigation.propTypes = {
     handleToggleAccountNav: PropTypes.func,
     handleToggleLoginOpen: PropTypes.func,
     intl: intlShape,
+    navigateToRegistration: PropTypes.func,
     permissions: PropTypes.shape({
         admin: PropTypes.bool,
         social: PropTypes.bool,
@@ -304,6 +304,10 @@ const mapDispatchToProps = dispatch => ({
     handleToggleLoginOpen: event => {
         event.preventDefault();
         dispatch(navigationActions.toggleLoginOpen());
+    },
+    navigateToRegistration: event => {
+        event.preventDefault();
+        dispatch(navigationActions.navigateToRegistration());
     },
     setMessageCount: newCount => {
         dispatch(messageCountActions.setCount(newCount));

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -196,7 +196,10 @@ class Navigation extends React.Component {
                                 className="link right join"
                                 key="join"
                             >
+                                {/* there's no css class registrationLink -- this is
+                                just to make the link findable for testing */}
                                 <a
+                                    className="registrationLink"
                                     href="#"
                                     onClick={this.handleClickRegistration}
                                 >
@@ -307,16 +310,22 @@ const mapDispatchToProps = dispatch => ({
     },
     navigateToRegistration: event => {
         event.preventDefault();
-        dispatch(navigationActions.navigateToRegistration());
+        navigationActions.navigateToRegistration();
     },
     setMessageCount: newCount => {
         dispatch(messageCountActions.setCount(newCount));
     }
 });
 
+// Allow incoming props to override redux-provided props. Used to mock in tests.
+const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(
+    {}, stateProps, dispatchProps, ownProps
+);
+
 const ConnectedNavigation = connect(
     mapStateToProps,
-    mapDispatchToProps
+    mapDispatchToProps,
+    mergeProps
 )(Navigation);
 
 module.exports = injectIntl(ConnectedNavigation);

--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -92,6 +92,10 @@ module.exports.setSearchTerm = searchTerm => ({
     searchTerm: searchTerm
 });
 
+module.exports.navigateToRegistration = () => {
+    window.location = '/join';
+};
+
 module.exports.handleCompleteRegistration = createProject => (dispatch => {
     if (createProject) {
         window.location = '/projects/editor/?tutorial=getStarted';

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -1,0 +1,69 @@
+const React = require('react');
+const {shallowWithIntl} = require('../../helpers/intl-helpers.jsx');
+import configureStore from 'redux-mock-store';
+const Navigation = require('../../../src/components/navigation/www/navigation.jsx');
+const sessionActions = require('../../../src/redux/session.js');
+
+describe('Navigation', () => {
+    const mockStore = configureStore();
+    let store;
+
+    beforeEach(() => {
+    });
+
+    const getNavigationWrapper = props => {
+        const wrapper = shallowWithIntl(
+            <Navigation
+                {...props}
+            />
+            , {context: {store}}
+        );
+        return wrapper
+            .dive() // unwrap redux connect(injectIntl(JoinFlow))
+            .dive(); // unwrap injectIntl(JoinFlow)
+    };
+
+    test('when using old join flow, clicking Join Scratch attemps to open registration', () => {
+        store = mockStore({
+            navigation: {
+                useScratch3Registration: false
+            },
+            session: {
+                status: sessionActions.Status.FETCHED
+            },
+            messageCount: {
+                messageCount: 0
+            }
+        });
+        const props = {
+            handleOpenRegistration: jest.fn()
+        };
+        const navWrapper = getNavigationWrapper(props);
+        const navInstance = navWrapper.instance();
+
+        navWrapper.find('a.registrationLink').simulate('click');
+        expect(navInstance.props.handleOpenRegistration).toHaveBeenCalled();
+    });
+
+    test('when using new join flow, clicking Join Scratch attemps to navigate to registration', () => {
+        store = mockStore({
+            navigation: {
+                useScratch3Registration: true
+            },
+            session: {
+                status: sessionActions.Status.FETCHED
+            },
+            messageCount: {
+                messageCount: 0
+            }
+        });
+        const props = {
+            navigateToRegistration: jest.fn()
+        };
+        const navWrapper = getNavigationWrapper(props);
+        const navInstance = navWrapper.instance();
+
+        navWrapper.find('a.registrationLink').simulate('click');
+        expect(navInstance.props.navigateToRegistration).toHaveBeenCalled();
+    });
+});

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -9,6 +9,7 @@ describe('Navigation', () => {
     let store;
 
     beforeEach(() => {
+        store = null;
     });
 
     const getNavigationWrapper = props => {


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

instead of popping up new join flow in a modal, this makes most pages redirect to /join. Except for editor.
