### PR TITLE
Add Sentry to Join Flow; set Sentry tags on various ErrorBoundaries

### DIFF
--- a/src/components/errorboundary/errorboundary.jsx
+++ b/src/components/errorboundary/errorboundary.jsx
@@ -17,6 +17,9 @@ class ErrorBoundary extends React.Component {
     componentDidCatch (error, errorInfo) {
         // Display fallback UI
         Sentry.withScope(scope => {
+            if (this.props.name) {
+                scope.setTag('errorboundary', this.props.name);
+            }
             Object.keys(errorInfo).forEach(key => {
                 scope.setExtra(key, errorInfo[key]);
             });
@@ -46,7 +49,8 @@ class ErrorBoundary extends React.Component {
     }
 }
 ErrorBoundary.propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    name: PropTypes.string
 };
 
 module.exports = ErrorBoundary;

--- a/src/components/errorboundary/errorboundary.jsx
+++ b/src/components/errorboundary/errorboundary.jsx
@@ -18,8 +18,8 @@ class ErrorBoundary extends React.Component {
         // Display fallback UI
         Sentry.withScope(scope => {
             scope.setTag('project', 'scratch-www');
-            if (this.props.name) {
-                scope.setTag('component', this.props.name);
+            if (this.props.componentName) {
+                scope.setTag('component', this.props.componentName);
             }
             Object.keys(errorInfo).forEach(key => {
                 scope.setExtra(key, errorInfo[key]);
@@ -51,7 +51,7 @@ class ErrorBoundary extends React.Component {
 }
 ErrorBoundary.propTypes = {
     children: PropTypes.node,
-    name: PropTypes.string
+    componentName: PropTypes.string
 };
 
 module.exports = ErrorBoundary;

--- a/src/components/errorboundary/errorboundary.jsx
+++ b/src/components/errorboundary/errorboundary.jsx
@@ -17,6 +17,7 @@ class ErrorBoundary extends React.Component {
     componentDidCatch (error, errorInfo) {
         // Display fallback UI
         Sentry.withScope(scope => {
+            scope.setTag('project', 'www');
             if (this.props.name) {
                 scope.setTag('errorboundary', this.props.name);
             }

--- a/src/components/errorboundary/errorboundary.jsx
+++ b/src/components/errorboundary/errorboundary.jsx
@@ -19,7 +19,7 @@ class ErrorBoundary extends React.Component {
         Sentry.withScope(scope => {
             scope.setTag('project', 'scratch-www');
             if (this.props.name) {
-                scope.setTag('errorboundary', this.props.name);
+                scope.setTag('component', this.props.name);
             }
             Object.keys(errorInfo).forEach(key => {
                 scope.setExtra(key, errorInfo[key]);

--- a/src/components/errorboundary/errorboundary.jsx
+++ b/src/components/errorboundary/errorboundary.jsx
@@ -17,7 +17,7 @@ class ErrorBoundary extends React.Component {
     componentDidCatch (error, errorInfo) {
         // Display fallback UI
         Sentry.withScope(scope => {
-            scope.setTag('project', 'www');
+            scope.setTag('project', 'scratch-www');
             if (this.props.name) {
                 scope.setTag('errorboundary', this.props.name);
             }

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -10,7 +10,7 @@ const Page = ({
     children,
     className
 }) => (
-    <ErrorBoundary>
+    <ErrorBoundary name="page">
         <div className={classNames('page', className)}>
             <div
                 className={classNames({

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -10,7 +10,7 @@ const Page = ({
     children,
     className
 }) => (
-    <ErrorBoundary name="page">
+    <ErrorBoundary name="Page">
         <div className={classNames('page', className)}>
             <div
                 className={classNames({

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -10,7 +10,7 @@ const Page = ({
     children,
     className
 }) => (
-    <ErrorBoundary name="Page">
+    <ErrorBoundary componentName="Page">
         <div className={classNames('page', className)}>
             <div
                 className={classNames({

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -5,6 +5,7 @@ const initSentry = () => {
 
         Sentry.init({
             dsn: `${process.env.SENTRY_DSN}`,
+            environment: 'www',
             // Do not collect global onerror, only collect specifically from React error boundaries.
             // TryCatch plugin also includes errors from setTimeouts (i.e. the VM)
             integrations: integrations => integrations.filter(i =>

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -5,7 +5,6 @@ const initSentry = () => {
 
         Sentry.init({
             dsn: `${process.env.SENTRY_DSN}`,
-            environment: 'www',
             // Do not collect global onerror, only collect specifically from React error boundaries.
             // TryCatch plugin also includes errors from setTimeouts (i.e. the VM)
             integrations: integrations => integrations.filter(i =>

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -10,7 +10,7 @@ initSentry();
 
 require('./join.scss');
 const Register = () => (
-    <ErrorBoundary name="join">
+    <ErrorBoundary name="Join">
         <div className="join">
             <a
                 aria-label="Scratch"

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -5,9 +5,12 @@ const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx'
 // Require this even though we don't use it because, without it, webpack runs out of memory...
 const Page = require('../../components/page/www/page.jsx'); // eslint-disable-line no-unused-vars
 
+const initSentry = require('../../lib/sentry.js');
+initSentry();
+
 require('./join.scss');
 const Register = () => (
-    <ErrorBoundary>
+    <ErrorBoundary name="join">
         <div className="join">
             <a
                 aria-label="Scratch"

--- a/src/views/join/join.jsx
+++ b/src/views/join/join.jsx
@@ -10,7 +10,7 @@ initSentry();
 
 require('./join.scss');
 const Register = () => (
-    <ErrorBoundary name="Join">
+    <ErrorBoundary componentName="Join">
         <div className="join">
             <a
                 aria-label="Scratch"

--- a/src/views/preview/embed-view.jsx
+++ b/src/views/preview/embed-view.jsx
@@ -5,7 +5,6 @@ const PropTypes = require('prop-types');
 const connect = require('react-redux').connect;
 const injectIntl = require('react-intl').injectIntl;
 
-const ErrorBoundary = require('../../components/errorboundary/errorboundary.jsx');
 const projectShape = require('./projectshape.jsx').projectShape;
 const NotAvailable = require('../../components/not-available/not-available.jsx');
 const Meta = require('./meta.jsx');
@@ -35,11 +34,9 @@ class EmbedView extends React.Component {
     render () {
         if (this.props.projectNotAvailable || this.state.invalidProject) {
             return (
-                <ErrorBoundary name="embed">
-                    <div className="preview">
-                        <NotAvailable />
-                    </div>
-                </ErrorBoundary>
+                <div className="preview">
+                    <NotAvailable />
+                </div>
             );
         }
 

--- a/src/views/preview/embed-view.jsx
+++ b/src/views/preview/embed-view.jsx
@@ -35,7 +35,7 @@ class EmbedView extends React.Component {
     render () {
         if (this.props.projectNotAvailable || this.state.invalidProject) {
             return (
-                <ErrorBoundary>
+                <ErrorBoundary name="embed">
                     <div className="preview">
                         <NotAvailable />
                     </div>

--- a/src/views/preview/embed.jsx
+++ b/src/views/preview/embed.jsx
@@ -26,5 +26,8 @@ if (isSupportedBrowser()) {
         EmbedView.guiMiddleware
     );
 } else {
-    render(<ErrorBoundary><UnsupportedBrowser /></ErrorBoundary>, document.getElementById('app'));
+    render(
+        <ErrorBoundary name="unsupportedbrowser"><UnsupportedBrowser /></ErrorBoundary>,
+        document.getElementById('app')
+    );
 }

--- a/src/views/preview/embed.jsx
+++ b/src/views/preview/embed.jsx
@@ -13,7 +13,7 @@ const UnsupportedBrowser = require('./unsupported-browser.jsx');
 if (isSupportedBrowser()) {
     const EmbedView = require('./embed-view.jsx');
     render(
-        <ErrorBoundary name="EmbedView">
+        <ErrorBoundary componentName="EmbedView">
             <EmbedView.View />
         </ErrorBoundary>,
         document.getElementById('app'),
@@ -29,7 +29,7 @@ if (isSupportedBrowser()) {
     );
 } else {
     render(
-        <ErrorBoundary name="UnsupportedBrowser"><UnsupportedBrowser /></ErrorBoundary>,
+        <ErrorBoundary componentName="UnsupportedBrowser"><UnsupportedBrowser /></ErrorBoundary>,
         document.getElementById('app')
     );
 }

--- a/src/views/preview/embed.jsx
+++ b/src/views/preview/embed.jsx
@@ -13,7 +13,9 @@ const UnsupportedBrowser = require('./unsupported-browser.jsx');
 if (isSupportedBrowser()) {
     const EmbedView = require('./embed-view.jsx');
     render(
-        <EmbedView.View />,
+        <ErrorBoundary name="EmbedView">
+            <EmbedView.View />
+        </ErrorBoundary>,
         document.getElementById('app'),
         {
             preview: previewActions.previewReducer,
@@ -27,7 +29,7 @@ if (isSupportedBrowser()) {
     );
 } else {
     render(
-        <ErrorBoundary name="unsupportedbrowser"><UnsupportedBrowser /></ErrorBoundary>,
+        <ErrorBoundary name="UnsupportedBrowser"><UnsupportedBrowser /></ErrorBoundary>,
         document.getElementById('app')
     );
 }

--- a/test/unit/components/errorboundary.test.jsx
+++ b/test/unit/components/errorboundary.test.jsx
@@ -41,7 +41,7 @@ describe('ErrorBoundary', () => {
     beforeEach(() => {
         errorBoundaryWrapper = mountWithIntl(
             <ErrorBoundary
-                name="TestEBName"
+                componentName="TestEBName"
             >
                 <ChildClass id="childClass" />
             </ErrorBoundary>

--- a/test/unit/components/errorboundary.test.jsx
+++ b/test/unit/components/errorboundary.test.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+const {mountWithIntl} = require('../../helpers/intl-helpers.jsx');
+
+jest.mock('@sentry/browser', () => {
+    const setExtra = jest.fn();
+    const setTag = jest.fn();
+
+    const makeScope = (setExtraParam, setTagParam) => {
+        const thisScope = {
+            setExtra: setExtraParam,
+            setTag: setTagParam
+        };
+        return thisScope;
+    };
+    const Sentry = {
+        captureException: jest.fn(),
+        lastEventId: function () {
+            return 0;
+        },
+        setExtra: setExtra,
+        setTag: setTag,
+        withScope: jest.fn(cb => {
+            cb(makeScope(setExtra, setTag));
+        })
+    };
+    return Sentry;
+});
+
+const Sentry = require('@sentry/browser');
+import ErrorBoundary from '../../../src/components/errorboundary/errorboundary.jsx';
+
+describe('ErrorBoundary', () => {
+    test('calling ErrorBoundary\'s componentDidCatch() calls Sentry.withScope()', () => {
+        const errorBoundaryWrapper = mountWithIntl(
+            <ErrorBoundary>
+                <div>
+                    Children here
+                </div>
+            </ErrorBoundary>
+        );
+        const errorBoundaryInstance = errorBoundaryWrapper.instance();
+        errorBoundaryInstance.componentDidCatch('error', {});
+        expect(Sentry.withScope).toHaveBeenCalled();
+    });
+
+    test('calling ErrorBoundary\'s componentDidCatch() calls Sentry.captureException()', () => {
+        const errorBoundaryWrapper = mountWithIntl(
+            <ErrorBoundary>
+                <div>
+                    Children here
+                </div>
+            </ErrorBoundary>
+        );
+        const errorBoundaryInstance = errorBoundaryWrapper.instance();
+        errorBoundaryInstance.componentDidCatch('error', {});
+        expect(Sentry.captureException).toHaveBeenCalledWith('error');
+    });
+
+    test('throwing error under ErrorBoundary calls Sentry.withScope()', () => {
+        const ChildClass = () => (
+            <div>
+                Children here
+            </div>
+        );
+        const errorBoundaryWrapper = mountWithIntl(
+            <ErrorBoundary>
+                <ChildClass id="childClass" />
+            </ErrorBoundary>
+        );
+        const child = errorBoundaryWrapper.find('#childClass');
+        expect(child.exists()).toEqual(true);
+        child.simulateError({}, {});
+        expect(Sentry.withScope).toHaveBeenCalled();
+    });
+
+    test('ErrorBoundary with name prop causes Sentry to setTag with that name', () => {
+        const ChildClass = () => (
+            <div>
+                Children here
+            </div>
+        );
+        const errorBoundaryWrapper = mountWithIntl(
+            <ErrorBoundary
+                name="testEB"
+            >
+                <ChildClass id="childClass" />
+            </ErrorBoundary>
+        );
+        const child = errorBoundaryWrapper.find('#childClass');
+        expect(child.exists()).toEqual(true);
+        child.simulateError({});
+        expect(Sentry.setTag).toHaveBeenCalledWith('errorboundary', 'testEB');
+    });
+});

--- a/test/unit/components/errorboundary.test.jsx
+++ b/test/unit/components/errorboundary.test.jsx
@@ -30,43 +30,37 @@ const Sentry = require('@sentry/browser');
 import ErrorBoundary from '../../../src/components/errorboundary/errorboundary.jsx';
 
 describe('ErrorBoundary', () => {
-    test('calling ErrorBoundary\'s componentDidCatch() calls Sentry.withScope()', () => {
-        const errorBoundaryWrapper = mountWithIntl(
-            <ErrorBoundary>
-                <div>
-                    Children here
-                </div>
+    let errorBoundaryWrapper;
+
+    const ChildClass = () => (
+        <div>
+            Children here
+        </div>
+    );
+
+    beforeEach(() => {
+        errorBoundaryWrapper = mountWithIntl(
+            <ErrorBoundary
+                name="TestEBName"
+            >
+                <ChildClass id="childClass" />
             </ErrorBoundary>
         );
+    });
+
+    test('calling ErrorBoundary\'s componentDidCatch() calls Sentry.withScope()', () => {
         const errorBoundaryInstance = errorBoundaryWrapper.instance();
         errorBoundaryInstance.componentDidCatch('error', {});
         expect(Sentry.withScope).toHaveBeenCalled();
     });
 
     test('calling ErrorBoundary\'s componentDidCatch() calls Sentry.captureException()', () => {
-        const errorBoundaryWrapper = mountWithIntl(
-            <ErrorBoundary>
-                <div>
-                    Children here
-                </div>
-            </ErrorBoundary>
-        );
         const errorBoundaryInstance = errorBoundaryWrapper.instance();
         errorBoundaryInstance.componentDidCatch('error', {});
         expect(Sentry.captureException).toHaveBeenCalledWith('error');
     });
 
     test('throwing error under ErrorBoundary calls Sentry.withScope()', () => {
-        const ChildClass = () => (
-            <div>
-                Children here
-            </div>
-        );
-        const errorBoundaryWrapper = mountWithIntl(
-            <ErrorBoundary>
-                <ChildClass id="childClass" />
-            </ErrorBoundary>
-        );
         const child = errorBoundaryWrapper.find('#childClass');
         expect(child.exists()).toEqual(true);
         child.simulateError({}, {});
@@ -74,21 +68,9 @@ describe('ErrorBoundary', () => {
     });
 
     test('ErrorBoundary with name prop causes Sentry to setTag with that name', () => {
-        const ChildClass = () => (
-            <div>
-                Children here
-            </div>
-        );
-        const errorBoundaryWrapper = mountWithIntl(
-            <ErrorBoundary
-                name="testEB"
-            >
-                <ChildClass id="childClass" />
-            </ErrorBoundary>
-        );
         const child = errorBoundaryWrapper.find('#childClass');
         expect(child.exists()).toEqual(true);
         child.simulateError({});
-        expect(Sentry.setTag).toHaveBeenCalledWith('errorboundary', 'testEB');
+        expect(Sentry.setTag).toHaveBeenCalledWith('component', 'TestEBName');
     });
 });


### PR DESCRIPTION
### Resolves:

* Resolves https://github.com/LLK/scratch-www/issues/3443
* Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

* adds Sentry support to Join Flow, by making the standalone join view initialize Sentry
* makes www's Sentry reporting code report to Sentry:
   * that the error was caught inside scratch-www
   * which ErrorBoundary caught the error

### Test Coverage:

Added some unsurprisingly complex tests :)