### PR TITLE
Add translation resource mapping

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -133,6 +133,8 @@ var localizedAssetUrls = {};
 //   - txMapping: if the name of the transifex resource is different from the route name
 var txMapping = {
     'projects': 'preview',
+    'embed': 'preview',
+    'vernier': 'gdxfor',
     'scratch_1.4': 'scratch_14' // transifex doesn't allow dots in resource names
 };
 // start with english default for all views


### PR DESCRIPTION
When the name of the view in `routes.json` does not match the name of the resource in transifex there needs to be a mapping added to the script that generates translations. _Note: the resource name in transifex is usually based on the name of the source file in the `views` directory. Usually the name of the view in the routes file matches._

Since `routes.json` is a JSON file that does not support comments there’s no way to add a warning to the file when someone is adding a route.

The sympton was the message that there were no translations for ‘vernier’ or ‘embed’ when running translate. The `vernier` route is actually the `gdxfor` view, and `embed` is just another version of `preview`


### Changes:
Adds a mapping for the `embed` and `vernier` routes to the correct transifex resources `preview` and `gdxfor`. Both of these already exist in transifex and in scratch0-l10n, so there are no changes to `.tx/config`

### Test Coverage:
Running `npm run translate` no longer produces warnings.
