### PR TITLE
set modal close icon to draggable false

### DIFF
--- a/src/components/modal/base/modal.jsx
+++ b/src/components/modal/base/modal.jsx
@@ -56,6 +56,7 @@ class Modal extends React.Component {
                     <img
                         alt="close-icon"
                         className="modal-content-close-img"
+                        draggable="false"
                         src="/svgs/modal/close-x.svg"
                     />
                 </div>


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* on most browsers (not firefox), make close icon ("x") in modal not draggable.

