### PR TITLE
Set language cookie domain to allow for cross-domain cookies

### DIFF
--- a/src/components/languagechooser/languagechooser.jsx
+++ b/src/components/languagechooser/languagechooser.jsx
@@ -21,7 +21,11 @@ class LanguageChooser extends React.Component {
         ]);
     }
     handleSetLanguage (name, value) {
-        jar.set('scratchlanguage', value, {domain: `.${window.location.hostname}`});
+        let opts = {};
+        if (window.location.hostname !== 'localhost') {
+            opts = {domain: `.${window.location.hostname}`};
+        }
+        jar.set('scratchlanguage', value, opts);
         window.location.reload();
     }
     render () {

--- a/src/components/languagechooser/languagechooser.jsx
+++ b/src/components/languagechooser/languagechooser.jsx
@@ -21,7 +21,7 @@ class LanguageChooser extends React.Component {
         ]);
     }
     handleSetLanguage (name, value) {
-        jar.set('scratchlanguage', value);
+        jar.set('scratchlanguage', value, {domain: `.${window.location.hostname}`});
         window.location.reload();
     }
     render () {


### PR DESCRIPTION
### Resolves:

Part of fixing #3325 

### Changes:
Add leading `.` to the current hostname for the language cookie domain.

The scratchlanguage cookie was being set as `scratch.mit.edu` rather than `.scratch.mit.edu`, note the leading `.` Other backend servers processing the project creation did not have access to the cookie.

### Test Coverage:

**Manual testing prerequisites:**
* access to the database where project metadata is stored
* open dev tools and delete the scratchlanguage cookie

- [ ] default language setting in the browser is used if cookie is not set
  - open browser settings and add another language, place it first in the language list
  - click create
  - editor loads in the new default language, and the project in the database has the same language in metadata

Delete the cookie in between these tests:
- [ ] scratchlanguage cookie is used if set on www
  - On a www page (e.g., home, explore...), choose a language in the language menu
  - create a project
  - [ ] editor loads in the new language, and project in the database also has the same language
  - [ ] in devtools...Application...Cookies, the domain for the scratchlanguage cookie starts with `.`
- [ ] scratchlanguage cookie is used if set on scratchr2
  - On a scratchr2 page (e.g., profile, studios), choose a language in the language menu
  - create a project
  - [ ] editor loads in the new language, and project in the database also has the same language
  - [ ] in devtools...Application...Cookies, the domain for the scratchlanguage cookie starts with `.`
- [ ] scratchlanguage cookie is used if set in the editor
  - In the editor, change language
  - use File...New to create a new project
  - [ ] editor loads in the new language, and project in the database also has the same language
- [ ] in devtools...Application...Cookies, the domain for the scratchlanguage cookie starts with `.`
