### PR TITLE
fix for session promise issue

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -99,20 +99,20 @@ const handleSessionResponse = (dispatch, body) => {
 
 module.exports.refreshSession = () => (dispatch => {
     dispatch(module.exports.setStatus(module.exports.Status.FETCHING));
-    return new Promise((resolve, reject) => (
-        requestSession(resolve, reject).then(body => {
-            handleSessionResponse(dispatch, body);
-        }, err => {
-            dispatch(module.exports.setSessionError(err));
-        })
-    ));
+    return new Promise((resolve, reject) => {
+        requestSession(resolve, reject);
+    }).then(body => {
+        handleSessionResponse(dispatch, body);
+    }, err => {
+        dispatch(module.exports.setSessionError(err));
+    });
 });
 
 module.exports.refreshSessionWithRetry = () => (dispatch => {
     dispatch(module.exports.setStatus(module.exports.Status.FETCHING));
-    return new Promise((resolve, reject) => (
-        requestSessionWithRetry(resolve, reject, 4, 7500)
-    )).then(body => {
+    return new Promise((resolve, reject) => {
+        requestSessionWithRetry(resolve, reject, 4, 7500);
+    }).then(body => {
         handleSessionResponse(dispatch, body);
     }, err => {
         dispatch(module.exports.setSessionError(err));


### PR DESCRIPTION
### Resolves:

Fixes a problem with https://github.com/LLK/scratch-www/pull/3618 where it was treating a non-promise, undefined object like a promise

### Changes:

Instead of calling `then` on a function call that returns the undefined object, calls `then` on the Promise that wraps the function call.
