### PR TITLE
Redirect to login page when logged out user tries to load messages

### DIFF
--- a/src/redux/messages.js
+++ b/src/redux/messages.js
@@ -186,7 +186,6 @@ module.exports.clearAdminMessage = (messageType, messageId, messageCount, adminM
  * @return {null}                     returns nothing
  */
 module.exports.getMessages = (username, token, opts) => {
-    if (!!!username) location.replace("/login/?next=/messages/");
     opts = defaults(opts, {
         messages: [],
         offset: 0,

--- a/src/redux/messages.js
+++ b/src/redux/messages.js
@@ -186,6 +186,7 @@ module.exports.clearAdminMessage = (messageType, messageId, messageCount, adminM
  * @return {null}                     returns nothing
  */
 module.exports.getMessages = (username, token, opts) => {
+    if (!!!username) location.replace("/login/?next=/messages/");
     opts = defaults(opts, {
         messages: [],
         offset: 0,

--- a/src/views/messages/presentation.jsx
+++ b/src/views/messages/presentation.jsx
@@ -182,6 +182,7 @@ class SocialMessagesList extends React.Component {
         return null;
     }
     render () {
+        if (!props.user.username) location.href = "/login/?next=/messages";
         if (this.props.loadStatus === messageStatuses.MESSAGES_ERROR) {
             return (
                 <section className="messages-social">


### PR DESCRIPTION
### Changes:

When a logged out user tries to load [the messages page](https://scratch.mit.edu/messages), the user will be stuck at this screen:
![image](https://user-images.githubusercontent.com/60622217/80869091-96be5980-8c9e-11ea-8400-b5c41d27551c.png)
What this pull request does is: when a logged out user tries to load the messages page, the logged out user will get redirected to the [login page](https://scratch.mit.edu/login/).

### Test Coverage:

The code added (to src/redux/messages.js at line 189) is:
```javascript
if (!!!username) location.replace("/login/?next=/messages/");
```
When either the username is `null`, `undefined`, `false` or a empty string, the user will get redirected.
