### PR TITLE
Additional ChromeOS/Android FAQs for the download page

### DIFF
--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -9,6 +9,7 @@ const bindAll = require('lodash.bindall');
 const Page = require('../../components/page/www/page.jsx');
 const render = require('../../lib/render.jsx');
 const detectOS = require('../../lib/detect-os.js').default;
+const OS_ENUM = require('../../lib/os-enum.js');
 const {CHROME_APP_RELEASED} = require('../../lib/feature-flags.js');
 const OSChooser = require('../../components/os-chooser/os-chooser.jsx');
 const InstallScratch = require('../../components/install-scratch/install-scratch.jsx');
@@ -303,6 +304,43 @@ class Download extends React.Component {
                                 <FormattedMessage id="download.supportLinuxAnswer" />
                             }
                         </p>
+                        {CHROME_APP_RELEASED && isFromGooglePlay(this.state.OS) && (
+                            <React.Fragment>
+                                <h3 className="faq-question">
+                                    <FormattedMessage id="download.whyNoDevicesVisible" />
+                                </h3>
+                                <p>
+                                    <FormattedMessage
+                                        id="download.whyNoDevicesVisibleAnswer"
+                                        values={{
+                                            devicePosessive: (
+                                                this.state.OS === OS_ENUM.ANDROID ?
+                                                    <FormattedMessage id="download.androidPossessive" /> :
+                                                    <FormattedMessage id="download.chromebookPossessive" />
+                                            ),
+                                            whyNoDevicesContactUsLink: (
+                                                <a href="//scratch.mit.edu/contact-us/">
+                                                    <FormattedMessage id="download.whyNoDevicesContactUsLink" />
+                                                </a>
+                                            )
+                                        }}
+                                    />
+                                </p>
+                            </React.Fragment>
+                        )}
+                        {CHROME_APP_RELEASED && isFromGooglePlay(this.state.OS) && (
+                            <React.Fragment>
+                                <h3 className="faq-question">
+                                    <FormattedMessage
+                                        id="download.whyAskForLocation"
+                                        values={{operatingsystem: this.state.OS}}
+                                    />
+                                </h3>
+                                <p>
+                                    <FormattedMessage id="download.whyAskForLocationAnswer" />
+                                </p>
+                            </React.Fragment>
+                        )}
                     </FlexRow>
                 </div>
 

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -47,5 +47,5 @@
   "download.chromebookPossessive": "Chromebook's",
   "download.androidPossessive": "Android tablet's",
   "download.whyAskForLocation" : "Why is {operatingsystem} asking for my location?",
-  "download.whyAskForLocationAnswer" : "Scratch uses bluetooth to connect to other devices, such as a Micro:Bit or Lego Boost.  Bluetooth can be used to provide location data to the app, so Google requires every app that uses bluetooth ask users for permission to access their location. Scratch will not use bluetooth to track your location."
+  "download.whyAskForLocationAnswer" : "Scratch uses bluetooth to connect to other devices, such as a micro:bit or LEGO BOOST.  Bluetooth can be used to provide location data to the app, so Google requires every app that uses bluetooth ask users for permission to access their location. Scratch will not use bluetooth to track your location."
 }

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -40,5 +40,12 @@
   "download.canIShareAnswer": "This isn’t supported currently. For now, you can save a project from Scratch Desktop, upload it to your Scratch account, and share it there. In a later version we will add the ability to upload to your Scratch account directly in Scratch Desktop.",
   "download.canIShareApp": "Can I share to the online community from the Scratch app for {operatingsystem}?",
   "download.canIShareAnswerPlayStore": "Yes. Click the 3-dots menu on a project in the lobby and select \"Share\" from the options. In addition to sharing by email, you can sign in to your Scratch account and share a project to the Scratch online community.",
-  "download.canIShareAnswerDownloaded": "Sharing directly to online community from the Scratch app for {operatingsystem} is not currently supported. For now, you can export a project from the Scratch app, then log onto the Scratch website, and upload and share your project there."
+  "download.canIShareAnswerDownloaded": "Sharing directly to online community from the Scratch app for {operatingsystem} is not currently supported. For now, you can export a project from the Scratch app, then log onto the Scratch website, and upload and share your project there.",
+  "download.whyNoDevicesVisible" : "Why doesn't Scratch show any devices when I try to connect hardware extensions?",
+  "download.whyNoDevicesVisibleAnswer": "We’ve found that turning your {devicePosessive} bluetooth off and on again in the system settings usually allows you to see hardware devices again. If the problem persists, please {whyNoDevicesContactUsLink}.",
+  "download.whyNoDevicesContactUsLink": "contact us",
+  "download.chromebookPossessive": "Chromebook's",
+  "download.androidPossessive": "Android tablet's",
+  "download.whyAskForLocation" : "Why is {operatingsystem} asking for my location?",
+  "download.whyAskForLocationAnswer" : "Scratch uses bluetooth to connect to other devices, such as a Micro:Bit or Lego Boost.  Bluetooth can be used to provide location data to the app, so Google requires every app that uses bluetooth ask users for permission to access their location. Scratch will not use bluetooth to track your location."
 }


### PR DESCRIPTION
Two more questions related to bluetooth on ChromeOS/Android.

They should only be visible if either Chrome or Android is selected, and the `CHROME_APP_RELEASED` feature flag is true.
