### PR TITLE
Fix editor title when not logged in

### DIFF
--- a/src/views/preview/meta.jsx
+++ b/src/views/preview/meta.jsx
@@ -1,14 +1,23 @@
 const React = require('react');
 const Helmet = require('react-helmet').default;
+const PropTypes = require('prop-types');
 
 const projectShape = require('./projectshape.jsx').projectShape;
 
 const Meta = props => {
     const {id, title, instructions, author} = props.projectInfo;
 
-    // Do not want to render any meta tags unless all the info is loaded
-    // Check only author (object) because it is ok to have empty string instructions
-    if (!author) return null;
+    if (!author) {
+        // Project info is not ready. It's either fetching state, or logged-out users creating project.
+        if (!props.userPresent) {
+            return (
+                <Helmet>
+                    <title>Scratch - Imagine, Program, Share</title>
+                </Helmet>
+            );
+        }
+        return null;
+    }
 
     const truncatedInstructions = instructions.split(' ')
         .slice(0, 50)
@@ -38,7 +47,8 @@ const Meta = props => {
 };
 
 Meta.propTypes = {
-    projectInfo: projectShape
+    projectInfo: projectShape,
+    userPresent: PropTypes.bool
 };
 
 module.exports = Meta;

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -700,7 +700,10 @@ class Preview extends React.Component {
 
         return (
             <React.Fragment>
-                <Meta projectInfo={this.props.projectInfo} />
+                <Meta
+                    projectInfo={this.props.projectInfo}
+                    userPresent={this.props.userPresent}
+                />
                 {this.props.playerMode ?
                     <Page
                         className={classNames({


### PR DESCRIPTION
### Resolves:
Resolves #3798 

### Changes:
Previously, if `projectInfo.author` is not available, there were no meta-tags. It was not a problem for logged-in users, because when they create new project, a new project is created immediately and author is passed. However, when not logged in, projects are not "created", so there is no author. In this case, check `userPresent` and if it doesn't exist, returns a helmet with `Scratch - Imagine, Program, Share` title. Other meta tags are omitted.

### Test Coverage:
Manually tested
