### PR TITLE
[Develop] Hotfix/mandrill outage page banner

### DIFF
--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -6,6 +6,11 @@ const Navigation = require('../../navigation/www/navigation.jsx');
 const Footer = require('../../footer/www/footer.jsx');
 const DonorRecognition = require('./donor-recognition.jsx');
 const ErrorBoundary = require('../../errorboundary/errorboundary.jsx');
+const WarningBanner = require('../../title-banner/warning-banner.jsx');
+
+// Mandrill outage banner
+const MANDRILL_OUTAGE_START_TIME = 1578718800000; // 2020-01-11 12:00:00
+const MANDRILL_OUTAGE_END_TIME = 1578747600000; // 2020-01-11 08:00:00
 
 const Page = ({
     children,
@@ -23,6 +28,12 @@ const Page = ({
                 <Navigation />
             </div>
             <div id="view">
+                {(Date.now() >= MANDRILL_OUTAGE_START_TIME && Date.now() < MANDRILL_OUTAGE_END_TIME) && (
+                    <WarningBanner>
+                    We are experiencing a disruption with email delivery.
+                    If you are not receiving emails from us, please try later.
+                    </WarningBanner>
+                )}
                 {children}
             </div>
             <div id="footer">

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -30,8 +30,8 @@ const Page = ({
             <div id="view">
                 {(Date.now() >= MANDRILL_OUTAGE_START_TIME && Date.now() < MANDRILL_OUTAGE_END_TIME) && (
                     <WarningBanner>
-                    We are experiencing a disruption with email delivery.
-                    If you are not receiving emails from us, please try later.
+                        We are experiencing a disruption with email delivery.
+                        If you are not receiving emails from us, please try after 8am EST.
                     </WarningBanner>
                 )}
                 {children}

--- a/src/components/title-banner/warning-banner.jsx
+++ b/src/components/title-banner/warning-banner.jsx
@@ -1,0 +1,24 @@
+const injectIntl = require('react-intl').injectIntl;
+const PropTypes = require('prop-types');
+const React = require('react');
+
+const FlexRow = require('../flex-row/flex-row.jsx');
+const TitleBanner = require('./title-banner.jsx');
+
+require('./warning-banner.scss');
+
+const WarningBanner = props => (
+    <TitleBanner className="warning-banner">
+        <FlexRow className="warning-banner-container">
+            <p className="title-banner-p">
+                {props.children}
+            </p>
+        </FlexRow>
+    </TitleBanner>
+);
+
+WarningBanner.propTypes = {
+    children: PropTypes.node
+};
+
+module.exports = injectIntl(WarningBanner);

--- a/src/components/title-banner/warning-banner.scss
+++ b/src/components/title-banner/warning-banner.scss
@@ -2,6 +2,7 @@
 
 .warning-banner {
     background-color: $ui-red;
+    margin-bottom: 0;
 
     .warning-banner-container {
         justify-content: center;

--- a/src/components/title-banner/warning-banner.scss
+++ b/src/components/title-banner/warning-banner.scss
@@ -1,0 +1,9 @@
+@import "../../colors";
+
+.warning-banner {
+    background-color: $ui-red;
+
+    .warning-banner-container {
+        justify-content: center;
+    }
+}

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -34,9 +34,14 @@ const ShareProjectMessage = require('./activity-rows/share-project.jsx');
 // Hour of Code Banner Components
 const TopBanner = require('./hoc/top-banner.jsx');
 const MiddleBanner = require('./hoc/middle-banner.jsx');
+const WarningBanner = require('../../components/title-banner/warning-banner.jsx');
 
 const HOC_START_TIME = 1575262800000; // 2019-12-02 00:00:00
 const HOC_END_TIME = 1577077200000; // 2019-12-23 00:00:00
+
+// Mandrill outage banner
+const MANDRILL_OUTAGE_START_TIME = 1578718800000; // 2020-01-11 12:00:00
+const MANDRILL_OUTAGE_END_TIME = 1578747600000; // 2020-01-11 08:00:00
 
 require('./splash.scss');
 
@@ -277,7 +282,7 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                 </Box>
             );
         }
-        
+
         if (this.props.featuredGlobal.scratch_design_studio &&
             this.props.featuredGlobal.scratch_design_studio.length > 4) {
 
@@ -416,6 +421,17 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                         messages={messages}
                     />
                 ] : []}
+                {(Date.now() >= MANDRILL_OUTAGE_START_TIME && Date.now() < MANDRILL_OUTAGE_END_TIME) && (
+                    <MediaQuery
+                        key="frameless-tablet"
+                        minWidth={frameless.tabletPortrait}
+                    >
+                        <WarningBanner>
+                            We are experiencing a disruption with email delivery.
+                            If you are not receiving emails from us, please try later.
+                        </WarningBanner>
+                    </MediaQuery>
+                )}
                 {
                     this.props.sessionStatus === sessionActions.Status.FETCHED &&
                     Object.keys(this.props.user).length === 0 && (// Only show top banner if user is not logged in

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -34,14 +34,9 @@ const ShareProjectMessage = require('./activity-rows/share-project.jsx');
 // Hour of Code Banner Components
 const TopBanner = require('./hoc/top-banner.jsx');
 const MiddleBanner = require('./hoc/middle-banner.jsx');
-const WarningBanner = require('../../components/title-banner/warning-banner.jsx');
 
 const HOC_START_TIME = 1575262800000; // 2019-12-02 00:00:00
 const HOC_END_TIME = 1577077200000; // 2019-12-23 00:00:00
-
-// Mandrill outage banner
-const MANDRILL_OUTAGE_START_TIME = 1578718800000; // 2020-01-11 12:00:00
-const MANDRILL_OUTAGE_END_TIME = 1578747600000; // 2020-01-11 08:00:00
 
 require('./splash.scss');
 
@@ -421,17 +416,6 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                         messages={messages}
                     />
                 ] : []}
-                {(Date.now() >= MANDRILL_OUTAGE_START_TIME && Date.now() < MANDRILL_OUTAGE_END_TIME) && (
-                    <MediaQuery
-                        key="frameless-tablet"
-                        minWidth={frameless.tabletPortrait}
-                    >
-                        <WarningBanner>
-                            We are experiencing a disruption with email delivery.
-                            If you are not receiving emails from us, please try later.
-                        </WarningBanner>
-                    </MediaQuery>
-                )}
                 {
                     this.props.sessionStatus === sessionActions.Status.FETCHED &&
                     Object.keys(this.props.user).length === 0 && (// Only show top banner if user is not logged in


### PR DESCRIPTION
## Resolves:

Resolves #3620

## Changes:

Adds a "warning-banner" component and shows it, with a warning message about Mandrill outage banner, if user's local time is during the planned Mandrill outage.

Note that page styling is not consistent, so some pages have a margin above the banner, while others don't.

## Screenshots:

![image](https://user-images.githubusercontent.com/3431616/72040149-a7713c80-3275-11ea-8602-d65f54faf609.png)

![image](https://user-images.githubusercontent.com/3431616/72040165-b526c200-3275-11ea-961f-91097fc87aa7.png)

![image](https://user-images.githubusercontent.com/3431616/72040175-ba840c80-3275-11ea-846b-6d28ac3cbf61.png)


