### PR TITLE
Switch to using scratchr2 check_username endpoint instead of api. 

### DIFF
--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -18,12 +18,17 @@ module.exports.validateUsernameLocally = username => {
 module.exports.validateUsernameRemotely = username => (
     new Promise(resolve => {
         api({
-            uri: `/accounts/checkusername/${username}/`
+            host: '', // not handled by API; use existing infrastructure
+            uri: `/accounts/check_username/${username}/`
         }, (err, body, res) => {
             if (err || res.statusCode !== 200) {
                 resolve({requestSucceeded: false, valid: false, errMsgId: 'general.error'});
             }
-            switch (body.msg) {
+            let msg = '';
+            if (body && body[0]) {
+                msg = body[0].msg;
+            }
+            switch (msg) {
             case 'valid username':
                 resolve({requestSucceeded: true, valid: true});
                 break;


### PR DESCRIPTION
There are some cleanspeak level differences with api that need to be resolved to make it match the scratchr2 version. Until then, we'll use the scratchr2 endpoint.

