### PR TITLE
new join flow modal stays open on click outside

### DIFF
--- a/src/components/modal/join/modal.jsx
+++ b/src/components/modal/join/modal.jsx
@@ -14,6 +14,7 @@ const JoinModal = ({
         isOpen
         useStandardSizes
         className="mod-join"
+        shouldCloseOnOverlayClick={false}
         onRequestClose={onRequestClose}
         {...modalProps}
     >


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

Set the flag `shouldCloseOnOverlayClick` to `false` in join modal, so clicks outside it don't close it.

### Test Coverage:

I don't think this is testable yet -- smoke tests can be added after launch