### PR TITLE
Fix contact-us mistakes

### DIFF
--- a/src/components/helpform/helpform.jsx
+++ b/src/components/helpform/helpform.jsx
@@ -4,10 +4,10 @@ const React = require('react');
 const FormattedMessage = require('react-intl').FormattedMessage;
 
 const HelpForm = props => {
-    const prefix = 'https://mitscratch.freshdesk.com/widgets/feedback_widget/new?&widgetType=embedded&widgetView=yes&screenshot=No&searchArea=No&captcha=yes';
+    const prefix = 'https://mitscratch.freshdesk.com/widgets/feedback_widget/new?&widgetType=embedded&widgetView=yes&screenshot=No&searchArea=No';
     const title = `formTitle=${props.title}`;
     const username = `helpdesk_ticket[custom_field][cf_scratch_name_40167]=${props.user.username || ''}`;
-    const agentText = encodeURI(window.navigator.userAgent.replace(';', ' -'));
+    const agentText = encodeURIComponent(window.navigator.userAgent);
     const browser = `helpdesk_ticket[custom_field][cf_browser_40167]=${agentText}`;
     const formSubject = `helpdesk_ticket[subject]=${props.subject}`;
     const formDescription = `helpdesk_ticket[description]=${props.body}`;

--- a/src/routes.json
+++ b/src/routes.json
@@ -94,8 +94,8 @@
     },
     {
         "name": "contact-us",
-        "pattern": "^/contact-us/?$",
-        "routeAlias": "/contact-us/?$",
+        "pattern": "^/contact-us/?(\\?.*)?$",
+        "routeAlias": "/contact-us/?",
         "view": "contact-us/contact-us",
         "title": "Contact Us",
         "viewportWidth": "device-width"

--- a/src/views/contact-us/contact-us.jsx
+++ b/src/views/contact-us/contact-us.jsx
@@ -39,7 +39,7 @@ class ContactUs extends React.Component {
                         <p><FormattedMessage
                             id="contactUs.intro"
                             values={{faqLink: (
-                                <a href="/faq"><FormattedMessage id="contactUs.faqLinkText" /></a>
+                                <a href="/info/faq"><FormattedMessage id="contactUs.faqLinkText" /></a>
                             )}}
                         /></p>
                         <p><FormattedMessage id="contactUs.forumsInfo" /></p>
@@ -53,13 +53,13 @@ class ContactUs extends React.Component {
                             <li><FormattedMessage
                                 id="contactUs.scriptsForum"
                                 values={{scriptsLink: (
-                                    <a href="/discuss/4/"><FormattedMessage id="contactUs.scriptsLinkText" /></a>
+                                    <a href="/discuss/7/"><FormattedMessage id="contactUs.scriptsLinkText" /></a>
                                 )}}
                             /></li>
                             <li><FormattedMessage
                                 id="contactUs.bugsForum"
                                 values={{bugsLink: (
-                                    <a href="/discuss/4/"><FormattedMessage id="contactUs.bugsLinkText" /></a>
+                                    <a href="/discuss/3/"><FormattedMessage id="contactUs.bugsLinkText" /></a>
                                 )}}
                             /></li>
                         </ul>
@@ -69,7 +69,7 @@ class ContactUs extends React.Component {
                 <nav>
                     <ol>
                         <li className="nav-header"><FormattedMessage id="contactUs.findHelp" /></li>
-                        <li><a href="/faq"><FormattedMessage id="contactUs.faqLinkText" /></a></li>
+                        <li><a href="/info/faq"><FormattedMessage id="contactUs.faqLinkText" /></a></li>
                     </ol>
                 </nav>
                 <HelpForm


### PR DESCRIPTION
- take captcha off the helpform url
- use encodeUriComponent to make sure semicolons in the agent string don’t mess up the form parameters
- take the `$` end matcher off the route to allow for parameters to be passed
- fix forum links
- fix faq link `/faq` => `/info/faq`
