### PR TITLE
join flow bold text and related design tweaks

### DIFF
--- a/src/components/formik-forms/formik-checkbox.scss
+++ b/src/components/formik-forms/formik-checkbox.scss
@@ -26,3 +26,8 @@ input[type="checkbox"].formik-checkbox {
         background-position: center;
     }
 }
+
+.formik-checkbox-label {
+    padding-top: .0625rem;
+    display: block;
+}

--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -53,7 +53,11 @@
     padding: 0.875rem 1.5rem;
     background-color: $ui-blue-25percent;
     font-size: .75rem;
-    font-weight: 600;
+    font-weight: 500;
     text-align: center;
     color: $ui-blue;
+}
+
+.join-flow-footer-message a {
+    font-weight: 500;
 }

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -237,13 +237,12 @@ class UsernameStep extends React.Component {
                                         onFocus={() => this.handleFocused('passwordConfirm')}
                                         /* eslint-enable react/jsx-no-bind */
                                     />
-                                    <div className="join-flow-input-title">
-                                        <FormikCheckbox
-                                            id="showPassword"
-                                            label={this.props.intl.formatMessage({id: 'registration.showPassword'})}
-                                            name="showPassword"
-                                        />
-                                    </div>
+                                    <FormikCheckbox
+                                        id="showPassword"
+                                        label={this.props.intl.formatMessage({id: 'registration.showPassword'})}
+                                        labelClassName="join-flow-input-title"
+                                        name="showPassword"
+                                    />
                                 </div>
                             </div>
                         </JoinFlowStep>


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* makes "Show Password" text bold, and moves it down slightly to look balanced
* makes email step terms of use statement only semi-bold

### Screenshots

![image](https://user-images.githubusercontent.com/3431616/65716524-54c89780-e06d-11e9-9719-a8e1aba907c0.png)

![image](https://user-images.githubusercontent.com/3431616/65716532-585c1e80-e06d-11e9-98e1-417d6c366aaa.png)

