### PR TITLE
Join flow responsive changes for input, button and select widths

### DIFF
--- a/src/components/formik-forms/formik-radio-button.scss
+++ b/src/components/formik-forms/formik-radio-button.scss
@@ -39,7 +39,7 @@ input[type="radio"].formik-radio-button {
 
 input.formik-radio-input, .formik-radio-input input {
     height: 2.1875rem;
-    width: 10.25rem;
+    width: 100%;
     margin-bottom: 0;
     border-radius: .5rem;
     background-color: $ui-white;
@@ -52,6 +52,7 @@ input.formik-radio-input, .formik-radio-input input {
 .formik-radio-input-wrapper {
     margin-left: auto;
     margin-right: .25rem;
+    width: 10.25rem;
 }
 
 .formik-radio-label-other {

--- a/src/components/join-flow/join-flow-step.scss
+++ b/src/components/join-flow/join-flow-step.scss
@@ -12,7 +12,7 @@
 
 .join-flow-inner-content {
     box-shadow: none;
-    width: calc(100% - 5.875rem);
+    width: calc(50% + 7.84375rem);
     /* must use padding for top, rather than margin, because margins will collapse */
     margin: 0 auto;
     padding: 2.3125rem 0 2.5rem;

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -89,10 +89,18 @@
 .select .join-flow-select-month {
     margin-right: .5rem;
     width: 9.125rem;
+
+    @media #{$small} {
+        width: 8.25rem;
+    }
 }
 
 .select .join-flow-select-year {
     width: 9.125rem;
+
+    @media #{$small} {
+        width: 8.25rem;
+    }
 }
 
 .select .join-flow-select-country {

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -185,7 +185,7 @@
 
 .gender-radio-row {
     transition: all .125s ease;
-    width: 20.875rem;
+    width: 97%;
     min-height: 2.85rem;
     background-color: $ui-gray;
     border-radius: .5rem;


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* change how we handle the width of gender custom input
* change calculation for join flow modal inner content width, to be more friedly at small sizes
* custom birth month and year width for small window sizes

these changes should not cause changes in the appearance of the join flow at regular size, only at small window widths.

### Screenshots:

These are all at a window size of 320px wide:

Before:

![image](https://user-images.githubusercontent.com/3431616/66348553-d26d8c80-e924-11e9-86ce-a73554222ff1.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66348563-d699aa00-e924-11e9-9553-1fd121a8b0b8.png)

Before:

![image](https://user-images.githubusercontent.com/3431616/66348579-e31e0280-e924-11e9-987a-5627138b7483.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66348585-e6b18980-e924-11e9-9d39-da885d2a2b0d.png)

Before:

![image](https://user-images.githubusercontent.com/3431616/66348590-eadda700-e924-11e9-93d6-851a7d677ab2.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66348597-ed400100-e924-11e9-8f17-3e2193e416ed.png)


Before:

![image](https://user-images.githubusercontent.com/3431616/66348602-f03af180-e924-11e9-802b-32bf5800cb71.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66348609-f3ce7880-e924-11e9-8320-a08fc1ed66a7.png)


Before:

![image](https://user-images.githubusercontent.com/3431616/66348742-3f812200-e925-11e9-80e4-2ec089e2f616.png)

After:

![image](https://user-images.githubusercontent.com/3431616/66348746-427c1280-e925-11e9-89b7-1d610019eb24.png)
