### PR TITLE
adjust join flow email centering

### DIFF
--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -136,9 +136,8 @@
 }
 
 .join-flow-inner-email-step {
-    padding-top: 1.25rem;
+    padding-top: .75rem;
     padding-bottom: 0;
-    min-height: 16.625rem;
 }
 
 .join-flow-inner-welcome-step {
@@ -217,7 +216,7 @@
 
 .join-flow-email-checkbox-row {
     font-size: .75rem;
-    margin: 1.5rem .125rem .25rem;
+    margin: 1.5rem .125rem 1rem;
 }
 
 a.join-flow-link:link, a.join-flow-link:visited, a.join-flow-link:active {


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

Improves the vertical centering of the email step, so the checkbox text stays some margin away from the blue ToS text.

Done alongside @kathymakes .