### PR TITLE
Move Andrew and Abisola to past contributors

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -156,10 +156,10 @@ const Credits = () => (
                     Chris Graves, Joel Gritter, Megan Haddadi, Connor Hudson,
                     Christina Huang, Tony Hwang, Abdulrahman Idlbi, Randy Jou,
                     Lily Kim, Tauntaun Kim, Saskia Leggett, Tim Mickel,
-                    Amon Millner, My Nguyen, Lisa O&apos;Brien, Tina Quach,
-                    Ricarose Roque, Andrea Saxman, Jay Silver, Tammy Stern,
-                    Lis Sylvan, Hanako Tjia, Claudia Urrea, Julia Zimmerman,
-                    Oren Zuckerman.
+                    Amon Millner, My Nguyen, Lisa O&apos;Brien, Abisola Okuk,
+                    Tina Quach, Ricarose Roque, Andrea Saxman, Jay Silver,
+                    Andrew Sliwinski, Tammy Stern, Lis Sylvan, Hanako Tjia,
+                    Claudia Urrea, Julia Zimmerman, Oren Zuckerman.
                 </p>
                 <p>
                     <FormattedMessage id="credits.partnersBody" />

--- a/src/views/credits/people.json
+++ b/src/views/credits/people.json
@@ -1,18 +1,8 @@
 [
     {
-        "userName": "",
-        "userId": "",
-        "name": "Abisola"
-    },
-    {
         "userName": "amylaser",
         "userId": 17462181,
         "name": "Amy"
-    },
-    {
-        "userName": "thisandagain",
-        "userId": 1709047,
-        "name": "Andrew"
     },
     {
         "userName": "achouse",


### PR DESCRIPTION
### Resolves:

Resolves #3848 

### Changes:

Removes Andrew Sliwinski and Abisola Okuk from the current Scratch Team members section and adds them to the past contributors section.