### PR TITLE
attempt to get travis cron job to only run translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,6 @@ jobs:
       script: npm run deploy
       on:
         repo: LLK/scratch-www
-        condition: $TRAVIS_EVENT_TYPE != cron
         branch:
         - develop
         - hotfix/*
@@ -138,8 +137,10 @@ jobs:
     script: npm run test:integration:remote
   - stage: update translations
     script: npm run i18n:push
-    if: branch == develop AND type == cron
 stages:
 - test
+  if: type != cron
 - name: smoke
-  if: type != pull_request
+  if: type NOT IN (cron, pull_request)
+- name: update translations
+  if: branch == develop AND type == cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,7 @@ jobs:
       script: npm run deploy
       on:
         repo: LLK/scratch-www
+        condition: $TRAVIS_EVENT_TYPE != cron
         branch:
         - develop
         - hotfix/*
@@ -135,13 +136,10 @@ jobs:
         - master
   - stage: smoke
     script: npm run test:integration:remote
+  - stage: update translations
+    script: npm run i18n:push
+    if: branch == develop AND type == cron
 stages:
 - test
 - name: smoke
   if: type != pull_request
-- provider: script
-  on:
-    branch: develop
-    condition: $TRAVIS_EVENT_TYPE == cron
-  skip_cleanup: true
-  script: npm run i18n:push


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/3215 , to correct a mistake in https://github.com/LLK/scratch-www/pull/3643 .

### Changes:

Second attempt to configure .travis.yml file to cause Travis's develop branch cron job to trigger our translation push script.

