### PR TITLE
username step and email step caches ignore api failures

### DIFF
--- a/src/components/join-flow/email-step.jsx
+++ b/src/components/join-flow/email-step.jsx
@@ -91,7 +91,10 @@ class EmailStep extends React.Component {
         // email is not in our cache
         return validate.validateEmailRemotely(email).then(
             remoteResult => {
-                this.emailRemoteCache[email] = remoteResult;
+                // cache result, if it successfully heard back from server
+                if (remoteResult.requestSucceeded) {
+                    this.emailRemoteCache[email] = remoteResult;
+                }
                 return remoteResult;
             }
         );

--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -56,7 +56,10 @@ class UsernameStep extends React.Component {
         // username is not in our cache
         return validate.validateUsernameRemotely(username).then(
             remoteResult => {
-                this.usernameRemoteCache[username] = remoteResult;
+                // cache result, if it successfully heard back from server
+                if (remoteResult.requestSucceeded) {
+                    this.usernameRemoteCache[username] = remoteResult;
+                }
                 return remoteResult;
             }
         );

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -50,9 +50,7 @@ module.exports.validateUsernameRemotely = username => (
 module.exports.validatePassword = (password, username) => {
     if (!password) {
         return {valid: false, errMsgId: 'general.required'};
-    // get length of password, considering unicode symbols as single chars.
-    // see discussion at https://stackoverflow.com/a/54370584/2308190
-    } else if (Array.from(password).length < 6) {
+    } else if (password.length < 6) {
         return {valid: false, errMsgId: 'registration.validationPasswordLength'};
     } else if (password === 'password') {
         return {valid: false, errMsgId: 'registration.validationPasswordNotEquals'};

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -21,21 +21,21 @@ module.exports.validateUsernameRemotely = username => (
             uri: `/accounts/checkusername/${username}/`
         }, (err, body, res) => {
             if (err || res.statusCode !== 200) {
-                resolve({valid: false, errMsgId: 'general.error'});
+                resolve({requestSucceeded: false, valid: false, errMsgId: 'general.error'});
             }
             switch (body.msg) {
             case 'valid username':
-                resolve({valid: true});
+                resolve({requestSucceeded: true, valid: true});
                 break;
             case 'username exists':
-                resolve({valid: false, errMsgId: 'registration.validationUsernameExists'});
+                resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationUsernameExists'});
                 break;
             case 'bad username': // i.e., vulgar
-                resolve({valid: false, errMsgId: 'registration.validationUsernameNotAllowed'});
+                resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationUsernameNotAllowed'});
                 break;
             case 'invalid username':
             default:
-                resolve({valid: false, errMsgId: 'registration.validationUsernameNotAllowed'});
+                resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationUsernameNotAllowed'});
             }
         });
     })
@@ -50,7 +50,9 @@ module.exports.validateUsernameRemotely = username => (
 module.exports.validatePassword = (password, username) => {
     if (!password) {
         return {valid: false, errMsgId: 'general.required'};
-    } else if (password.length < 6) {
+    // get length of password, considering unicode symbols as single chars.
+    // see discussion at https://stackoverflow.com/a/54370584/2308190
+    } else if (Array.from(password).length < 6) {
         return {valid: false, errMsgId: 'registration.validationPasswordLength'};
     } else if (password === 'password') {
         return {valid: false, errMsgId: 'registration.validationPasswordNotEquals'};
@@ -86,16 +88,16 @@ module.exports.validateEmailRemotely = email => (
             uri: '/accounts/check_email/'
         }, (err, body, res) => {
             if (err || res.statusCode !== 200 || !body || body.length < 1 || !body[0].msg) {
-                resolve({valid: false, errMsgId: 'general.apiError'});
+                resolve({requestSucceeded: false, valid: false, errMsgId: 'general.apiError'});
             }
             switch (body[0].msg) {
             case 'valid email':
-                resolve({valid: true});
+                resolve({requestSucceeded: true, valid: true});
                 break;
             case 'Scratch is not allowed to send email to this address.': // e.g., bad TLD or block-listed
             case 'Enter a valid email address.':
             default:
-                resolve({valid: false, errMsgId: 'registration.validationEmailInvalid'});
+                resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationEmailInvalid'});
                 break;
             }
         });

--- a/test/unit/components/email-step.test.jsx
+++ b/test/unit/components/email-step.test.jsx
@@ -4,9 +4,24 @@ const JoinFlowStep = require('../../../src/components/join-flow/join-flow-step.j
 const FormikInput = require('../../../src/components/formik-forms/formik-input.jsx');
 const FormikCheckbox = require('../../../src/components/formik-forms/formik-checkbox.jsx');
 
-const mockedValidateEmailRemotely = jest.fn(() => (
+const requestSuccessResponse = {
+    requestSucceeded: true,
+    valid: false,
+    errMsgId: 'registration.validationEmailInvalid'
+};
+const requestFailureResponse = {
+    requestSucceeded: false,
+    valid: false,
+    errMsgId: 'general.error'
+};
+// mockedValidateEmailRemotely will return a promise resolving with remoteRequestResponse.
+// Using remoteRequestResponse, rather than using requestSuccessResponse directly,
+// lets us change where remoteRequestResponse points later, without actually changing
+// mockedValidateEmailRemotely.
+let remoteRequestResponse = requestSuccessResponse;
+let mockedValidateEmailRemotely = jest.fn(() => (
     /* eslint-disable no-undef */
-    Promise.resolve({valid: false, errMsgId: 'registration.validationEmailInvalid'})
+    Promise.resolve(remoteRequestResponse)
     /* eslint-enable no-undef */
 ));
 
@@ -193,6 +208,13 @@ describe('EmailStep test', () => {
         const val = formikWrapper.instance().validateEmail();
         expect(val).toBe('general.required');
     });
+});
+
+describe('validateEmailRemotelyWithCache test with successful requests', () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
 
     test('validateEmailRemotelyWithCache calls validate.validateEmailRemotely', done => {
         const wrapper = shallowWithIntl(
@@ -251,6 +273,82 @@ describe('EmailStep test', () => {
                         expect(mockedValidateEmailRemotely).toHaveBeenCalledTimes(1);
                         expect(response.valid).toBe(false);
                         expect(response.errMsgId).toBe('registration.validationEmailInvalid');
+                        done();
+                    });
+            });
+    });
+});
+
+
+describe('validateEmailRemotelyWithCache test with failing requests', () => {
+
+    beforeEach(() => {
+        // needs to be wrapped inside beforeEach, because if not, it gets run as this
+        // test file is loaded, and goes into effect before any of the earlier tests run!
+        remoteRequestResponse = requestFailureResponse;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('validateEmailRemotelyWithCache calls validate.validateEmailRemotely', done => {
+        const wrapper = shallowWithIntl(
+            <EmailStep />);
+        const instance = wrapper.dive().instance();
+
+        instance.validateEmailRemotelyWithCache('some-email@some-domain.com')
+            .then(response => {
+                expect(mockedValidateEmailRemotely).toHaveBeenCalled();
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('general.error');
+                done();
+            });
+    });
+
+    test('validateEmailRemotelyWithCache, called twice with different data, makes two remote requests', done => {
+        const wrapper = shallowWithIntl(
+            <EmailStep />
+        );
+        const instance = wrapper.dive().instance();
+
+        instance.validateEmailRemotelyWithCache('some-email@some-domain.com')
+            .then(response => {
+                expect(mockedValidateEmailRemotely).toHaveBeenCalledTimes(1);
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('general.error');
+            })
+            .then(() => {
+                // make the same request a second time
+                instance.validateEmailRemotelyWithCache('different-email@some-domain.org')
+                    .then(response => {
+                        expect(mockedValidateEmailRemotely).toHaveBeenCalledTimes(2);
+                        expect(response.valid).toBe(false);
+                        expect(response.errMsgId).toBe('general.error');
+                        done();
+                    });
+            });
+    });
+
+    test('validateEmailRemotelyWithCache, called 2x w/same data, makes 2 requests, since 1st not stored', done => {
+        const wrapper = shallowWithIntl(
+            <EmailStep />
+        );
+        const instance = wrapper.dive().instance();
+
+        instance.validateEmailRemotelyWithCache('some-email@some-domain.com')
+            .then(response => {
+                expect(mockedValidateEmailRemotely).toHaveBeenCalledTimes(1);
+                expect(response.valid).toBe(false);
+                expect(response.errMsgId).toBe('general.error');
+            })
+            .then(() => {
+                // make the same request a second time
+                instance.validateEmailRemotelyWithCache('some-email@some-domain.com')
+                    .then(response => {
+                        expect(mockedValidateEmailRemotely).toHaveBeenCalledTimes(2);
+                        expect(response.valid).toBe(false);
+                        expect(response.errMsgId).toBe('general.error');
                         done();
                     });
             });

--- a/test/unit/components/username-step.test.jsx
+++ b/test/unit/components/username-step.test.jsx
@@ -1,9 +1,9 @@
 const React = require('react');
 const {shallowWithIntl} = require('../../helpers/intl-helpers.jsx');
 
-const mockedValidateUsernameRemotely = jest.fn(() => (
+let mockedValidateUsernameRemotely = jest.fn(() => (
     /* eslint-disable no-undef */
-    Promise.resolve({valid: false, errMsgId: 'registration.validationUsernameNotAllowed'})
+    Promise.resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationUsernameNotAllowed'})
     /* eslint-enable no-undef */
 ));
 
@@ -17,7 +17,7 @@ jest.mock('../../../src/lib/validate.js', () => (
 // must come after validation mocks, so validate.js will be mocked before it is required
 const UsernameStep = require('../../../src/components/join-flow/username-step.jsx');
 
-describe('UsernameStep test', () => {
+describe('UsernameStep tests', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -54,9 +54,18 @@ describe('UsernameStep test', () => {
         expect(mockedOnNextStep).toHaveBeenCalledWith(formData);
     });
 
+});
+
+describe('validateUsernameRemotelyWithCache test', () => {
+
+    // mockedValidateUsernameRemotely = jest.fn(() => (
+    //     /* eslint-disable no-undef */
+    //     Promise.resolve({requestSucceeded: true, valid: false, errMsgId: 'registration.validationUsernameNotAllowed'})
+    //     /* eslint-enable no-undef */
+    // ));
+
     test('validateUsernameRemotelyWithCache calls validate.validateUsernameRemotely', done => {
-        const wrapper = shallowWithIntl(
-            <UsernameStep />);
+        const wrapper = shallowWithIntl(<UsernameStep />);
         const instance = wrapper.dive().instance();
 
         instance.validateUsernameRemotelyWithCache('newUniqueUsername55')


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratch-www/issues/3053

### Changes:

username step and email step caches ignore api failures

### Test Coverage:

no change to tests, as these validations check external API functionality that is not testable here