### PR TITLE
Reorder and de-red the report action on project page

### DIFF
--- a/src/views/preview/subactions.jsx
+++ b/src/views/preview/subactions.jsx
@@ -29,6 +29,26 @@ const Subactions = props => (
             {/*  eslint-enable react/jsx-sort-props */}
         </div>
         <FlexRow className="action-buttons">
+            {(props.canReport) &&
+                <React.Fragment>
+                    <Button
+                        className="action-button report-button"
+                        key="report-button"
+                        onClick={props.onReportClicked}
+                    >
+                        <FormattedMessage id="general.report" />
+                    </Button>
+                    {props.reportOpen && (
+                        <ReportModal
+                            isOpen
+                            key="report-modal"
+                            type="project"
+                            onReport={props.onReportSubmit}
+                            onRequestClose={props.onReportClose}
+                        />
+                    )}
+                </React.Fragment>
+            }
             {props.canAddToStudio &&
                 <React.Fragment>
                     <Button
@@ -69,26 +89,6 @@ const Subactions = props => (
                     )}
                 </React.Fragment>
             )}
-            {(props.canReport) &&
-            <React.Fragment>
-                <Button
-                    className="action-button report-button"
-                    key="report-button"
-                    onClick={props.onReportClicked}
-                >
-                    <FormattedMessage id="general.report" />
-                </Button>
-                {props.reportOpen && (
-                    <ReportModal
-                        isOpen
-                        key="report-modal"
-                        type="project"
-                        onReport={props.onReportSubmit}
-                        onRequestClose={props.onReportClose}
-                    />
-                )}
-            </React.Fragment>
-            }
         </FlexRow>
     </FlexRow>
 );

--- a/src/views/preview/subactions.scss
+++ b/src/views/preview/subactions.scss
@@ -88,8 +88,6 @@
             }
 
             &.report-button {
-                background-color: $ui-coral;
-
                 &:before {
                     background-image: url("/svgs/project/report-white.svg");
                 }


### PR DESCRIPTION
### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Reduce the prominence of the report action on project pages to reduce casual/joke/low-quality reports. The thinking is that the prominence of that button is a contributing factor to the increase in false positive reports after launching 3.0 (when the button was made as prominent as it is). 

The new look will put it on an equal footing with the other buttons in that row.

![image](https://user-images.githubusercontent.com/654102/75688789-1bc0ce80-5c6e-11ea-9cc6-a2f3e32e7761.png)

### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._

The new button should look like the screenshot above, and it should continue to function the way it always has. 

For reference, the change comes from discussions with community/design teams, so they have already been consulted. 