### PR TITLE
Add Logo to join flow standalone page.

### DIFF
--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -5,8 +5,21 @@ const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx'
 // Require this even though we don't use it because, without it, webpack runs out of memory...
 const Page = require('../../components/page/www/page.jsx'); // eslint-disable-line no-unused-vars
 
+require('./join.scss');
 const Register = () => (
     <ErrorBoundary>
+        <div className="join">
+            <a
+                aria-label="Scratch"
+                href="/"
+            >
+                <img
+                    className="logo"
+                    src="/images/logo_sm.png"
+                />
+            </a>
+
+        </div>
         <JoinModal
             isOpen
             key="scratch3registration"

--- a/src/views/join/join.scss
+++ b/src/views/join/join.scss
@@ -1,0 +1,29 @@
+@import "../../frameless";
+
+.join {
+    position: absolute;
+    z-index: 1000;
+    top: 12px;
+    left: 12px;
+    left: calc(25% - 76px);
+
+    .logo {
+      width: 76px;
+  }
+}
+
+@media #{$small} {
+    .join {
+        left: calc(50% - 38px);
+    }
+}
+@media #{$medium} {
+    .join {
+        left: calc(50% - 38px);
+    }
+}
+@media #{$intermediate} {
+    .join {
+        left: calc(50% - 38px);
+    }
+}


### PR DESCRIPTION
Logo links back to scratch homepage. 

This will need some positioning css work if we want to match it to teacher registration, especially on small screens. Right now it is set to be 25% of the way across the screen until it gets small when it is set to be centered.

<img width="1095" alt="Screen Shot 2019-09-23 at 6 05 03 PM" src="https://user-images.githubusercontent.com/15675877/65479151-566e4180-de5a-11e9-8ad5-d5af22c2a757.png">

<img width="572" alt="Screen Shot 2019-09-23 at 6 05 12 PM" src="https://user-images.githubusercontent.com/15675877/65479142-52422400-de5a-11e9-94b8-9014badb6195.png">


