### PR TITLE
Join flow cache remote

### DIFF
--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -34,7 +34,8 @@ class UsernameStep extends React.Component {
             focused: null,
             showPassword: false
         };
-        // keeps us from submitting multiple remote requests for a single username
+        // simple object to memoize remote requests for usernames.
+        // keeps us from submitting multiple requests for same data.
         this.usernameRemoteCache = {};
     }
     componentDidMount () {
@@ -52,6 +53,7 @@ class UsernameStep extends React.Component {
     handleSetUsernameRef (usernameInputRef) {
         this.usernameInput = usernameInputRef;
     }
+    // simple function to memoize remote requests for usernames
     validateUsernameRemotelyWithCache (username) {
         if (this.usernameRemoteCache.hasOwnProperty(username)) {
             return Promise.resolve(this.usernameRemoteCache[username]);

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -27,12 +27,15 @@ class UsernameStep extends React.Component {
             'validatePasswordIfPresent',
             'validatePasswordConfirmIfPresent',
             'validateUsernameIfPresent',
+            'validateUsernameRemotelyWithCache',
             'validateForm'
         ]);
         this.state = {
             focused: null,
             showPassword: false
         };
+        // keeps us from submitting multiple remote requests for a single username
+        this.usernameRemoteCache = {};
     }
     componentDidMount () {
         // automatically start with focus on username field
@@ -49,12 +52,24 @@ class UsernameStep extends React.Component {
     handleSetUsernameRef (usernameInputRef) {
         this.usernameInput = usernameInputRef;
     }
+    validateUsernameRemotelyWithCache (username) {
+        if (this.usernameRemoteCache.hasOwnProperty(username)) {
+            return Promise.resolve(this.usernameRemoteCache[username]);
+        }
+        // username is not in our cache
+        return validate.validateUsernameRemotely(username).then(
+            remoteResult => {
+                this.usernameRemoteCache[username] = remoteResult;
+                return remoteResult;
+            }
+        );
+    }
     // we allow username to be empty on blur, since you might not have typed anything yet
     validateUsernameIfPresent (username) {
         if (!username) return null; // skip validation if username is blank; null indicates valid
         // if username is not blank, run both local and remote validations
         const localResult = validate.validateUsernameLocally(username);
-        return validate.validateUsernameRemotely(username).then(
+        return this.validateUsernameRemotelyWithCache(username).then(
             remoteResult => {
                 // there may be multiple validation errors. Prioritize vulgarity, then
                 // length, then having invalid chars, then all other remote reports

--- a/test/unit/components/username-step.test.jsx
+++ b/test/unit/components/username-step.test.jsx
@@ -1,0 +1,118 @@
+const React = require('react');
+const {shallowWithIntl} = require('../../helpers/intl-helpers.jsx');
+
+const mockedValidateUsernameRemotely = jest.fn(() => (
+    /* eslint-disable no-undef */
+    Promise.resolve({valid: false, errMsgId: 'registration.validationUsernameNotAllowed'})
+    /* eslint-enable no-undef */
+));
+
+jest.mock('../../../src/lib/validate.js', () => (
+    {
+        ...(jest.requireActual('../../../src/lib/validate.js')),
+        validateUsernameRemotely: mockedValidateUsernameRemotely
+    }
+));
+
+// must come after validation mocks, so validate.js will be mocked before it is required
+const UsernameStep = require('../../../src/components/join-flow/username-step.jsx');
+
+describe('UsernameStep test', () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('send correct props to formik', () => {
+        const wrapper = shallowWithIntl(<UsernameStep />);
+        const formikWrapper = wrapper.dive();
+        expect(formikWrapper.props().initialValues.username).toBe('');
+        expect(formikWrapper.props().initialValues.password).toBe('');
+        expect(formikWrapper.props().initialValues.passwordConfirm).toBe('');
+        expect(formikWrapper.props().initialValues.showPassword).toBe(false);
+        expect(formikWrapper.props().validateOnBlur).toBe(false);
+        expect(formikWrapper.props().validateOnChange).toBe(false);
+        expect(formikWrapper.props().validate).toBe(formikWrapper.instance().validateForm);
+        expect(formikWrapper.props().onSubmit).toBe(formikWrapper.instance().handleValidSubmit);
+    });
+
+    test('handleValidSubmit passes formData to next step', () => {
+        const formikBag = {
+            setSubmitting: jest.fn()
+        };
+        const formData = {item1: 'thing', item2: 'otherthing'};
+        const mockedOnNextStep = jest.fn();
+        const wrapper = shallowWithIntl(
+            <UsernameStep
+                onNextStep={mockedOnNextStep}
+            />
+        );
+        const instance = wrapper.dive().instance();
+
+        instance.handleValidSubmit(formData, formikBag);
+        expect(formikBag.setSubmitting).toHaveBeenCalledWith(false);
+        expect(mockedOnNextStep).toHaveBeenCalledWith(formData);
+    });
+
+    test('validateUsernameRemotelyWithCache calls validate.validateUsernameRemotely', done => {
+        const wrapper = shallowWithIntl(
+            <UsernameStep />);
+        const instance = wrapper.dive().instance();
+
+        instance.validateUsernameRemotelyWithCache('newUniqueUsername55')
+            .then(response => {
+                expect(mockedValidateUsernameRemotely).toHaveBeenCalled();
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('registration.validationUsernameNotAllowed');
+                done();
+            });
+    });
+
+    test('validateUsernameRemotelyWithCache, called twice with different data, makes two remote requests', done => {
+        const wrapper = shallowWithIntl(
+            <UsernameStep />
+        );
+        const instance = wrapper.dive().instance();
+
+        instance.validateUsernameRemotelyWithCache('newUniqueUsername55')
+            .then(response => {
+                expect(mockedValidateUsernameRemotely).toHaveBeenCalledTimes(1);
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('registration.validationUsernameNotAllowed');
+            })
+            .then(() => {
+                // make the same request a second time
+                instance.validateUsernameRemotelyWithCache('secondDifferent66')
+                    .then(response => {
+                        expect(mockedValidateUsernameRemotely).toHaveBeenCalledTimes(2);
+                        expect(response.valid).toBe(false);
+                        expect(response.errMsgId).toBe('registration.validationUsernameNotAllowed');
+                        done();
+                    });
+            });
+    });
+
+    test('validateUsernameRemotelyWithCache, called twice with same data, only makes one remote request', done => {
+        const wrapper = shallowWithIntl(
+            <UsernameStep />
+        );
+        const instance = wrapper.dive().instance();
+
+        instance.validateUsernameRemotelyWithCache('newUniqueUsername55')
+            .then(response => {
+                expect(mockedValidateUsernameRemotely).toHaveBeenCalledTimes(1);
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('registration.validationUsernameNotAllowed');
+            })
+            .then(() => {
+                // make the same request a second time
+                instance.validateUsernameRemotelyWithCache('newUniqueUsername55')
+                    .then(response => {
+                        expect(mockedValidateUsernameRemotely).toHaveBeenCalledTimes(1);
+                        expect(response.valid).toBe(false);
+                        expect(response.errMsgId).toBe('registration.validationUsernameNotAllowed');
+                        done();
+                    });
+            });
+    });
+});

--- a/test/unit/components/username-step.test.jsx
+++ b/test/unit/components/username-step.test.jsx
@@ -29,7 +29,7 @@ describe('UsernameStep test', () => {
         expect(formikWrapper.props().initialValues.username).toBe('');
         expect(formikWrapper.props().initialValues.password).toBe('');
         expect(formikWrapper.props().initialValues.passwordConfirm).toBe('');
-        expect(formikWrapper.props().initialValues.showPassword).toBe(false);
+        expect(formikWrapper.props().initialValues.showPassword).toBe(true);
         expect(formikWrapper.props().validateOnBlur).toBe(false);
         expect(formikWrapper.props().validateOnChange).toBe(false);
         expect(formikWrapper.props().validate).toBe(formikWrapper.instance().validateForm);


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

adds simple local caches to username and email steps to memoize remote requests, so they are not repeated with the same data.

Note that I cleared this approach with @rschamp .

### Tests:

Added tests of cacheing remote requests for both username and email step