### PR TITLE
make join flow step scroll on mount

### DIFF
--- a/src/components/join-flow/join-flow-step.jsx
+++ b/src/components/join-flow/join-flow-step.jsx
@@ -8,72 +8,82 @@ const ModalInnerContent = require('../modal/base/modal-inner-content.jsx');
 
 require('./join-flow-step.scss');
 
-const JoinFlowStep = ({
-    children,
-    innerClassName,
-    description,
-    descriptionClassName,
-    footerContent,
-    headerImgSrc,
-    nextButton,
-    onSubmit,
-    title,
-    titleClassName,
-    waiting
-}) => (
-    <form onSubmit={onSubmit}>
-        <div className="join-flow-outer-content">
-            {headerImgSrc && (
-                <div className="join-flow-header-image-wrapper">
-                    <img
-                        className="join-flow-header-image"
-                        src={headerImgSrc}
-                    />
-                </div>
-            )}
-            <div>
-                <ModalInnerContent
-                    className={classNames(
-                        'join-flow-inner-content',
-                        innerClassName
-                    )}
-                >
-                    {title && (
-                        <ModalTitle
-                            className={classNames(
-                                'join-flow-title',
-                                titleClassName
-                            )}
-                            title={title}
-                        />
-                    )}
-                    {description && (
-                        <div
-                            className={classNames(
-                                'join-flow-description',
-                                descriptionClassName
-                            )}
-                        >
-                            {description}
+class JoinFlowStep extends React.Component {
+    componentDidMount () {
+        const progressionEls = document.getElementsByClassName('progression');
+        const progressionEl = progressionEls[0];
+        progressionEl.scrollIntoView();
+    }
+    render () {
+        const {
+            children,
+            innerClassName,
+            description,
+            descriptionClassName,
+            footerContent,
+            headerImgSrc,
+            nextButton,
+            onSubmit,
+            title,
+            titleClassName,
+            waiting
+        } = this.props;
+        return (
+            <form onSubmit={onSubmit}>
+                <div className="join-flow-outer-content">
+                    {headerImgSrc && (
+                        <div className="join-flow-header-image-wrapper">
+                            <img
+                                className="join-flow-header-image"
+                                src={headerImgSrc}
+                            />
                         </div>
                     )}
-                    {children}
-                </ModalInnerContent>
-            </div>
-            <div>
-                {footerContent && (
-                    <div className="join-flow-footer-message">
-                        {footerContent}
+                    <div>
+                        <ModalInnerContent
+                            className={classNames(
+                                'join-flow-inner-content',
+                                innerClassName
+                            )}
+                        >
+                            {title && (
+                                <ModalTitle
+                                    className={classNames(
+                                        'join-flow-title',
+                                        titleClassName
+                                    )}
+                                    title={title}
+                                />
+                            )}
+                            {description && (
+                                <div
+                                    className={classNames(
+                                        'join-flow-description',
+                                        descriptionClassName
+                                    )}
+                                >
+                                    {description}
+                                </div>
+                            )}
+                            {children}
+                        </ModalInnerContent>
                     </div>
-                )}
-                <NextStepButton
-                    content={nextButton}
-                    waiting={waiting}
-                />
-            </div>
-        </div>
-    </form>
-);
+                    <div>
+                        {footerContent && (
+                            <div className="join-flow-footer-message">
+                                {footerContent}
+                            </div>
+                        )}
+                        <NextStepButton
+                            content={nextButton}
+                            waiting={waiting}
+                        />
+                    </div>
+                </div>
+            </form>
+        );
+    }
+}
 
 JoinFlowStep.propTypes = {
     children: PropTypes.node,


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

When a join flow step appears, scroll so that the top of it is in view.

This stops an annoying UI problem in small screens where you can't see the title of the form, because you scrolled down to click Next.

### Screenshots

say you're in a very short window (e.g., keyboard is open in android) and you click next...

![image](https://user-images.githubusercontent.com/3431616/66148569-34ee2200-e5df-11e9-9ffb-401fa9372385.png)

...before this PR, the next screen would appear at the same scroll position:

![image](https://user-images.githubusercontent.com/3431616/66148560-30c20480-e5df-11e9-95bf-4a52a14dac44.png)

...after this PR, the next screen will appear scrolled to the top of the modal:

![image](https://user-images.githubusercontent.com/3431616/66148582-40d9e400-e5df-11e9-9ca4-cf2baa023450.png)

...at least for some users!
