### PR TITLE
make text selectable, so users can copy errors

### DIFF
--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -178,6 +178,7 @@
 }
 
 .join-flow-registration-error {
+    user-select: text; /* make text selectable, so users can copy errors */
     padding-top: 5.5rem;
 }
 


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

Makes text in join-flow modal selectable, so users can copy error messages if necessary.
