### PR TITLE
use api instead of scratchr2 to validate usernames

### DIFF
--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -20,16 +20,14 @@ module.exports.validateUsernameLocally = username => {
 module.exports.validateUsernameRemotely = username => (
     new Promise(resolve => {
         api({
-            host: '', // not handled by API; use existing infrastructure
-            uri: `/accounts/check_username/${username}/`
+            uri: `/accounts/checkusername/${username}/`
         }, (err, body, res) => {
             if (err || res.statusCode !== 200) {
                 resolve({requestSucceeded: false, valid: false, errMsgId: 'general.error'});
             }
             let msg = '';
-            if (body && body[0]) {
-                msg = body[0].msg;
-            }
+            if (body && body.msg) msg = body.msg;
+            else if (body && body[0]) msg = body[0].msg;
             switch (msg) {
             case 'valid username':
                 resolve({requestSucceeded: true, valid: true});


### PR DESCRIPTION
### Resolves:

* Reverts the core change of https://github.com/LLK/scratch-www/pull/3507
* Sets up https://github.com/LLK/scratch-api/pull/884 to be tested/merged, after this is deployed

### Changes:

* uses api endpoint, rather than scratchr2, to validate usernames.

![Feb-05-2020 15-47-27](https://user-images.githubusercontent.com/3431616/73882225-b07f0a80-482f-11ea-8ce1-7c4a15bb96a1.gif)
