### PR TITLE
truncate custom gender, and other inputs

### DIFF
--- a/src/components/join-flow/email-step.jsx
+++ b/src/components/join-flow/email-step.jsx
@@ -174,7 +174,7 @@ class EmailStep extends React.Component {
                                 /* eslint-disable react/jsx-no-bind */
                                 onBlur={() => validateField('email')}
                                 onChange={e => {
-                                    setFieldValue('email', e.target.value);
+                                    setFieldValue('email', e.target.value.substring(0, 254));
                                     setFieldTouched('email');
                                     setFieldError('email', null);
                                 }}

--- a/src/components/join-flow/gender-step.jsx
+++ b/src/components/join-flow/gender-step.jsx
@@ -150,8 +150,8 @@ class GenderStep extends React.Component {
                                     value={values.custom}
                                     /* eslint-disable react/jsx-no-bind */
                                     onSetCustom={newCustomVal => setValues({
-                                        gender: newCustomVal,
-                                        custom: newCustomVal
+                                        gender: newCustomVal.substring(0, 25),
+                                        custom: newCustomVal.substring(0, 25)
                                     })}
                                     onSetCustomRef={this.handleSetCustomRef}
                                     /* eslint-enable react/jsx-no-bind */

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -157,7 +157,7 @@ class UsernameStep extends React.Component {
                                     /* eslint-disable react/jsx-no-bind */
                                     onBlur={() => validateField('username')}
                                     onChange={e => {
-                                        setFieldValue('username', e.target.value);
+                                        setFieldValue('username', e.target.value.substring(0, 30));
                                         setFieldTouched('username');
                                         setFieldError('username', null);
                                     }}
@@ -187,7 +187,7 @@ class UsernameStep extends React.Component {
                                         validationClassName="validation-full-width-input"
                                         onBlur={() => validateField('password')}
                                         onChange={e => {
-                                            setFieldValue('password', e.target.value);
+                                            setFieldValue('password', e.target.value.substring(0, 128));
                                             setFieldTouched('password');
                                             setFieldError('password', null);
                                         }}
@@ -225,7 +225,7 @@ class UsernameStep extends React.Component {
                                         validationClassName="validation-full-width-input"
                                         onBlur={() => validateField('passwordConfirm')}
                                         onChange={e => {
-                                            setFieldValue('passwordConfirm', e.target.value);
+                                            setFieldValue('passwordConfirm', e.target.value.substring(0, 128));
                                             setFieldTouched('passwordConfirm');
                                             setFieldError('passwordConfirm', null);
                                         }}


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* when user changes content of the custom gender input, truncate the value to 25 chars -- the limit of the field we store in the database.
* do the same for username (30 chars), password and passwordConfirm (128 chars), and email (254 chars)

these values would be truncated on the backend anyway, but this will reduce the network throughput.