### PR TITLE
Hotfix TEST ONLY: artificially throw errors in 2 places to test Sentry changes

### DIFF
--- a/src/components/join-flow/country-step.jsx
+++ b/src/components/join-flow/country-step.jsx
@@ -34,6 +34,10 @@ class CountryStep extends React.Component {
                 value: 'null'
             });
         }
+        // NOTE: this should not be merged to the develop or master branches!
+        const customSentryTestErr = new Error('Test of Sentry catching from join flow country step');
+        customSentryTestErr.code = 'JOIN_FLOW_CUSTOM_ERROR_CODE';
+        throw customSentryTestErr;
     }
     validateSelect (selection) {
         if (selection === 'null') {

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -611,6 +611,12 @@ class Preview extends React.Component {
                 </Page>
             );
         }
+        // NOTE: this should not be merged to the develop or master branches!
+        if (!this.props.playerMode) {
+            const customSentryTestErr = new Error('Test of Sentry catching from wrapper around project editor');
+            customSentryTestErr.code = 'PROJECT_VIEW_EDITOR_CUSTOM_ERROR_CODE';
+            throw customSentryTestErr;
+        }
 
         return (
             <React.Fragment>


### PR DESCRIPTION
To test changes introduced in https://github.com/LLK/scratch-www/pull/3444 , this PR brings in test code to a hotfix branch.

Once we've tested this on staging, this hotfix branch should be deleted.