### PR TITLE
[Master] Hotfix project page indexing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15756,9 +15756,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20200122215224",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200122215224.tgz",
-      "integrity": "sha512-rfIZ+89t+LpYln+Ubc2+R2TnMMkuXkmOmTYGZvd5Mkrg442HJDk9HhrxCN8OhlAUzbjjDITABKBL7ilJ39orIg==",
+      "version": "0.1.0-prerelease.20200127164821",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200127164821.tgz",
+      "integrity": "sha512-LyNzqx6wLxINFo74kcLtDumKV5MxsOQiqHSywEFESciUbScktCDp0UrYk7eu9b8A8/e3gUa/v4RM5Aqf5WPH7Q==",
       "dev": true
     },
     "scratch-l10n": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20200122215224",
+    "scratch-gui": "0.1.0-prerelease.20200127164821",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Hotfix to master with https://github.com/LLK/scratch-gui/pull/5333

This fix ensures that the full-screen "unsupported browser" modal does not show for the googlebot crawler when it fails to load full projects. To repro what this looks like, you need to do two things:
1. Enable "Request Blocking" for `assets.scratch.mit.edu/*` in the chrome dev tools to mimic what happens to the crawler, which is it automatically kills requests from the asset server when there are too many. 
![image](https://user-images.githubusercontent.com/654102/73199618-29c97f80-4103-11ea-9a11-4366860153b7.png)

2. Under "Network Conditions", uncheck "select automatically" and choose of the googlebot user agents. 
![image](https://user-images.githubusercontent.com/654102/73199657-3b128c00-4103-11ea-91ea-05dba3cea3f2.png)

Now load any project page. You'll see the full screen "Your browser is not supported" screen:
![image](https://user-images.githubusercontent.com/654102/73199692-4e255c00-4103-11ea-8ff2-ad4736c09b7e.png)

Now do the same for request blocking on staging, and try to load a project as googlebot UA. You should not see the full screen takeover. You can confirm that the browser support screen is still working for other unsupported UA though, by e.g. choosing Opera UA and reloading.

/cc @BryceLTaylor @rschamp I have confirmed all of ^ on staging
