### PR TITLE
Join flow responsive fixes

### DIFF
--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -42,10 +42,16 @@
     margin: 0;
     border-top-left-radius: 1rem;
     border-top-right-radius: 1rem;
+
+    /* match the small window setting for modal as a whole */
+    @media #{$small}, #{$small-height} {
+        border-top-left-radius: 0rem;
+        border-top-right-radius: 0rem;
+    }
 }
 
 .join-flow-header-image {
-    width: 27.5rem;
+    width: 100%;
 }
 
 .join-flow-footer-message {

--- a/src/components/join-flow/next-step-button.scss
+++ b/src/components/join-flow/next-step-button.scss
@@ -14,6 +14,12 @@
         transition: background-color .25s ease;
         background-color: $ui-orange-90percent;
     }
+
+    /* match the small window setting for modal as a whole */
+    @media #{$small}, #{$small-height} {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 }
 
 .next-step-title {

--- a/src/components/modal/join/modal.scss
+++ b/src/components/modal/join/modal.scss
@@ -1,13 +1,32 @@
 @import "../../../colors";
 @import "../../../frameless";
 
+/* unusually for a modal, the join flow modal cares about the screen around it
+being clickable, because of the standalone join view. */
 .mod-join {
     width: 27.4375rem;
+
+    @media #{$small} {
+        width: auto;
+    }
+}
+
+/* enable vertical scrolling when modal showing, if page is short */
+.modal-overlay {
+    @media #{$small-height}, #{$medium-height} {
+        overflow: auto;
+    }
+}
+
+.modal-content {
+    @media #{$small}, #{$small-height} {
+        height: unset;
+    }
 }
 
 /* lower the modal slightly to accomodate Scratch logo above it */
 .modal-sizes {
-    @media #{$medium}, #{$medium-height} {
+    @media #{$small}, #{$small-height}, #{$medium}, #{$medium-height} {
         margin: 3.5rem auto;
     }
 }

--- a/src/views/join/join.scss
+++ b/src/views/join/join.scss
@@ -8,21 +8,11 @@
     left: calc(25% - 76px);
 
     .logo {
-      width: 76px;
-  }
+        width: 76px;
+    }
 }
 
-@media #{$small} {
-    .join {
-        left: calc(50% - 38px);
-    }
-}
-@media #{$medium} {
-    .join {
-        left: calc(50% - 38px);
-    }
-}
-@media #{$intermediate} {
+@media #{$small}, #{$medium}, #{$intermediate} {
     .join {
         left: calc(50% - 38px);
     }


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

Several fixes to responsive appearance:
* correctly handle join flow modal's switch from rounded corners to square corners at small window sizes
* make modal occupy full width of window, and mo more, at small window sizes, to avoid horizontal scrolling or off-center appearance
* enable vertical scrolling when modal showing, if page is short
* make small sized windows bump the join flow modal down to accommodate Scratch logo
* rewrite join view scss to be simpler, without changing appearance

