### PR TITLE
turn off automplete and autocorrect for join-flow inputs

### DIFF
--- a/src/components/formik-forms/formik-radio-button.jsx
+++ b/src/components/formik-forms/formik-radio-button.jsx
@@ -89,8 +89,12 @@ const FormikRadioButton = ({
     >
         {isCustomInput && (
             <FormikInput
+                autoCapitalize="off"
+                autoComplete="off"
+                autoCorrect="off"
                 className="formik-radio-input"
                 name="custom"
+                spellCheck={false}
                 wrapperClassName="formik-radio-input-wrapper"
                 /* eslint-disable react/jsx-no-bind */
                 onChange={event => onSetCustom(event.target.value)}

--- a/src/components/join-flow/email-step.jsx
+++ b/src/components/join-flow/email-step.jsx
@@ -160,6 +160,9 @@ class EmailStep extends React.Component {
                             onSubmit={handleSubmit}
                         >
                             <FormikInput
+                                autoCapitalize="off"
+                                autoComplete="off"
+                                autoCorrect="off"
                                 className={classNames(
                                     'join-flow-input',
                                     'join-flow-input-tall',
@@ -169,6 +172,7 @@ class EmailStep extends React.Component {
                                 id="email"
                                 name="email"
                                 placeholder={this.props.intl.formatMessage({id: 'general.emailAddress'})}
+                                type="email"
                                 validate={this.validateEmail}
                                 validationClassName="validation-full-width-input"
                                 /* eslint-disable react/jsx-no-bind */

--- a/src/components/join-flow/join-flow-step.jsx
+++ b/src/components/join-flow/join-flow-step.jsx
@@ -21,7 +21,10 @@ const JoinFlowStep = ({
     titleClassName,
     waiting
 }) => (
-    <form onSubmit={onSubmit}>
+    <form
+        autoComplete="off"
+        onSubmit={onSubmit}
+    >
         <div className="join-flow-outer-content">
             {headerImgSrc && (
                 <div className="join-flow-header-image-wrapper">

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -143,6 +143,9 @@ class UsernameStep extends React.Component {
                                     {this.props.intl.formatMessage({id: 'registration.createUsername'})}
                                 </div>
                                 <FormikInput
+                                    autoCapitalize="off"
+                                    autoComplete="off"
+                                    autoCorrect="off"
                                     className={classNames(
                                         'join-flow-input'
                                     )}
@@ -150,6 +153,7 @@ class UsernameStep extends React.Component {
                                     id="username"
                                     name="username"
                                     placeholder={this.props.intl.formatMessage({id: 'general.username'})}
+                                    spellCheck={false}
                                     toolTip={this.state.focused === 'username' && !touched.username &&
                                         this.props.intl.formatMessage({id: 'registration.usernameAdviceShort'})}
                                     validate={this.validateUsernameIfPresent}
@@ -170,6 +174,9 @@ class UsernameStep extends React.Component {
                                         {this.props.intl.formatMessage({id: 'registration.choosePasswordStepTitle'})}
                                     </div>
                                     <FormikInput
+                                        autoCapitalize="off"
+                                        autoComplete={values.showPassword ? 'off' : 'new-password'}
+                                        autoCorrect="off"
                                         className={classNames(
                                             'join-flow-input',
                                             {'join-flow-input-password':
@@ -179,6 +186,7 @@ class UsernameStep extends React.Component {
                                         id="password"
                                         name="password"
                                         placeholder={this.props.intl.formatMessage({id: 'general.password'})}
+                                        spellCheck={false}
                                         toolTip={this.state.focused === 'password' && !touched.password &&
                                             this.props.intl.formatMessage({id: 'registration.passwordAdviceShort'})}
                                         type={values.showPassword ? 'text' : 'password'}
@@ -195,6 +203,9 @@ class UsernameStep extends React.Component {
                                         /* eslint-enable react/jsx-no-bind */
                                     />
                                     <FormikInput
+                                        autoCapitalize="off"
+                                        autoComplete={values.showPassword ? 'off' : 'new-password'}
+                                        autoCorrect="off"
                                         className={classNames(
                                             'join-flow-input',
                                             'join-flow-password-confirm',
@@ -210,6 +221,7 @@ class UsernameStep extends React.Component {
                                         placeholder={this.props.intl.formatMessage({
                                             id: 'registration.confirmPasswordInstruction'
                                         })}
+                                        spellCheck={false}
                                         toolTip={
                                             this.state.focused === 'passwordConfirm' && !touched.passwordConfirm &&
                                                 this.props.intl.formatMessage({


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* adds several attributes to the input fields in the new join-flow. These attributes tell the browser to disable autocomplete and suggestions of past input.

### Screenshots

before:

![bad-small](https://user-images.githubusercontent.com/3431616/65999405-56c69800-e46b-11e9-8001-bca04faf602e.gif)

after:

![Oct-01-2019 16-36-31](https://user-images.githubusercontent.com/3431616/65999410-59c18880-e46b-11e9-8dc8-ad921db2c192.gif)
