### PR TITLE
docs: Change examples of scratchr2 pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Setting `FALLBACK=https://scratch.mit.edu` allows the web client to retrieve dat
 * Login on the splash page (*In the process of being fixed*)
 * Some update attempts to production data made through a development version of the web client
 
-Additionally, if you set `FALLBACK=https://scratch.mit.edu`, be aware that clicking on links to parts of the website not yet migrated over (currently such as `Explore`, `Discuss`, `Profile`, etc.) will take you to the Scratch website itself.
+Additionally, if you set `FALLBACK=https://scratch.mit.edu`, be aware that clicking on links to parts of the website not yet migrated over (currently such as `Discuss`, `Profile`, `My Stuff`, etc.) will take you to the Scratch website itself.
 
 #### Windows
 Some users have experienced difficulties when trying to get our web client to work on Windows. One solution could be to use [Cygwin](https://www.cygwin.com/). If that doesn't work, you might want to use [Wubi](https://wiki.ubuntu.com/WubiGuide) (Windows XP, Vista, 7) or [Wubiuefi](https://github.com/hakuna-m/wubiuefi) (Windows 8 or higher). Wubi(uefi) is a Windows Installer for Ubuntu that allows you to have Ubuntu and Windows on one disk, without the need of an extra partition.


### PR DESCRIPTION
Explore is already migrated you know. Changed the example of README to My Stuff.