### PR TITLE
if username has spaces, provide validation message specifically mentioning that

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -230,6 +230,7 @@
     "registration.validationUsernameNotAllowed": "Username not allowed",
     "registration.validationUsernameVulgar": "Hmm, that looks inappropriate",
     "registration.validationUsernameInvalid": "Invalid username",
+    "registration.validationUsernameSpaces": "Usernames can't have spaces",
     "registration.validationEmailInvalid": "Email doesn’t look right. Try another?",
     "registration.waitForApproval": "Wait for Approval",
     "registration.waitForApprovalDescription": "You can log into your Scratch Account now, but the features specific to Teachers are not yet available. Your information is being reviewed. Please be patient, the approval process can take up to one day. You will receive an email indicating your account has been upgraded once your account has been approved.",

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -9,6 +9,8 @@ module.exports.validateUsernameLocally = username => {
         return {valid: false, errMsgId: 'registration.validationUsernameMinLength'};
     } else if (username.length > 20) {
         return {valid: false, errMsgId: 'registration.validationUsernameMaxLength'};
+    } else if (/\s/i.test(username)) {
+        return {valid: false, errMsgId: 'registration.validationUsernameSpaces'};
     } else if (!/^[\w-]+$/i.test(username)) {
         return {valid: false, errMsgId: 'registration.validationUsernameRegexp'};
     }

--- a/test/unit/lib/validate.test.js
+++ b/test/unit/lib/validate.test.js
@@ -33,7 +33,7 @@ describe('unit test lib/validate.js', () => {
 
     test('validate username spaces not allowed', () => {
         const response = validate.validateUsernameLocally('abc def');
-        expect(response).toEqual({valid: false, errMsgId: 'registration.validationUsernameRegexp'});
+        expect(response).toEqual({valid: false, errMsgId: 'registration.validationUsernameSpaces'});
     });
 
     test('validate username special chars not allowed', () => {


### PR DESCRIPTION

### Resolves:

Partially addresses https://github.com/LLK/scratch-www/issues/3526

### Changes:

If, in join flow username field, user types a username with spaces in it, provide a validation message specifically pointing out that problem, rather than showing a general error

### Test Coverage:

Revised relevant test.