### PR TITLE
remove extraneous parenthesis from student signup route

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -283,7 +283,7 @@
     {
         "name": "student-registration-token-only",
         "pattern": "^/signup/:token",
-        "routeAlias": "/signup/.+)",
+        "routeAlias": "/signup/.+",
         "view": "studentregistration/studentregistration",
         "title": "Class Registration"
     },


### PR DESCRIPTION
### Changes:

removes extraneous parenthesis from the student signup route's routeAlias field. Fastly was throwing an error because of it, understandably!

