### PR TITLE
release Scratch Desktop 3.8.0

### DIFF
--- a/src/components/install-scratch/install-scratch.jsx
+++ b/src/components/install-scratch/install-scratch.jsx
@@ -109,8 +109,8 @@ const InstallScratch = ({
                                     <a
                                         href={
                                             currentOS === OS_ENUM.WINDOWS ?
-                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.6.0.exe' :
-                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.6.0.dmg'
+                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.7.0.exe' :
+                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.7.0.dmg'
                                         }
 
                                     >

--- a/src/components/install-scratch/install-scratch.jsx
+++ b/src/components/install-scratch/install-scratch.jsx
@@ -109,8 +109,8 @@ const InstallScratch = ({
                                     <a
                                         href={
                                             currentOS === OS_ENUM.WINDOWS ?
-                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.7.0.exe' :
-                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.7.0.dmg'
+                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.8.0.exe' :
+                                                'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.8.0.dmg'
                                         }
 
                                     >


### PR DESCRIPTION
### Resolves:

Releases Scratch Desktop 3.8.0

Note: DO NOT DEPLOY YET. The files are not yet in place as certification is still pending.