### PR TITLE
Fix gh-3781: Delay Scratch Conference

### DIFF
--- a/src/views/conference/2020/index/index.jsx
+++ b/src/views/conference/2020/index/index.jsx
@@ -28,7 +28,7 @@ const ConferenceSplash = () => (
         <div className="inner">
             <section className="conf2020-panel mod-desc">
                 <p className="conf2020-panel-desc">
-                    <FormattedMessage id="conference-2020.desc1" />
+                    <FormattedMessage id="conference-2020.desc1" />{' '}
                     <strong><FormattedMessage id="conference-2020.desc1a" /></strong>
                     <br />
                     <br />

--- a/src/views/conference/2020/index/index.jsx
+++ b/src/views/conference/2020/index/index.jsx
@@ -96,8 +96,8 @@ const ConferenceSplash = () => (
                         id="conference-2020.connectNow"
                         values={{
                             scratchInPracticeLink: <a href="https://sip.scratch.mit.edu/">
-                                 <FormattedMessage id="conference-2020.scratchInPracticeText" />
-                           </a>
+                                <FormattedMessage id="conference-2020.scratchInPracticeText" />
+                            </a>
                         }}
                     />
                 </p>

--- a/src/views/conference/2020/index/index.jsx
+++ b/src/views/conference/2020/index/index.jsx
@@ -29,6 +29,7 @@ const ConferenceSplash = () => (
             <section className="conf2020-panel mod-desc">
                 <p className="conf2020-panel-desc">
                     <FormattedMessage id="conference-2020.desc1" />
+                    <strong><FormattedMessage id="conference-2020.desc1a" /></strong>
                     <br />
                     <br />
                     <FormattedMessage id="conference-2020.desc2" />
@@ -91,6 +92,7 @@ const ConferenceSplash = () => (
                     <br />
                     <br />
                     <FormattedMessage id="conference-2020.registrationDelayed" />
+                    <br />
                     <br />
                     <FormattedMessage
                         id="conference-2020.connectNow"

--- a/src/views/conference/2020/index/index.jsx
+++ b/src/views/conference/2020/index/index.jsx
@@ -92,13 +92,13 @@ const ConferenceSplash = () => (
                     <br />
                     <FormattedMessage id="conference-2020.registrationDelayed" />
                     <br />
-                    <FormattedMessage 
+                    <FormattedMessage
                         id="conference-2020.connectNow"
                         values={{
-                           scratchInPracticeLink: <a href="https://sip.scratch.mit.edu/">
-                                <FormattedMessage id="conference-2020.scratchInPracticeText" />
-                            </a> 
-                        }} 
+                            scratchInPracticeLink: <a href="https://sip.scratch.mit.edu/">
+                                 <FormattedMessage id="conference-2020.scratchInPracticeText" />
+                           </a>
+                        }}
                     />
                 </p>
                 <a

--- a/src/views/conference/2020/index/index.jsx
+++ b/src/views/conference/2020/index/index.jsx
@@ -51,14 +51,14 @@ const ConferenceSplash = () => (
                                 <FormattedDate
                                     day="2-digit"
                                     month="long"
-                                    value={new Date(2020, 6, 23)}
+                                    value={new Date(2021, 6, 22)}
                                     year="numeric"
                                 />
                                 {' - '}
                                 <FormattedDate
                                     day="2-digit"
                                     month="long"
-                                    value={new Date(2020, 6, 25)}
+                                    value={new Date(2021, 6, 24)}
                                     year="numeric"
                                 />
                                 <FormattedMessage id="conference-2020.dateDescMore" />
@@ -91,6 +91,15 @@ const ConferenceSplash = () => (
                     <br />
                     <br />
                     <FormattedMessage id="conference-2020.registrationDelayed" />
+                    <br />
+                    <FormattedMessage 
+                        id="conference-2020.connectNow"
+                        values={{
+                           scratchInPracticeLink: <a href="https://sip.scratch.mit.edu/">
+                                <FormattedMessage id="conference-2020.scratchInPracticeText" />
+                            </a> 
+                        }} 
+                    />
                 </p>
                 <a
                     className="button mod-2020-panel"
@@ -101,14 +110,7 @@ const ConferenceSplash = () => (
             </section>
             <section className="conf2020-panel mod-stay">
                 <p className="conf2020-panel-desc">
-                    <FormattedMessage
-                        id="conference-2020.stayDesc1"
-                        values={{
-                            hyattLink: <a href="https://www.hyatt.com/en-US/group-booking/BOSRC/G-SCRA">Hyatt Regency Cambridge Hotel​</a>,
-                            acLink: <a href="https://www.marriott.com/event-reservations/reservation-link.mi?id=1582152189255&key=GRP&app=resvlink">AC Hotel Boston Cambridge​</a>,
-                            allstonLink: <a href="https://hotelstudioallston.reztrip.com/ext/promoRate?property=1604&mode=b&pm=true&sr=556197&vr=3">Studio Allston Hotel​</a>
-                        }}
-                    />
+                    <FormattedMessage id="conference-2020.stayDesc1" />
                     <br />
                     <br />
                     <FormattedMessage
@@ -116,9 +118,6 @@ const ConferenceSplash = () => (
                         values={{
                             emailLink: <a href="mailto:conference@scratch.mit.edu">
                                 conference@scratch.mit.edu
-                            </a>,
-                            registrationLink: <a href="http://scratch2020.eventbrite.com/">
-                                <FormattedMessage id="conference-2020.registrationLinkText" />
                             </a>
                         }}
                     />

--- a/src/views/conference/2020/index/l10n.json
+++ b/src/views/conference/2020/index/l10n.json
@@ -9,7 +9,7 @@
     "conference-2020.location": "Where:",
 
     "conference-2020.desc1": "Join us for the Scratch Conference, an international gathering where educators, researchers, and developers share ideas for supporting creative learning with Scratch.",
-    "conference-2020.desc1a": " Due to the global health crisis, we have delayed the conference for one year, to July 22-24, 2021.",
+    "conference-2020.desc1a": "Due to the global health crisis, we have delayed the conference for one year, to July 22-24, 2021.",
     "conference-2020.desc2": "Scratch has become the world's largest coding community for children around the world. The conference offers hands-on workshops, panel discussions, and interactive demonstrations to explore ways for using Scratch to expand creative learning experiences for diverse learners across subject areas.",
     "conference-2020.desc3": "Together we'll exchange ideas and strategies on how to use Scratch to engage students in learning to think creatively, reason systematically, and work collaboratively—essential skills for everyone in today’s society.",
 

--- a/src/views/conference/2020/index/l10n.json
+++ b/src/views/conference/2020/index/l10n.json
@@ -17,7 +17,7 @@
     "conference-2020.registrationOpen": "The conference fee includes 7 meals (3 breakfast, 3 lunches, 1 dinner) plus refreshments during the day.",
     "conference-2020.registrationDelayed": "In response to the coronavirus crisis (COVID-19), we have decided to delay the Scratch conference for one year, to July 22-24, 2021. We are sending well wishes to our entire global community and hope you can join us then!",
     "conference-2020.connectNow": "Want to connect now? We invite you to learn more about our online conversations, resources, and events at {scratchInPracticeLink}.",
-    "conference-2020.scratchInPracticeText": "Scratch In Practice",
+    "conference-2020.scratchInPracticeText": "Scratch in Practice",
     "conference-2020.register": "Go to registration page",
 
     "conference-2020.stayDesc1": "We will be posting revised lodging options at the beginning of 2021.",

--- a/src/views/conference/2020/index/l10n.json
+++ b/src/views/conference/2020/index/l10n.json
@@ -1,26 +1,26 @@
 {
-    "conference-2020.title": "Scratch Conference 2020:",
+    "conference-2020.title": "Scratch Conference 2021:",
     "conference-2020.subtitle": "Let's Create Together!",
-    "conference-2020.dateDesc": "July 23-25, 2020 | Cambridge, MA, USA",
-    "conference-2020.dateDescMore": " (with opening reception the evening of July 22)",
+    "conference-2020.dateDesc": "July 22-24, 2021 | Cambridge, MA, USA",
+    "conference-2020.dateDescMore": " (with opening reception the evening of July 21)",
     "conference-2020.locationDetails": "MIT Media Lab, Cambridge, MA",
-    "conference-2020.seeBelow": "Learn more about conference dates and locations below.",
 
     "conference-2020.date": "When:",
     "conference-2020.location": "Where:",
 
-    "conference-2020.desc1": "Join us for the Scratch Conference, an international gathering where educators, researchers, and developers share ideas for supporting creative learning with Scratch.",
+    "conference-2020.desc1": "Join us for the Scratch Conference, an international gathering where educators, researchers, and developers share ideas for supporting creative learning with Scratch. Due to the global health crisis, we have delayed the conference for one year, to July 22-24, 2021.",
     "conference-2020.desc2": "Scratch has become the world's largest coding community for children around the world. The conference offers hands-on workshops, panel discussions, and interactive demonstrations to explore ways for using Scratch to expand creative learning experiences for diverse learners across subject areas.",
     "conference-2020.desc3": "Together we'll exchange ideas and strategies on how to use Scratch to engage students in learning to think creatively, reason systematically, and work collaboratively—essential skills for everyone in today’s society.",
 
     "conference-2020.registrationTitle": "Registration:",
     "conference-2020.registrationFee": "Conference Fee: $250",
     "conference-2020.registrationOpen": "The conference fee includes 7 meals (3 breakfast, 3 lunches, 1 dinner) plus refreshments during the day.",
-    "conference-2020.registrationDelayed": "We have delayed the opening of registration until April 3. We’re excited to gather together as a community in July, but we are closely monitoring the situation around the Coronavirus (COVID-19) to determine how it might impact our plans. We will provide more information as it becomes available.",
+    "conference-2020.registrationDelayed": "In response to the coronavirus crisis (COVID-19), we have decided to delay the Scratch conference for one year, to July 22-24, 2021. We are sending well wishes to our entire global community and hope you can join us then!",
+    "conference-2020.connectNow": "Want to connect now? We invite you to learn more about our online conversations, resources, and events at {scratchInPracticeLink}.",
+    "conference-2020.scratchInPracticeText": "Scratch In Practice",
     "conference-2020.register": "Go to registration page",
 
-    "conference-2020.stayDesc1": "We have organized for conference rates at three hotels in the area for Scratch Conference participants, including: {hyattLink} (1.2 miles: 24 minute walk), {acLink} (2.3 miles, 25 minutes by subway), and the {allstonLink} (4.4 miles, 35 minutes by bus+subway)​. ​To reserve a room, click the link for that hotel. We recommend booking as soon as possible as the discounted rates are subject to availability. We're also planning to offer a lower-cost, college dormitory option; we'll post information as soon as it's available. You can also explore other hotel and housing options that work best for you.",
-    "conference-2020.stayDesc2": "Please see the ​{registrationLink} for more details. For additional questions, contact the Scratch Conference Team at {emailLink}",
-    "conference-2020.registrationLinkText": "Registration page",
+    "conference-2020.stayDesc1": "We will be posting revised lodging options at the beginning of 2021.",
+    "conference-2020.stayDesc2": "For additional questions, contact the Scratch Conference Team at {emailLink}",
     "conference-2020.organizedBy": "The Scratch Conference is organized by the Lifelong Kindergarten group at the MIT Media Lab in collaboration with the Scratch Foundation."
 }

--- a/src/views/conference/2020/index/l10n.json
+++ b/src/views/conference/2020/index/l10n.json
@@ -8,7 +8,8 @@
     "conference-2020.date": "When:",
     "conference-2020.location": "Where:",
 
-    "conference-2020.desc1": "Join us for the Scratch Conference, an international gathering where educators, researchers, and developers share ideas for supporting creative learning with Scratch. Due to the global health crisis, we have delayed the conference for one year, to July 22-24, 2021.",
+    "conference-2020.desc1": "Join us for the Scratch Conference, an international gathering where educators, researchers, and developers share ideas for supporting creative learning with Scratch.",
+    "conference-2020.desc1a": " Due to the global health crisis, we have delayed the conference for one year, to July 22-24, 2021.",
     "conference-2020.desc2": "Scratch has become the world's largest coding community for children around the world. The conference offers hands-on workshops, panel discussions, and interactive demonstrations to explore ways for using Scratch to expand creative learning experiences for diverse learners across subject areas.",
     "conference-2020.desc3": "Together we'll exchange ideas and strategies on how to use Scratch to engage students in learning to think creatively, reason systematically, and work collaboratively—essential skills for everyone in today’s society.",
 


### PR DESCRIPTION
### Resolves:

This resolves #3781 

### Changes:

The Scratch Conference was delayed to 2021, so this pull request changes the Scratch Conference page in order to reflect the changes made to the dates of the Scratch Conference.

### Test Coverage:

I didn't really understand how to test this, and when I tried to test it, it wouldn't work, so instead, I re-read the changes that I made twice in order to try and catch anything that I might have broken.