### PR TITLE
added /signup/TOKEN route; handle route alongside existing student signup route

### DIFF
--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -1,0 +1,15 @@
+module.exports = {};
+
+// try to extract classroom token from either of two routes
+module.exports.getURIClassroomToken = uriPathname => {
+    // first try to match /classes/CLASSROOM_ID/register/CLASSROOM_TOKEN
+    const classRegisterRegexp = /^\/?classes\/\d*\/register\/([a-zA-Z0-9]*)\/?$/;
+    const classRegisterMatch = classRegisterRegexp.exec(uriPathname);
+    if (classRegisterMatch) return classRegisterMatch[1];
+    // if regex match failed, try to match /join/CLASSROOM_TOKEN
+    const joinTokenRegexp = /^\/?join\/([a-zA-Z0-9]*)\/?$/;
+    const joinTokenMatch = joinTokenRegexp.exec(uriPathname);
+    if (joinTokenMatch) return joinTokenMatch[1];
+    // if neither matched
+    return null;
+};

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -6,10 +6,10 @@ module.exports.getURIClassroomToken = uriPathname => {
     const classRegisterRegexp = /^\/?classes\/\d*\/register\/([a-zA-Z0-9]*)\/?$/;
     const classRegisterMatch = classRegisterRegexp.exec(uriPathname);
     if (classRegisterMatch) return classRegisterMatch[1];
-    // if regex match failed, try to match /join/CLASSROOM_TOKEN
-    const joinTokenRegexp = /^\/?join\/([a-zA-Z0-9]*)\/?$/;
-    const joinTokenMatch = joinTokenRegexp.exec(uriPathname);
-    if (joinTokenMatch) return joinTokenMatch[1];
+    // if regex match failed, try to match /signup/CLASSROOM_TOKEN
+    const signupTokenRegexp = /^\/?signup\/([a-zA-Z0-9]*)\/?$/;
+    const signupTokenMatch = signupTokenRegexp.exec(uriPathname);
+    if (signupTokenMatch) return signupTokenMatch[1];
     // if neither matched
     return null;
 };

--- a/src/routes.json
+++ b/src/routes.json
@@ -281,6 +281,13 @@
         "title": "Class Registration"
     },
     {
+        "name": "student-registration-token-only",
+        "pattern": "^/join/:token",
+        "routeAlias": "/classes/(complete_registration|.+/register/.+)",
+        "view": "studentregistration/studentregistration",
+        "title": "Class Registration"
+    },
+    {
         "name": "teacher-faq",
         "pattern": "^/educators/faq/?$",
         "routeAlias": "/educators(?:/(faq|register|waiting))?/?$",

--- a/src/routes.json
+++ b/src/routes.json
@@ -282,8 +282,8 @@
     },
     {
         "name": "student-registration-token-only",
-        "pattern": "^/join/:token",
-        "routeAlias": "/classes/(complete_registration|.+/register/.+)",
+        "pattern": "^/signup/:token",
+        "routeAlias": "/signup/.+)",
         "view": "studentregistration/studentregistration",
         "title": "Class Registration"
     },

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -75,7 +75,7 @@ class StudentRegistration extends React.Component {
                 ),
                 country: formData.user.country,
                 is_robot: formData.user.isRobot,
