### PR TITLE
[Master] Contain zalgo text

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -223,6 +223,8 @@
             font-size: 1rem;
             line-height: 1.5rem;
             overflow-wrap: break-word;
+            display: block;
+            overflow: hidden;
         }
 
         .comment-bottom-row {


### PR DESCRIPTION
Keeps nefarious text from escaping the comment container on project pages. This was fixed once before, but the fix wasn't carried over to the project page.