### PR TITLE
make validations be the same width as inputs…

### DIFF
--- a/src/components/join-flow/birthdate-step.jsx
+++ b/src/components/join-flow/birthdate-step.jsx
@@ -117,6 +117,7 @@ class BirthDateStep extends React.Component {
                                     options={birthMonthOptions}
                                     validate={this.validateSelect}
                                     validationClassName={classNames(
+                                        'validation-birthdate',
                                         'validation-birthdate-month',
                                         'validation-left'
                                     )}
@@ -135,7 +136,10 @@ class BirthDateStep extends React.Component {
                                     name="birth_year"
                                     options={birthYearOptions}
                                     validate={this.validateSelect}
-                                    validationClassName="validation-birthdate-year"
+                                    validationClassName={classNames(
+                                        'validation-birthdate',
+                                        'validation-birthdate-year'
+                                    )}
                                     /* eslint-disable react/jsx-no-bind */
                                     onFocus={() => setFieldError('birth_year', null)}
                                     /* eslint-enable react/jsx-no-bind */

--- a/src/components/join-flow/country-step.jsx
+++ b/src/components/join-flow/country-step.jsx
@@ -93,7 +93,10 @@ class CountryStep extends React.Component {
                                     name="country"
                                     options={this.countryOptions}
                                     validate={this.validateSelect}
-                                    validationClassName="validation-full-width-input"
+                                    validationClassName={classNames(
+                                        'validation-full-width-input',
+                                        'validation-country'
+                                    )}
                                     /* eslint-disable react/jsx-no-bind */
                                     onFocus={() => setFieldError('country', null)}
                                     /* eslint-enable react/jsx-no-bind */

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -56,11 +56,25 @@
     .validation-full-width-input {
         transform: unset;
         margin-bottom: .75rem;
+        max-width: 100%;
     }
 
-    .validation-birthdate-input {
+    .validation-country {
+        top: .5rem;
+    }
+
+    .validation-birthdate {
         transform: unset;
-        width: 8rem;
+        top: .5rem;
+        width: 19rem;
+    }
+
+    .validation-birthdate-month {
+        margin-right: -9.25rem;
+    }
+
+    .validation-birthdate-year {
+        margin-left: -9.625rem;
     }
 }
 


### PR DESCRIPTION
…when window is narrow

### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

when window is narrow:
* makes validation messages (including blue tooltips) be 100% of the input's width that they refer to
* for country and birthdate step, moves validation messages down a bit (since selects are extra tall)
* for birthdate step, make validations be double-wide (so they appear below both dropdowns)


### Screenshots:

Before:

![image](https://user-images.githubusercontent.com/3431616/65459589-3caf0900-de1e-11e9-89ca-9289114f9a20.png)

After:

![image](https://user-images.githubusercontent.com/3431616/65459686-6700c680-de1e-11e9-96df-714bece6b2f0.png)


<br>
<br>

Before:

![image](https://user-images.githubusercontent.com/3431616/65459627-4c2e5200-de1e-11e9-9b0a-88f548cf7d6f.png)

After:

![image](https://user-images.githubusercontent.com/3431616/65459717-75e77900-de1e-11e9-933d-7293b1494828.png)


<br>
<br>

Before:

![image](https://user-images.githubusercontent.com/3431616/65459656-55b7ba00-de1e-11e9-8d89-47e2940c4677.png)

After:

![image](https://user-images.githubusercontent.com/3431616/65459737-7ed84a80-de1e-11e9-98fb-79dcd5acbaca.png)


<br>
<br>
