### PR TITLE
break word in project description

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -475,6 +475,7 @@ $stage-width: 480px;
         font-size: 1rem;
         line-height: 1.5rem;
         flex: 1;
+        word-break: break-word;
     }
 
     .project-description:last-of-type {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -476,6 +476,7 @@ $stage-width: 480px;
         line-height: 1.5rem;
         flex: 1;
         word-break: break-word;
+        overflow-wrap: break-word;
     }
 
     .project-description:last-of-type {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -475,7 +475,6 @@ $stage-width: 480px;
         font-size: 1rem;
         line-height: 1.5rem;
         flex: 1;
-        word-break: break-word;
         overflow-wrap: break-word;
     }
 


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2853

### Changes:

Implements the fix that @Smrman proposed in https://github.com/LLK/scratch-www/issues/2853#issuecomment-550104414 , which is to apply the `word-break: break-word` style to the `project-description` class.

### Screenshots:

Chrome:

Before:

![image](https://user-images.githubusercontent.com/3431616/70684050-cc709080-1c72-11ea-865a-3b8b7e2cdf16.png)

After:

![image](https://user-images.githubusercontent.com/3431616/70684055-d1cddb00-1c72-11ea-9e5d-50686d0034da.png)


Firefox:

Before: (narrow window size):

![image](https://user-images.githubusercontent.com/3431616/70684075-e316e780-1c72-11ea-88ab-efc1e432cf8c.png)

After: (narrow window size):

![image](https://user-images.githubusercontent.com/3431616/70684091-ec07b900-1c72-11ea-8bcd-0280edff73ac.png)


Safari:

Before:

![image](https://user-images.githubusercontent.com/3431616/70684109-f6c24e00-1c72-11ea-9c6f-fa62dcb7fca8.png)

After:

![image](https://user-images.githubusercontent.com/3431616/70684120-fcb82f00-1c72-11ea-8795-d2dd285ed8f4.png)



