### PR TITLE
Add comments.isNotPermitted string

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -293,6 +293,7 @@
     "comments.isDisallowed": "Hmm, it looks like comments have been turned off for this page. :/",
     "comments.isIPMuted": "Sorry, the Scratch Team had to prevent your network from sharing comments or projects because it was used to break our community guidelines too many times. You can still share comments and projects from another network. If you'd like to appeal this block, you can contact appeals@scratch.mit.edu and reference Case Number {appealId}.",
     "comments.isTooLong": "That comment is too long! Please find a way to shorten your text.",
+    "comments.isNotPermitted": "Sorry, you need to confirm your email address before commenting.",
     "comments.error": "Oops! Something went wrong posting your comment",
     "comments.posting": "Posting...",
     "comments.post": "Post",


### PR DESCRIPTION
We were missing a string for the case where a user has not confirmed their email address. These string IDs are interpolated directly from the error code, so no other change is needed.

### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/2861 in a minimal way

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Add a string for the error code that comes back `isNotPermitted`, which corresponds with a user who has not confirmed their email address.

This is the way it is now.
![image](https://user-images.githubusercontent.com/654102/73492008-d31baa00-437d-11ea-9408-327ea95f5d25.png)
