### PR TITLE
[HOTFIX] Update troubleshooting and FAQ sections for Scratch App and hardware …

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -318,5 +318,8 @@
     "social.copyEmbedLinkText": "Copy embed",
     "social.linkLabel": "Link",
     "social.copyLinkLinkText": "Copy link",
-    "social.embedCopiedResultText": "Copied"
+    "social.embedCopiedResultText": "Copied",
+
+    "bluetooth.enableLocationServicesTitle": "Make sure you have location services enabled on Chromebooks or Android tablets",
+    "bluetooth.enableLocationServicesText": "Bluetooth can be used to provide location data to the app. In addition to granting the Scratch App permission to access location, location must be enabled in your general device settings. Search for 'Location' in your settings, and make sure it is on. On Chromebooks search for 'Location' in the Google Play Store Android preferences."
 }

--- a/src/views/boost/boost.jsx
+++ b/src/views/boost/boost.jsx
@@ -235,6 +235,10 @@ class Boost extends ExtensionLanding {
                     <p>
                         <FormattedMessage id="boost.otherComputerConnectedText" />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="bluetooth.enableLocationServicesTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="bluetooth.enableLocationServicesText" />
+                    </p>
                 </ExtensionSection>
             </div>
         );

--- a/src/views/download/download.jsx
+++ b/src/views/download/download.jsx
@@ -181,130 +181,70 @@ class Download extends React.Component {
                         <h2 className="title">
                             <FormattedMessage id="download.troubleshootingTitle" />
                         </h2>
-
-                        {CHROME_APP_RELEASED && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.doIHaveToDownload" />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.doIHaveToDownloadAnswer" />
-                                </p>
-                            </React.Fragment>
+                        <h3 className="faq-question">
+                            <FormattedMessage id="download.doIHaveToDownload" />
+                        </h3>
+                        <p>
+                            <FormattedMessage id="download.doIHaveToDownloadAnswer" />
+                        </p>
+                        <h3 className="faq-question">
+                            <FormattedMessage id="download.howConnectHardwareDevices" />
+                        </h3>
+                        {isDownloaded(this.state.OS) && (
+                            <p>
+                                <FormattedMessage
+                                    id="download.howConnectHardwareDevicesAnswerLink"
+                                    values={{operatingsystem: this.state.OS}}
+                                />
+                            </p>
                         )}
-                        {!CHROME_APP_RELEASED && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.canIUseScratchLink" />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.canIUseScratchLinkAnswer" />
-                                </p>
-                            </React.Fragment>
-                        )}
-                        {CHROME_APP_RELEASED && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.howConnectHardwareDevices" />
-                                </h3>
-                                {isDownloaded(this.state.OS) && (
-                                    <p>
-                                        <FormattedMessage
-                                            id="download.howConnectHardwareDevicesAnswerLink"
-                                            values={{operatingsystem: this.state.OS}}
-                                        />
-                                    </p>
-                                )}
-                                {isFromGooglePlay(this.state.OS) && (
-                                    <p>
-                                        <FormattedMessage
-                                            id="download.howConnectHardwareDevicesAnswerApp"
-                                            values={{operatingsystem: this.state.OS}}
-                                        />
-                                    </p>
-                                )}
-                            </React.Fragment>
-                        )}
-                        {isDownloaded(this.state.OS) && (CHROME_APP_RELEASED ? (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage
-                                        id="download.canIShareApp"
-                                        values={{operatingsystem: this.state.OS}}
-                                    />
-                                </h3>
-                                <p>
-                                    <FormattedMessage
-                                        id="download.canIShareAnswerDownloaded"
-                                        values={{operatingsystem: this.state.OS}}
-                                    />
-                                </p>
-                            </React.Fragment>
-                        ) : (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.canIShare" />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.canIShareAnswer" />
-                                </p>
-                            </React.Fragment>
-                        ))}
                         {isFromGooglePlay(this.state.OS) && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage
-                                        id="download.canIShareApp"
-                                        values={{operatingsystem: this.state.OS}}
-                                    />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.canIShareAnswerPlayStore" />
-                                </p>
-                            </React.Fragment>
+                            <p>
+                                <FormattedMessage
+                                    id="download.howConnectHardwareDevicesAnswerApp"
+                                    values={{operatingsystem: this.state.OS}}
+                                />
+                            </p>
                         )}
                         <h3 className="faq-question">