-                classroom_id: this.props.classroomId,
+                classroom_id: this.state.classroom.id,
                 classroom_token: this.props.classroomToken
             }
         }, (err, body, res) => {
@@ -100,7 +100,7 @@ class StudentRegistration extends React.Component {
         });
     }
     handleGoToClass () {
-        window.location = `/classes/${this.props.classroomId}/`;
+        window.location = `/classes/${this.state.classroom.id}/`;
     }
     render () {
         const usernameDescription = this.props.intl.formatMessage({id: 'registration.studentUsernameStepDescription'});
@@ -151,13 +151,11 @@ class StudentRegistration extends React.Component {
 }
 
 StudentRegistration.propTypes = {
-    classroomId: PropTypes.string.isRequired,
     classroomToken: PropTypes.string.isRequired,
     intl: intlShape
 };
 
 StudentRegistration.defaultProps = {
-    classroomId: null,
     classroomToken: null
 };
 

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -32,11 +32,22 @@ class StudentRegistration extends React.Component {
     }
     componentDidMount () {
         this.setState({waiting: true}); // eslint-disable-line react/no-did-mount-set-state
+
+        // set uri and params
+        let uri;
+        let params;
+        if (this.props.classroomId === null || typeof this.props.classroomId === 'undefined') {
+            // configure for token-only endpoint
+            uri = `/classtoken/${this.props.classroomToken}`;
+        } else {
+            // configure for endpoint expecting classroomId and token
+            uri = `/classrooms/${this.props.classroomId}`;
+            params = {token: this.props.classroomToken};
+        }
+
         api({
-            uri: `/classrooms/${this.props.classroomId}`,
-            params: {
-                token: this.props.classroomToken
-            }
+            uri: uri,
+            params: params
         }, (err, body, res) => {
             this.setState({waiting: false});
             if (err) {
@@ -164,14 +175,23 @@ StudentRegistration.defaultProps = {
 
 const IntlStudentRegistration = injectIntl(StudentRegistration);
 
-const [classroomId, _, classroomToken] = document.location.pathname.split('/').filter(p => {
-    if (p) {
-        return p;
+// parse either format of student registration url:
+// "class register": http://scratch.mit.edu/classes/3/register/c0256654e1be
+// "join token": http://scratch.mit.edu/join/c025r54ebe
+let classroomId = null;
+let classroomToken = null;
+const classRegisterRegexp = /^\/?classes\/(\d*)\/register\/([a-zA-Z0-9]*)\/?$/;
+const classRegisterMatch = classRegisterRegexp.exec(document.location.pathname);
+if (classRegisterMatch) {
+    classroomId = classRegisterMatch[1];
+    classroomToken = classRegisterMatch[2];
+} else {
+    const joinTokenRegexp = /^\/?join\/([a-zA-Z0-9]*)\/?$/;
+    const joinTokenMatch = joinTokenRegexp.exec(document.location.pathname);
+    if (joinTokenMatch) {
+        classroomToken = joinTokenMatch[1];
     }
-    return null;
-})
-    .slice(-3);
-
+}
 const props = {classroomId, classroomToken};
 
 render(<IntlStudentRegistration {...props} />, document.getElementById('app'));

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -6,6 +6,7 @@ const React = require('react');
 const api = require('../../lib/api');
 const injectIntl = require('../../lib/intl.jsx').injectIntl;
 const intlShape = require('../../lib/intl.jsx').intlShape;
+const route = require('../../lib/route');
 
 const Deck = require('../../components/deck/deck.jsx');
 const Progression = require('../../components/progression/progression.jsx');
@@ -33,21 +34,8 @@ class StudentRegistration extends React.Component {
     componentDidMount () {
         this.setState({waiting: true}); // eslint-disable-line react/no-did-mount-set-state
 
-        // set uri and params
-        let uri;
-        let params;
-        if (this.props.classroomId === null || typeof this.props.classroomId === 'undefined') {
-            // configure for token-only endpoint
-            uri = `/classtoken/${this.props.classroomToken}`;
-        } else {
-            // configure for endpoint expecting classroomId and token
-            uri = `/classrooms/${this.props.classroomId}`;
-            params = {token: this.props.classroomToken};
-        }
-
         api({
-            uri: uri,
-            params: params
+            uri: `/classtoken/${this.props.classroomToken}`
         }, (err, body, res) => {
             this.setState({waiting: false});
             if (err) {
@@ -57,7 +45,7 @@ class StudentRegistration extends React.Component {
                     })
                 });
             }
-            if (res.statusCode === 404) {
+            if (res.statusCode >= 400) {
                 // TODO: Use react-router for this
                 window.location = '/404';
             }
@@ -178,20 +166,6 @@ const IntlStudentRegistration = injectIntl(StudentRegistration);
 // parse either format of student registration url:
 // "class register": http://scratch.mit.edu/classes/3/register/c0256654e1be
 // "join token": http://scratch.mit.edu/join/c025r54ebe
-let classroomId = null;
-let classroomToken = null;
-const classRegisterRegexp = /^\/?classes\/(\d*)\/register\/([a-zA-Z0-9]*)\/?$/;
-const classRegisterMatch = classRegisterRegexp.exec(document.location.pathname);
-if (classRegisterMatch) {
-    classroomId = classRegisterMatch[1];
-    classroomToken = classRegisterMatch[2];
-} else {
-    const joinTokenRegexp = /^\/?join\/([a-zA-Z0-9]*)\/?$/;
-    const joinTokenMatch = joinTokenRegexp.exec(document.location.pathname);
-    if (joinTokenMatch) {
-        classroomToken = joinTokenMatch[1];
-    }
-}
-const props = {classroomId, classroomToken};
+const props = {classroomToken: route.getURIClassroomToken(document.location.pathname)};
 
 render(<IntlStudentRegistration {...props} />, document.getElementById('app'));

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -163,7 +163,7 @@ const IntlStudentRegistration = injectIntl(StudentRegistration);
 
 // parse either format of student registration url:
 // "class register": http://scratch.mit.edu/classes/3/register/c0256654e1be
-// "join token": http://scratch.mit.edu/join/c025r54ebe
+// "signup token": http://scratch.mit.edu/signup/c025r54ebe
 const props = {classroomToken: route.getURIClassroomToken(document.location.pathname)};
 
 render(<IntlStudentRegistration {...props} />, document.getElementById('app'));

--- a/test/unit/lib/route.test.js
+++ b/test/unit/lib/route.test.js
@@ -1,0 +1,26 @@
+const route = require('../../../src/lib/route');
+
+describe('unit test lib/route.js', () => {
+
+    test('getURIClassroomToken exists', () => {
+        expect(typeof route.getURIClassroomToken).toBe('function');
+    });
+
+    test('getURIClassroomToken parses URI paths like /classes/21/register/r9n5f5xk', () => {
+        let response;
+        response = route.getURIClassroomToken('/classes/21/register/r9n5f5xk');
+        expect(response).toEqual('r9n5f5xk');
+    });
+
+    test('getURIClassroomToken parses URI paths like /join/e2dcfkx95', () => {
+        let response;
+        response = route.getURIClassroomToken('/join/e2dcfkx95');
+        expect(response).toEqual('e2dcfkx95');
+    });
+
+    test('getURIClassroomToken works with trailing slash', () => {
+        let response;
+        response = route.getURIClassroomToken('/join/r9n5f5xk/');
+        expect(response).toEqual('r9n5f5xk');
+    });
+});

--- a/test/unit/lib/route.test.js
+++ b/test/unit/lib/route.test.js
@@ -12,15 +12,15 @@ describe('unit test lib/route.js', () => {
         expect(response).toEqual('r9n5f5xk');
     });
 
-    test('getURIClassroomToken parses URI paths like /join/e2dcfkx95', () => {
+    test('getURIClassroomToken parses URI paths like /signup/e2dcfkx95', () => {
         let response;
-        response = route.getURIClassroomToken('/join/e2dcfkx95');
+        response = route.getURIClassroomToken('/signup/e2dcfkx95');
         expect(response).toEqual('e2dcfkx95');
     });
 
     test('getURIClassroomToken works with trailing slash', () => {
         let response;
-        response = route.getURIClassroomToken('/join/r9n5f5xk/');
+        response = route.getURIClassroomToken('/signup/r9n5f5xk/');
         expect(response).toEqual('r9n5f5xk');
     });
 });


### PR DESCRIPTION
Step towards resolving #5463


### Resolves:

Step towards resolving #5463

### Changes:

* adds /signup/TOKEN route that points to src/views/studentregistration/studentregistration.jsx ( /class/ID/register/TOKEN will also still point to it)
* add lib/route.js library to parse URI pathname
* refactor URI path parsing in studentregistration.jsx to extract fields from either route above
* make studentregistration.jsx use available info to send request to /classtoken/TOKEN 

### Test Coverage:

Added a unit test of route library function

### Testing plan

locally, we can both:
* create a new classroom
* note the classroom ID
* generate sign-up link
* log out
* visit the sign-up link URL and try to register
* also visit the old version of the sign-up link URL, by changing it to classes/ID/register/TOKEN

### Comparison of the two routes

response from API, when visiting www at http://localhost:8333/classes/21/register/r9n5f5xk :

{"id":21,"title":"With non-amb","description":"","status":"","date_start":"2020-03-25T00:00:00.000Z","date_end":null,"images":{"250x150":"https://cdn2.scratch.mit.edu/get_image/classroom/21_250x150.png?v=","170x100":"https://cdn2.scratch.mit.edu/get_image/classroom/21_170x100.png?v=","150x85":"https://cdn2.scratch.mit.edu/get_image/classroom/21_150x85.png?v=","75x55":"https://cdn2.scratch.mit.edu/get_image/classroom/21_75x55.png?v="},"educator":{"id":15704902,"username":"benjiwheelerteacher","scratchteam":false,"history":{"joined":"2020-03-09T17:04:02.000Z"},"profile":{"id":14869710,"images":{"90x90":"https://cdn2.scratch.mit.edu/get_image/user/15704902_90x90.png?v=","60x60":"https://cdn2.scratch.mit.edu/get_image/user/15704902_60x60.png?v=","55x55":"https://cdn2.scratch.mit.edu/get_image/user/15704902_55x55.png?v=","50x50":"https://cdn2.scratch.mit.edu/get_image/user/15704902_50x50.png?v=","32x32":"https://cdn2.scratch.mit.edu/get_image/user/15704902_32x32.png?v="},"status":"","bio":"","country":"United States"}}}

response from API, when visiting www at http://localhost:8333/signup/r9n5f5xk : (identical response)

{"id":21,"title":"With non-amb","description":"","status":"","date_start":"2020-03-25T00:00:00.000Z","date_end":null,"images":{"250x150":"https://cdn2.scratch.mit.edu/get_image/classroom/21_250x150.png?v=","170x100":"https://cdn2.scratch.mit.edu/get_image/classroom/21_170x100.png?v=","150x85":"https://cdn2.scratch.mit.edu/get_image/classroom/21_150x85.png?v=","75x55":"https://cdn2.scratch.mit.edu/get_image/classroom/21_75x55.png?v="},"educator":{"id":15704902,"username":"benjiwheelerteacher","scratchteam":false,"history":{"joined":"2020-03-09T17:04:02.000Z"},"profile":{"id":14869710,"images":{"90x90":"https://cdn2.scratch.mit.edu/get_image/user/15704902_90x90.png?v=","60x60":"https://cdn2.scratch.mit.edu/get_image/user/15704902_60x60.png?v=","55x55":"https://cdn2.scratch.mit.edu/get_image/user/15704902_55x55.png?v=","50x50":"https://cdn2.scratch.mit.edu/get_image/user/15704902_50x50.png?v=","32x32":"https://cdn2.scratch.mit.edu/get_image/user/15704902_32x32.png?v="},"status":"","bio":"","country":"United States"}}}
