### PR TITLE
Retry fetching session until it succeeds, when registering using join flow

### DIFF
--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -1,0 +1,29 @@
+const api = require('./api');
+
+module.exports = {};
+
+module.exports.requestSessionWithRetry = (count, resolve, reject) => {
+    console.log('starting refreshSessionWithRetry');
+    api({
+        host: '',
+        uri: '/session/'
+    }, (err, body, response) => {
+        if (err || (response && response.statusCode === 404)) {
+            console.log('refreshSessionWithRetry: resolving with session err');
+            return reject(err);
+        }
+        if (typeof body === 'undefined' || !body.user) {
+            // Retry after 500ms, 1.5s, 3.5s, 7.5s and then stop.
+            if (count > 4) {
+                console.log('refreshSessionWithRetry: too many tries, resolving');
+                return resolve(body);
+            }
+            console.log(`with count ${count}, waiting ${(250 * Math.pow(2, count))} ms`);
+            return setTimeout(module.exports.requestSessionWithRetry.bind(null, count + 1, resolve, reject),
+                250 * Math.pow(2, count));
+        }
+        console.log('refreshSessionWithRetry: session found! resolving with body:');
+        // console.log(body);
+        return resolve(body);
+    });
+};

--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -3,27 +3,21 @@ const api = require('./api');
 module.exports = {};
 
 module.exports.requestSessionWithRetry = (count, resolve, reject) => {
-    console.log('starting refreshSessionWithRetry');
     api({
         host: '',
         uri: '/session/'
     }, (err, body, response) => {
         if (err || (response && response.statusCode === 404)) {
-            console.log('refreshSessionWithRetry: resolving with session err');
             return reject(err);
         }
         if (typeof body === 'undefined' || !body.user) {
             // Retry after 500ms, 1.5s, 3.5s, 7.5s and then stop.
             if (count > 4) {
-                console.log('refreshSessionWithRetry: too many tries, resolving');
                 return resolve(body);
             }
-            console.log(`with count ${count}, waiting ${(250 * Math.pow(2, count))} ms`);
             return setTimeout(module.exports.requestSessionWithRetry.bind(null, count + 1, resolve, reject),
                 250 * Math.pow(2, count));
         }
-        console.log('refreshSessionWithRetry: session found! resolving with body:');
-        // console.log(body);
         return resolve(body);
     });
 };

--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -110,8 +110,9 @@ module.exports.handleCompleteRegistration = createProject => (dispatch => {
         // to be logged in before we try creating a project due to replication lag.
         window.location = '/';
     } else {
-        dispatch(sessionActions.refreshSession());
-        dispatch(module.exports.setRegistrationOpen(false));
+        dispatch(sessionActions.refreshSessionWithRetry()).then(
+            dispatch(module.exports.setRegistrationOpen(false))
+        );
     }
 });
 

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -2,6 +2,7 @@ const keyMirror = require('keymirror');
 const defaults = require('lodash.defaults');
 
 const api = require('../lib/api');
+const sessionLib = require('../lib/session');
 const messageCountActions = require('./message-count.js');
 const permissionsActions = require('./permissions.js');
 
@@ -101,5 +102,48 @@ module.exports.refreshSession = () => (dispatch => {
             dispatch(messageCountActions.getCount(body.user.username));
         }
         return;
+    });
+});
+
+module.exports.refreshSessionWithRetry = () => (dispatch => {
+    dispatch(module.exports.setStatus(module.exports.Status.FETCHING));
+    return new Promise((resolve, reject) => (
+        sessionLib.requestSessionWithRetry(1, resolve, reject)
+    )).then(body => {
+        if (typeof body === 'undefined') return dispatch(module.exports.setSessionError('No session content'));
+        if (
+            body.user &&
+            body.user.banned &&
+            banWhitelistPaths.indexOf(window.location.pathname) === -1
+        ) {
+            window.location = '/accounts/banned-response/';
+            return;
+        } else if (
+            body.flags &&
+            body.flags.must_complete_registration &&
+            window.location.pathname !== '/classes/complete_registration'
+        ) {
+            window.location = '/classes/complete_registration';
+            return;
+        } else if (
+            body.flags &&
+            body.flags.must_reset_password &&
+            !body.flags.must_complete_registration &&
+            window.location.pathname !== '/classes/student_password_reset/'
+        ) {
+            window.location = '/classes/student_password_reset/';
+            return;
+        }
+        dispatch(module.exports.setSession(body));
+        dispatch(module.exports.setStatus(module.exports.Status.FETCHED));
+
+        // get the permissions from the updated session
+        dispatch(permissionsActions.storePermissions(body.permissions));
+        if (typeof body.user !== 'undefined') {
+            dispatch(messageCountActions.getCount(body.user.username));
+        }
+        return;
+    }, err => {
+        dispatch(module.exports.setSessionError(err));
     });
 });


### PR DESCRIPTION
### Resolves:

Alleviates the problem of https://github.com/LLK/scratch-www/issues/3539 , even if it doesn't really solve the underlying problem.

### Changes:

* introduces lib/session.js, which has a `requestSessionWithRetry()` function which retries fetching session until it either gets one with a registered user, or runs out of tries
* adds a `refreshSessionWithRetry()` function to /redux/session.js, which replicates functionality of `refreshSession()` but calls `requestSessionWithRetry()` instead
* changes `join-flow.jsx` to use `refreshSessionWithRetry()` instead of `refreshSession()`; this means only setting the `state.waiting` state variable to `false` after the refreshSessionWithRetry promise resolves
* changes redux/navigation.js's `handleCompleteRegistration()` function to use `refreshSessionWithRetry()` instead of `refreshSession()`; this provides a second chance to obtain a valid session before dismissing the registration modal, when user joins from within the editor.

### Testing locally:

A good way to test is to set lib/api.js to return an empty session for most, but not all, session requests.

These changes make that happen, 70% of the time:

![image](https://user-images.githubusercontent.com/3431616/70107755-6d2cd380-1615-11ea-8577-e2ad4e8b61d3.png)

The result is that, _for this experiment_, 84% (1 - .7 ^ 5) of attempts to register succeed in retrieving the session after registration, but it often takes a second or two.

### Test Coverage:

No added or changed tests. Should I try testing lib/session.js by mocking lib/api.js?