-                            {CHROME_APP_RELEASED ?
-                                <FormattedMessage id="download.appAndBrowser" /> :
-                                <FormattedMessage id="download.desktopAndBrowser" />
-                            }
+                            <FormattedMessage
+                                id="download.canIShareApp"
+                                values={{operatingsystem: this.state.OS}}
+                            />
+                        </h3>
+                        {isDownloaded(this.state.OS) && (
+                            <p>
+                                <FormattedMessage
+                                    id="download.canIShareAnswerDownloaded"
+                                    values={{operatingsystem: this.state.OS}}
+                                />
+                            </p>
+                        )}
+                        {isFromGooglePlay(this.state.OS) && (
+                            <p>
+                                <FormattedMessage id="download.canIShareAnswerPlayStore" />
+                            </p>
+                        )}
+                        <h3 className="faq-question">
+                            <FormattedMessage id="download.appAndBrowser" />
                         </h3>
                         <p>
                             <FormattedMessage id="download.yesAnswer" />
                         </p>
-                        {CHROME_APP_RELEASED && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.onPhone" />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.onPhoneAnswer" />
-                                </p>
-                            </React.Fragment>
-                        )}
-                        {!CHROME_APP_RELEASED && (
-                            <React.Fragment>
-                                <h3 className="faq-question">
-                                    <FormattedMessage id="download.supportChromeOS" />
-                                </h3>
-                                <p>
-                                    <FormattedMessage id="download.supportChromeOSAnswer" />
-                                </p>
-                            </React.Fragment>
-                        )}
                         <h3 className="faq-question">
-                            {CHROME_APP_RELEASED ?
-                                <FormattedMessage id="download.whenSupportLinuxApp" /> :
-                                <FormattedMessage id="download.whenSupportLinux" />
-                            }
+                            <FormattedMessage id="download.onPhone" />
                         </h3>
                         <p>
-                            {CHROME_APP_RELEASED ?
-                                <FormattedMessage id="download.whenSupportLinuxAppAnswer" /> :
-                                <FormattedMessage id="download.supportLinuxAnswer" />
-                            }
+                            <FormattedMessage id="download.onPhoneAnswer" />
                         </p>
