### PR TITLE
Fix dev server by splitting up redirect regex

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -512,7 +512,13 @@
     },
     {
         "name": "fly-tutorial-redirect",
-        "pattern": "^/(makeit)?fly/?$",
+        "pattern": "^/fly/?$",
+        "routeAlias": "/(makeit)?fly/?$",
+        "redirect": "/projects/editor/?tutorial=make-it-fly"
+    },
+    {
+        "name": "makeitfly-tutorial-redirect",
+        "pattern": "^/makeitfly/?$",
         "routeAlias": "/(makeit)?fly/?$",
         "redirect": "/projects/editor/?tutorial=make-it-fly"
     },


### PR DESCRIPTION
This pattern works for building/deploying, but not for running locally. Split it up to deal with what express expects a path to look like.

`npm start` should now work instead of crashing due to the `(makeit)?fly` route.