### PR TITLE
Greenkeeper/scratch gui 0.1.0 prerelease.20191030020251

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15560,15 +15560,15 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20191022134757",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20191022134757.tgz",
-      "integrity": "sha512-nBFWGaJLV6GrAz+eMBHAOC/z8ImGo050A1JnqdgKgf6XxoLDh4XbdebQ2aDVe2TWhPkG8TlYuwAt6AigixYhqA==",
+      "version": "0.1.0-prerelease.20191030020251",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20191030020251.tgz",
+      "integrity": "sha512-gI//FZ+tQabykTwhkP8WdCDsQgnPU6ACgBwwJUo8Pm8q9YWu0fDW+7PnzptClAeV9FCZyT52Koo8+neQbYs/Gw==",
       "dev": true
     },
     "scratch-l10n": {
-      "version": "3.6.20191015223749",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.6.20191015223749.tgz",
-      "integrity": "sha512-hVujIj2kLg2dsk9/3ALksl4ZiLmNbsypH/Mp4nAgeJkDMmlaOR1V8TKn9K9X6O9R6xI8cyJHfmhShdf/8COpXg==",
+      "version": "3.6.20191029224007",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.6.20191029224007.tgz",
+      "integrity": "sha512-12LprZ35Z7j/h14CtmU0ZW+aHwOUme58bwIpF/dINil9bbUhasLzGd1Ov60y3eOmP0LO+EE4oebUbK6KV1rguQ==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20191022134757",
+    "scratch-gui": "0.1.0-prerelease.20191030020251",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Update gui. This version includes the latest translations.