-                        {CHROME_APP_RELEASED && isFromGooglePlay(this.state.OS) && (
+
+                        <h3 className="faq-question">
+                            <FormattedMessage id="download.whenSupportLinuxApp" />
+                        </h3>
+                        <p>
+                            <FormattedMessage id="download.whenSupportLinuxAppAnswer" />
+                        </p>
+                        {isFromGooglePlay(this.state.OS) && (
                             <React.Fragment>
                                 <h3 className="faq-question">
                                     <FormattedMessage id="download.whyNoDevicesVisible" />
@@ -328,7 +268,7 @@ class Download extends React.Component {
                                 </p>
                             </React.Fragment>
                         )}
-                        {CHROME_APP_RELEASED && isFromGooglePlay(this.state.OS) && (
+                        {isFromGooglePlay(this.state.OS) && (
                             <React.Fragment>
                                 <h3 className="faq-question">
                                     <FormattedMessage
@@ -338,6 +278,19 @@ class Download extends React.Component {
                                 </h3>
                                 <p>
                                     <FormattedMessage id="download.whyAskForLocationAnswer" />
+                                </p>
+                            </React.Fragment>
+                        )}
+                        {isFromGooglePlay(this.state.OS) && (
+                            <React.Fragment>
+                                <h3 className="faq-question">
+                                    <FormattedMessage
+                                        id="download.whereProjectStored"
+                                        values={{operatingsystem: this.state.OS}}
+                                    />
+                                </h3>
+                                <p>
+                                    <FormattedMessage id="download.whereProjectStoredAnswer" />
                                 </p>
                             </React.Fragment>
                         )}

--- a/src/views/download/l10n.json
+++ b/src/views/download/l10n.json
@@ -42,10 +42,12 @@
   "download.canIShareAnswerPlayStore": "Yes. Click the 3-dots menu on a project in the lobby and select \"Share\" from the options. In addition to sharing by email, you can sign in to your Scratch account and share a project to the Scratch online community.",
   "download.canIShareAnswerDownloaded": "Sharing directly to online community from the Scratch app for {operatingsystem} is not currently supported. For now, you can export a project from the Scratch app, then log onto the Scratch website, and upload and share your project there.",
   "download.whyNoDevicesVisible" : "Why doesn't Scratch show any devices when I try to connect hardware extensions?",
-  "download.whyNoDevicesVisibleAnswer": "We’ve found that turning your {devicePosessive} bluetooth off and on again in the system settings usually allows you to see hardware devices again. If the problem persists, please {whyNoDevicesContactUsLink}.",
+  "download.whyNoDevicesVisibleAnswer": "We’ve found that turning your {devicePosessive} bluetooth off and on again in the system settings usually allows you to see hardware devices again. If the problem persists, check that Location services are enabled for your device. If you still do not see any devices, please {whyNoDevicesContactUsLink}.",
   "download.whyNoDevicesContactUsLink": "contact us",
   "download.chromebookPossessive": "Chromebook's",
   "download.androidPossessive": "Android tablet's",
   "download.whyAskForLocation" : "Why is {operatingsystem} asking for my location?",
-  "download.whyAskForLocationAnswer" : "Scratch uses bluetooth to connect to other devices, such as a micro:bit or LEGO BOOST.  Bluetooth can be used to provide location data to the app, so Google requires every app that uses bluetooth ask users for permission to access their location. Scratch will not use bluetooth to track your location."
+  "download.whyAskForLocationAnswer" : "Scratch uses bluetooth to connect to other devices, such as a micro:bit or LEGO BOOST.  Bluetooth can be used to provide location data to the app, so Google requires every app that uses bluetooth ask users for permission to access their location. Scratch will not use bluetooth to track your location.",
+  "download.whereProjectStored" : "Where does the Scratch App store my projects?",
+  "download.whereProjectStoredAnswer" : "Projects are saved internally in the app. To export a project file, click the 3-dot menu and select \"Share\". On the next screen select \"export\". The options visible depend on the applications installed on your device. Common options are Google Drive, Files, and email."
 }

--- a/src/views/ev3/ev3.jsx
+++ b/src/views/ev3/ev3.jsx
@@ -357,6 +357,10 @@ class EV3 extends ExtensionLanding {
                             }}
                         />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="bluetooth.enableLocationServicesTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="bluetooth.enableLocationServicesText" />
+                    </p>
                 </ExtensionSection>
             </div>
         );

--- a/src/views/gdxfor/gdxfor.jsx
+++ b/src/views/gdxfor/gdxfor.jsx
@@ -244,6 +244,10 @@ class GdxFor extends ExtensionLanding {
                     <p>
                         <FormattedMessage id="gdxfor.otherComputerConnectedText" />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="bluetooth.enableLocationServicesTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="bluetooth.enableLocationServicesText" />
+                    </p>
                 </ExtensionSection>
             </div>
         );

--- a/src/views/microbit/microbit.jsx
+++ b/src/views/microbit/microbit.jsx
@@ -362,6 +362,10 @@ class MicroBit extends ExtensionLanding {
                     <p>
                         <FormattedMessage id="microbit.resetButtonText" />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="bluetooth.enableLocationServicesTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="bluetooth.enableLocationServicesText" />
+                    </p>
                 </ExtensionSection>
             </div>
         );

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -251,6 +251,10 @@ class Wedo2 extends ExtensionLanding {
                             }}
                         />
                     </p>
+                    <h3 className="faq-title"><FormattedMessage id="bluetooth.enableLocationServicesTitle" /></h3>
+                    <p>
+                        <FormattedMessage id="bluetooth.enableLocationServicesText" />
+                    </p>
                 </ExtensionSection>
             </div>
         );


### PR DESCRIPTION
### Resolves:

Fixes #3570 

### Changes:
Updates the FAQ/Troubleshooting sections for the Download page and extension landing pages.
Also removed the `CHROME_APP_RELEASED` feature flag since it's released now. Make sure to review ignoring whitespace for the flag removal.

### Test Coverage:

On the downloads page with ChromeOS or Android selected, additional troubleshooting for no visible Bluetooth devices, and question about where projects are stored.
<img width="1011" alt="Screen Shot 2019-12-09 at 1 26 42 PM" src="https://user-images.githubusercontent.com/399209/70461939-d8e4c580-1a87-11ea-87de-21d2934f2091.png">

Extensions pages all have an additional item with more detail about enabling Location services on Chromebooks and Android. Answer is visible regardless of OS as someone could be looking for help on a different OS.
<img width="960" alt="Screen Shot 2019-12-09 at 1 27 14 PM" src="https://user-images.githubusercontent.com/399209/70461982-ec902c00-1a87-11ea-86b7-e249212f9066.png">

