### PR TITLE
Revert "fixed country options to use full country name string as option value"

### DIFF
--- a/src/lib/country-data.js
+++ b/src/lib/country-data.js
@@ -1060,25 +1060,23 @@ const dupeCommonCountries = module.exports.dupeCommonCountries = (startingCountr
 
 /*
  * registrationCountryOptions is the result of taking the standard countryInfo,
- * setting a 'value' key and a 'label' key both to the country data's 'name' value,
- * but using the 'display' value for 'label' instead of 'name' if 'display' exists;
- * then duplicating 'United States of America' and 'United Kingdom' at the top of the list.
+ * and duplicating 'United States of America' and 'United Kingdom' at the top of the list.
  * The result is an array like:
  * [
- *    {value: 'United States', label: 'United States of America'},
- *    {value: 'United Kingdom', label: 'United Kingdom'},
- *    {value: 'Afghanistan', label: 'Afghanistan'},
+ *    {code: 'us', name: 'United States', display: 'United States of America'},
+ *    {code: 'gb', name: 'United Kingdom'},
+ *    {code: 'af', name: 'Afghanistan'},
  *    ...
- *    {value: 'United Arab Emirates', label: 'United Arab Emirates'},
- *    {value: 'United States', label: 'United States of America'},
- *    {value: 'United Kingdom', label: 'United Kingdom'},
- *    {value: 'Uzbekistan', label: 'Uzbekistan'},
+ *    {code: 'ae', name: 'United Arab Emirates'},
+ *    {code: 'us', name: 'United States', display: 'United States of America'},
+ *    {code: 'gb', name: 'United Kingdom'},
+ *    {code: 'uz', name: 'Uzbekistan'},
  *    ...
- *    {value: 'Zimbabwe', label: 'Zimbabwe'}
+ *    {code: 'zm', name: 'Zimbabwe'}
  * ]
  */
 module.exports.registrationCountryOptions =
-    countryOptions(dupeCommonCountries(countryInfo, ['us', 'gb']), 'name');
+    countryOptions(dupeCommonCountries(countryInfo, ['us', 'gb']), 'code');
 
 /* subdivisionOptions uses iso-3166 data to produce an array like:
  * [

--- a/test/unit/lib/country-data.test.js
+++ b/test/unit/lib/country-data.test.js
@@ -74,15 +74,6 @@ describe('unit test lib/country-data.js', () => {
         expect(ukItems.length).toEqual(2);
     });
 
-    test('registrationCountryOptions object uses country names for both option label and option value', () => {
-        expect(typeof registrationCountryOptions).toBe('object');
-        // test that there is one option with label and value === 'Brazil'
-        const brazilOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
-            (thisCountry.value === 'Brazil' && thisCountry.label === 'Brazil') ? [...acc, thisCountry] : acc
-        ), []);
-        expect(brazilOptions.length).toEqual(1);
-    });
-
     test('registrationCountryOptions object places USA and UK at start, with display name versions', () => {
         expect(typeof registrationCountryOptions).toBe('object');
         const numCountries = countryInfo.length;
@@ -90,17 +81,17 @@ describe('unit test lib/country-data.js', () => {
         // test that the two entries have been added to the start of the array, and that
         // the name of the USA includes "America"
         expect(registrationCountryOptions.length).toEqual(numCountries + 2);
-        expect(registrationCountryOptions[0]).toEqual({value: 'United States', label: 'United States of America'});
-        expect(registrationCountryOptions[1]).toEqual({value: 'United Kingdom', label: 'United Kingdom'});
+        expect(registrationCountryOptions[0]).toEqual({value: 'us', label: 'United States of America'});
+        expect(registrationCountryOptions[1]).toEqual({value: 'gb', label: 'United Kingdom'});
 
         // test that there are now two entries for USA
         const usaOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
-            thisCountry.value === 'United States' ? [...acc, thisCountry] : acc
+            thisCountry.value === 'us' ? [...acc, thisCountry] : acc
         ), []);
         expect(usaOptions.length).toEqual(2);
         // test that there are now two entries for UK
         const ukOptions = registrationCountryOptions.reduce((acc, thisCountry) => (
-            thisCountry.value === 'United Kingdom' ? [...acc, thisCountry] : acc
+            thisCountry.value === 'gb' ? [...acc, thisCountry] : acc
         ), []);
         expect(ukOptions.length).toEqual(2);
     });


### PR DESCRIPTION
Reverting because while this change works on the backend, it needs more work to make the educator registration form usable on the frontend. 

#3468 had the unintended effect of making the country dropdown always fail validation, so it was impossible to advance past that step of the educator registration flow.