### PR TITLE
Skip the join flow smoke test since it was put in place to make sure …

### DIFF
--- a/test/integration-legacy/smoke-testing/test-join.js
+++ b/test/integration-legacy/smoke-testing/test-join.js
@@ -23,7 +23,9 @@ tap.beforeEach(function () {
     return driver.get(rootUrl);
 });
 
-test('Clicking Join Scratch opens scratchr2 iframe', t => {
+// Skipping this test while launching new join flow.
+// TODO: Add new smoke tests for the new Join flow!
+test('Clicking Join Scratch opens scratchr2 iframe', {skip: true}, t => {
     clickText('Join Scratch')
         .then(() => findByXpath('//iframe[contains(@class, "mod-registration")]'))
         .then(() => t.end());


### PR DESCRIPTION
…we didn't launch the new join flow by mistake.

