### PR TITLE
make validations semi-bold

### DIFF
--- a/src/components/forms/validation-message.scss
+++ b/src/components/forms/validation-message.scss
@@ -18,6 +18,7 @@
     overflow: visible;
     color: $type-white;
     z-index: 1;
+    font-weight: 500;
 
     &:before {
         display: block;
@@ -82,7 +83,6 @@
 .validation-info {
     background-color: $ui-blue;
     box-shadow: 0 0 4px 2px rgba(0, 0, 0, .15);
-    font-weight: 500;
 
     &:before {
         background-color: $ui-blue;


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* Makes all validation popups/tooltips semi-bold (font-weight: 500)

(previously, some were regular, font-weight: 400)

### Before:

![image](https://user-images.githubusercontent.com/3431616/65716740-c1439680-e06d-11e9-8713-7b6d19bab162.png)

![image](https://user-images.githubusercontent.com/3431616/65716967-31eab300-e06e-11e9-85ca-240295a463b3.png)


### After:

![image](https://user-images.githubusercontent.com/3431616/65716755-c6084a80-e06d-11e9-96c1-cd6a1342f98b.png)

![image](https://user-images.githubusercontent.com/3431616/65716930-1b445c00-e06e-11e9-8921-a567b7948fe1.png)
