### PR TITLE
Ensure that the old scratchlanguage cookie is removed if it exists.

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -18,6 +18,17 @@ const jar = require('./lib/jar');
             if (['pt', 'pt-pt', 'PT', 'PT-PT'].indexOf(obj) !== -1) {
                 obj = 'pt-br'; // default Portuguese users to Brazilian Portuguese due to our user base. Added in 2.2.5.
             }
+        } else {
+            // delete the old cookie (just hostname) by setting it to null and expiring in the past
+            /* eslint-disable max-len */
+            document.cookie = `scratchlanguage=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${window.location.hostname}`;
+            /* eslint-enable max-len */
+            // create the new cookie
+            let opts = {};
+            if (window.location.hostname !== 'localhost') {
+                opts = {domain: `.${window.location.hostname}`};
+            }
+            jar.set('scratchlanguage', obj, opts);
         }
         return obj;
     };

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -626,7 +626,11 @@ class Preview extends React.Component {
         );
     }
     handleSetLanguage (locale) {
-        jar.set('scratchlanguage', locale);
+        let opts = {};
+        if (window.location.hostname !== 'localhost') {
+            opts = {domain: `.${window.location.hostname}`};
+        }
+        jar.set('scratchlanguage', locale, opts);
     }
     handleUpdateProjectId (projectId, callback) {
         this.setState({projectId: projectId}, () => {


### PR DESCRIPTION
### Resolves:

Fixes issue with https://github.com/LLK/scratch-www/pull/3647 where having the old cookie left around prevents you from changing language.

### Changes:
On init, remove the old cookie if it exists.
On the project page, make sure `handleSetLanguage` also sets the domain.

### Test Coverage:

Difficult to test locally due to hostname rules. See https://github.com/LLK/scratch-www/pull/3647 for testing steps.