### PR TITLE
Retry of the change that retries fetching session

### DIFF
--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -1,0 +1,69 @@
+const api = require('./api');
+
+module.exports = {};
+
+/*
+requestSessionWithRetry()
+
+Retries the session api call until it has either reached the limit of number of
+retries, or received a successful response with that contains a 'user' field in
+its body.
+
+Each time it retries, it will double its previous waiting time, and subtract
+that time from the totalDelayMS parameter.
+
+example of what this might look like:
+
+1st call:
+receives params: retriesLeft=3 and totalDelayMS=3500
+performs api call
+delay until next call: 3500 / (2^3 - 1) = 500ms
+next call params: retriesLeft=2, totalDelayMS=3000
+
+2nd call:
+receives params: retriesLeft=2 and totalDelayMS=3000
+performs api call
+delay until next call: 3000 / (2^2 - 1) = 1000ms
+next call: retriesLeft=1, totalDelayMS=2000
+
+3rd call:
+receives params: retriesLeft=1, totalDelayMS=2000
+performs api call
+delay until next call: 2000 / (2^1 - 1) = 2000ms
+next call: retriesLeft=0, totalDelayMS=0
+
+4th call:
+receives params: retriesLeft=0, totalDelayMS=0
+performs api call
+returns the response, even if it is undefined or empty
+
+total api calls: 4
+total delay time: 3500ms
+*/
+module.exports.requestSessionWithRetry = (resolve, reject, retriesLeft, totalDelayMS) => {
+    api({
+        host: '',
+        uri: '/session/'
+    }, (err, body, response) => {
+        if (err || (response && response.statusCode === 404)) {
+            return reject(err);
+        }
+        if (typeof body === 'undefined' || body === null || !body.user) {
+            if (retriesLeft < 1) {
+                return resolve(body);
+            }
+            const nextTimeout = totalDelayMS / (Math.pow(2, retriesLeft) - 1);
+            return setTimeout(
+                module.exports.requestSessionWithRetry.bind(
+                    null, resolve, reject, retriesLeft - 1, totalDelayMS - nextTimeout
+                ),
+                nextTimeout
+            );
+        }
+        return resolve(body);
+    });
+};
+
+module.exports.requestSession = (resolve, reject) => (
+    module.exports.requestSessionWithRetry(resolve, reject, 0, 0)
+);

--- a/src/redux/navigation.js
+++ b/src/redux/navigation.js
@@ -110,8 +110,9 @@ module.exports.handleCompleteRegistration = createProject => (dispatch => {
         // to be logged in before we try creating a project due to replication lag.
         window.location = '/';
     } else {
-        dispatch(sessionActions.refreshSession());
-        dispatch(module.exports.setRegistrationOpen(false));
+        dispatch(sessionActions.refreshSessionWithRetry()).then(
+            dispatch(module.exports.setRegistrationOpen(false))
+        );
     }
 });
 

