### PR TITLE
fixed the issue "Create a Username" has different font weight

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -195,8 +195,8 @@ class UsernameStep extends React.Component {
                         }}
                         onValidSubmit={this.handleValidSubmit}
                     >
-                        <div>
-                            <label className="username-label">
+                        <div className="form-group row">
+                            <label className="username-label col-sm-3">
                                 {this.props.intl.formatMessage({id: 'registration.createUsername'})}
                                 {this.props.usernameHelp ? (
                                     <p className="help-text">{this.props.usernameHelp}</p>

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -196,16 +196,14 @@ class UsernameStep extends React.Component {
                         onValidSubmit={this.handleValidSubmit}
                     >
                         <div>
-                            <div className="username-label">
-                                <b>
-                                    {this.props.intl.formatMessage({id: 'registration.createUsername'})}
-                                </b>
+                            <label className="username-label">
+                                {this.props.intl.formatMessage({id: 'registration.createUsername'})}
                                 {this.props.usernameHelp ? (
                                     <p className="help-text">{this.props.usernameHelp}</p>
                                 ) : (
                                     null
                                 )}
-                            </div>
+                            </label>
                             <Input
                                 required
                                 className={this.state.validUsername}


### PR DESCRIPTION
### Resolves:

Fixes the issue #3182, Teacher Registration page having different font weights for username and password labels.

### Changes:

Uses label tage instead of div-b combination for 'Create a Username'. Also updated the classname of the parent element to match the bottom margin.

### Test Coverage:

Opened the page http://localhost:8333/educators/register to confirm the font weight is normal for the username label. No automatic test scripts needed.
