### PR TITLE
fixed country options to use full country name string as option value

### DIFF
--- a/src/lib/country-data.js
+++ b/src/lib/country-data.js
@@ -1060,23 +1060,25 @@ const dupeCommonCountries = module.exports.dupeCommonCountries = (startingCountr
 
 /*
  * registrationCountryOptions is the result of taking the standard countryInfo,
- * and duplicating 'United States of America' and 'United Kingdom' at the top of the list.
+ * setting a 'value' key and a 'label' key both to the country data's 'name' value,
+ * but using the 'display' value for 'label' instead of 'name' if 'display' exists;
+ * then duplicating 'United States of America' and 'United Kingdom' at the top of the list.
  * The result is an array like:
  * [
- *    {code: 'us', name: 'United States', display: 'United States of America'},
- *    {code: 'gb', name: 'United Kingdom'},
- *    {code: 'af', name: 'Afghanistan'},
+ *    {value: 'United States', label: 'United States of America'},
+ *    {value: 'United Kingdom', label: 'United Kingdom'},
+ *    {value: 'Afghanistan', label: 'Afghanistan'},
  *    ...
- *    {code: 'ae', name: 'United Arab Emirates'},
- *    {code: 'us', name: 'United States', display: 'United States of America'},
- *    {code: 'gb', name: 'United Kingdom'},
- *    {code: 'uz', name: 'Uzbekistan'},
+ *    {value: 'United Arab Emirates', label: 'United Arab Emirates'},
+ *    {value: 'United States', label: 'United States of America'},
+ *    {value: 'United Kingdom', label: 'United Kingdom'},
+ *    {value: 'Uzbekistan', label: 'Uzbekistan'},
  *    ...
- *    {code: 'zm', name: 'Zimbabwe'}
+ *    {value: 'Zimbabwe', label: 'Zimbabwe'}
  * ]
  */
 module.exports.registrationCountryOptions =
-    countryOptions(dupeCommonCountries(countryInfo, ['us', 'gb']), 'code');
+    countryOptions(dupeCommonCountries(countryInfo, ['us', 'gb']), 'name');
 
 /* subdivisionOptions uses iso-3166 data to produce an array like:
  * [

--- a/test/unit/lib/country-data.test.js
+++ b/test/unit/lib/country-data.test.js
@@ -74,6 +74,15 @@ describe('unit test lib/country-data.js', () => {
         expect(ukItems.length).toEqual(2);
     });
 
+    test('registrationCountryOptions object uses country names for both option label and option value', () => {
+        expect(typeof registrationCountryOptions).toBe('object');
+        // test that there is one option with label and value === 'Brazil'
+        const brazilOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
+            (thisCountry.value === 'Brazil' && thisCountry.label === 'Brazil') ? [...acc, thisCountry] : acc
+        ), []);
+        expect(brazilOptions.length).toEqual(1);
+    });
+
     test('registrationCountryOptions object places USA and UK at start, with display name versions', () => {
         expect(typeof registrationCountryOptions).toBe('object');
         const numCountries = countryInfo.length;
@@ -81,17 +90,17 @@ describe('unit test lib/country-data.js', () => {
         // test that the two entries have been added to the start of the array, and that
         // the name of the USA includes "America"
         expect(registrationCountryOptions.length).toEqual(numCountries + 2);
-        expect(registrationCountryOptions[0]).toEqual({value: 'us', label: 'United States of America'});
-        expect(registrationCountryOptions[1]).toEqual({value: 'gb', label: 'United Kingdom'});
+        expect(registrationCountryOptions[0]).toEqual({value: 'United States', label: 'United States of America'});
+        expect(registrationCountryOptions[1]).toEqual({value: 'United Kingdom', label: 'United Kingdom'});
 
         // test that there are now two entries for USA
         const usaOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
-            thisCountry.value === 'us' ? [...acc, thisCountry] : acc
+            thisCountry.value === 'United States' ? [...acc, thisCountry] : acc
         ), []);
         expect(usaOptions.length).toEqual(2);
         // test that there are now two entries for UK
         const ukOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
-            thisCountry.value === 'gb' ? [...acc, thisCountry] : acc
+            thisCountry.value === 'United Kingdom' ? [...acc, thisCountry] : acc
         ), []);
         expect(ukOptions.length).toEqual(2);
     });


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3467

### Changes:

Sends country name strings, rather than country codes, when user registers (both for teacher registration and regular user registration)

### Test Coverage:

Added test to verify that options values are full country name strings

### Screenshots

Choosing Brazil in join flow...

![image](https://user-images.githubusercontent.com/3431616/67224740-e5419000-f3ff-11e9-9842-a76a0026a2c5.png)

Before change:

![image](https://user-images.githubusercontent.com/3431616/67224754-eb377100-f3ff-11e9-9fc1-635143ae963b.png)

After change:

![image](https://user-images.githubusercontent.com/3431616/67224757-eecaf800-f3ff-11e9-8675-1bd6f9575fce.png)