--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -99,20 +99,20 @@ const handleSessionResponse = (dispatch, body) => {
 
 module.exports.refreshSession = () => (dispatch => {
     dispatch(module.exports.setStatus(module.exports.Status.FETCHING));
-    return new Promise((resolve, reject) => (
-        requestSession(resolve, reject).then(body => {
-            handleSessionResponse(dispatch, body);
-        }, err => {
-            dispatch(module.exports.setSessionError(err));
-        })
-    ));
+    return new Promise((resolve, reject) => {
+        requestSession(resolve, reject);
+    }).then(body => {
+        handleSessionResponse(dispatch, body);
+    }, err => {
+        dispatch(module.exports.setSessionError(err));
+    });
 });
 
 module.exports.refreshSessionWithRetry = () => (dispatch => {
     dispatch(module.exports.setStatus(module.exports.Status.FETCHING));
-    return new Promise((resolve, reject) => (
-        requestSessionWithRetry(resolve, reject, 4, 7500)
-    )).then(body => {
+    return new Promise((resolve, reject) => {
+        requestSessionWithRetry(resolve, reject, 4, 7500);
+    }).then(body => {
         handleSessionResponse(dispatch, body);
     }, err => {
         dispatch(module.exports.setSessionError(err));

--- a/test/unit/lib/session.test.js
+++ b/test/unit/lib/session.test.js
@@ -1,0 +1,133 @@
+describe('session library', () => {
+    // respond to session requests with empty session object
+    let sessionNoUser = jest.fn((opts, callback) => {
+        callback(null, {}, {statusCode: 200});
+    });
+    // respond to session requests with session object that indicates
+    // successfully logged-in user
+    let sessionYesUser = jest.fn((opts, callback) => {
+        callback(null, {user: {username: 'test_username'}}, {statusCode: 200});
+    });
+    // respond to first two requests with empty session object; after that,
+    // respond with user in object
+    let sessionNoThenYes = jest.fn((opts, callback) => {
+        if (sessionNoThenYes.mock.calls.length <= 2) {
+            callback(null, {}, {statusCode: 200});
+        } else {
+            callback(null, {user: {username: 'test_username'}}, {statusCode: 200});
+        }
+    });
+    // respond to session requests with response code 404, indicating no session
+    // found for that user
+    let sessionNotFound = jest.fn((opts, callback) => {
+        callback(null, null, {statusCode: 404});
+    });
+    // respond to session requests with response code 503, indicating connection failure
+    let sessionConnectFailure = jest.fn((opts, callback) => {
+        callback(null, null, {statusCode: 503});
+    });
+
+    // by changing whichMockAPIRequest, we can simulate different api responses
+    let whichMockAPIRequest = null;
+    let mockAPIRequest = (opts, callback) => {
+        whichMockAPIRequest(opts, callback);
+    };
+
+    // mock lib/api.js, and include our mocked version in lib/session.js
+    jest.mock('../../../src/lib/api', () => {
+        return mockAPIRequest;
+    });
+    const sessionLib = require('../../../src/lib/session'); // eslint-disable-line global-require
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('requestSession can call api 1 time, when session found', done => {
+        whichMockAPIRequest = sessionYesUser;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSession(resolve, reject);
+        }).then(body => {
+            expect(sessionYesUser).toHaveBeenCalledTimes(1);
+            expect(body).toEqual({user: {username: 'test_username'}});
+            done();
+        });
+    });
+
+    test('requestSession can call api 1 time, when session not found', done => {
+        whichMockAPIRequest = sessionNoUser;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSession(resolve, reject);
+        }).then(body => {
+            expect(sessionNoUser).toHaveBeenCalledTimes(1);
+            expect(body).toEqual({});
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry can call api once', done => {
+        whichMockAPIRequest = sessionNoUser;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 0, 0);
+        }).then(() => {
+            expect(sessionNoUser).toHaveBeenCalledTimes(1);
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry can call api multiple times', done => {
+        whichMockAPIRequest = sessionNoUser;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 2, 0);
+        }).then(() => {
+            expect(sessionNoUser).toHaveBeenCalledTimes(3);
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry respects total delay time param within a reasonable tolerance', done => {
+        whichMockAPIRequest = sessionNoUser;
+        const startTime = new Date().getTime();
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 2, 2500);
+        }).then(() => {
+            const endTime = new Date().getTime();
+            expect(endTime - startTime > 2000).toBeTruthy();
+            expect(endTime - startTime < 3000).toBeTruthy();
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry will retry if no user found, then stop when user is found', done => {
+        whichMockAPIRequest = sessionNoThenYes;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 4, 3000);
+        }).then(body => {
+            expect(body).toEqual({user: {username: 'test_username'}});
+            expect(sessionNoThenYes).toHaveBeenCalledTimes(3);
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry handles session not found as immediate error', done => {
+        whichMockAPIRequest = sessionNotFound;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 2, 0);
+        }).then(() => {}, err => {
+            expect(err).toBeFalsy();
+            done();
+        });
+    });
+
+    test('requestSessionWithRetry handles connection failure by retrying', done => {
+        whichMockAPIRequest = sessionConnectFailure;
+        new Promise((resolve, reject) => { // eslint-disable-line no-undef
+            sessionLib.requestSessionWithRetry(resolve, reject, 2, 0);
+        }).then(body => {
+            expect(sessionConnectFailure).toHaveBeenCalledTimes(3);
+            expect(body).toBeFalsy();
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
### Resolves:

Partially addresses https://github.com/LLK/scratch-www/issues/3539 , even if it doesn't really solve the underlying problem.

### Changes:

* introduces lib/session.js, which has a `requestSessionWithRetry()` function which retries fetching session until it either gets one with a registered user, or runs out of tries
* adds a `refreshSessionWithRetry()` function to /redux/session.js, which replicates functionality of `refreshSession()` but calls `requestSessionWithRetry()` instead
* changes `join-flow.jsx` to use `refreshSessionWithRetry()` instead of `refreshSession()`; this means only setting the `state.waiting` state variable to `false` after the refreshSessionWithRetry promise resolves
* changes redux/navigation.js's `handleCompleteRegistration()` function to use `refreshSessionWithRetry()` instead of `refreshSession()`; this provides a second chance to obtain a valid session before dismissing the registration modal, when user joins from within the editor.

### Testing locally:

A good way to test is to set lib/api.js to return an empty session for most, but not all, session requests.

These changes make that happen, 70% of the time:

![image](https://user-images.githubusercontent.com/3431616/70107755-6d2cd380-1615-11ea-8577-e2ad4e8b61d3.png)

The result is that, _for this experiment_, 84% (1 - .7 ^ 5) of attempts to register succeed in retrieving the session after registration, but it often takes a second or two.

### Test Coverage:

Added tests of new session functionality, old functionality, and registration use of session calling