### PR TITLE
Always apply min-height: 0

### DIFF
--- a/src/components/modal/addtostudio/modal.scss
+++ b/src/components/modal/addtostudio/modal.scss
@@ -34,10 +34,8 @@
     background-color: $ui-blue-10percent;
     flex: 1;
     height: calc(100% - 5rem);
-
-    @media #{$small-height} {
-        min-height: 0;
-    }
+    /* Firefox requires min-height:0: #3775 */
+    min-height: 0;
 }
 
 .studio-list-inner-scrollbox {


### PR DESCRIPTION
### Resolves:
Resolves #3775

### Changes:
Always applies `min-height: 0` for outer container. See also: https://moduscreate.com/blog/how-to-fix-overflow-issues-in-css-flex-layouts/

### Test Coverage:
I manually added the CSS on the main website on Firefox and it showed the button as expected. I also tested it on Chrome and it worked just like before.