### PR TITLE
default student's country to educator's during reg

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -453,7 +453,7 @@ class DemographicsStep extends React.Component {
     handleChooseGender (name, gender) {
         this.setState({otherDisabled: gender !== 'other'});
     }
-    // look up country name using user's country code selection
+    // look up country name using user's country code selection ('us' -> 'United States')
     getCountryName (values) {
         if (values.countryCode) {
             const countryInfo = countryData.lookupCountryInfo(values.countryCode);
@@ -462,6 +462,12 @@ class DemographicsStep extends React.Component {
             }
         }
         return null;
+    }
+    // look up country code from country label ('United States' -> 'us')
+    // if `countryName` is not found, including if it's null or undefined, then this function will return undefined.
+    getCountryCode (countryName) {
+        const country = countryData.countryInfo.find(countryItem => countryItem.name === countryName);
+        return country && country.code;
     }
     handleValidSubmit (formData) {
         const countryName = this.getCountryName(formData);
@@ -573,7 +579,7 @@ class DemographicsStep extends React.Component {
                             validations={{
                                 countryVal: values => this.countryValidator(values)
                             }}
-                            value={countryOptions[0].value}
+                            value={this.getCountryCode(this.props.countryName) || countryOptions[0].value}
                         />
                         <Checkbox
                             className="demographics-checkbox-is-robot"
@@ -598,6 +604,7 @@ class DemographicsStep extends React.Component {
 DemographicsStep.propTypes = {
     activeStep: PropTypes.number,
     birthOffset: PropTypes.number,
+    countryName: PropTypes.string, // like 'United States', not 'US' or 'United States of America'
     description: PropTypes.string,
     intl: intlShape,
     onNextStep: PropTypes.func,

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -132,6 +132,7 @@ class StudentRegistration extends React.Component {
                             onNextStep={this.handleAdvanceStep}
                         />
                         <Steps.DemographicsStep
+                            countryName={this.state.classroom && this.state.classroom.educator.profile.country}
                             description={this.props.intl.formatMessage({
                                 id: 'registration.studentPersonalStepDescription'
                             })}

--- a/src/views/studentregistration/studentregistration.jsx
+++ b/src/views/studentregistration/studentregistration.jsx
@@ -132,7 +132,8 @@ class StudentRegistration extends React.Component {
                             onNextStep={this.handleAdvanceStep}
                         />
                         <Steps.DemographicsStep
-                            countryName={this.state.classroom && this.state.classroom.educator.profile.country}
+                            countryName={this.state.classroom && this.state.classroom.educator &&
+                                this.state.classroom.educator.profile && this.state.classroom.educator.profile.country}
                             description={this.props.intl.formatMessage({
                                 id: 'registration.studentPersonalStepDescription'
                             })}


### PR DESCRIPTION
### Changes:

When a student is registering with a class, pre-fill the country selection drop-down with that of the educator attached to the class.

There are a few things I would like feedback on, including:
- I stopped short of removing the country selection drop-down entirely, which was suggested in the Trello card. I imagine there are a few situations where the student might legitimately want to register a different country compared to the educator, but I suspect they're very rare. On the other hand it doesn't seem harmful to have the drop-down visible, especially if it's usually pre-filled with the correct option. Thoughts?
- The first time the `StudentRegistration` component renders, it doesn't yet have the classroom's data; that's the reason for `this.state.classroom &&` when passing the `countryName` to the `DemographicsStep`. I'm not sure if it's possible for any other items in that chain (`this.state.classroom.educator.profile.country`) to be null or undefined... do I need to add more checks?
- The classroom info returned by the API includes the educator's country name ('United States') but not the country code ('us') or label ('United States of America'). The `DemographicsStep` really would like the country code, so I added a function to convert a country name to a country code. I suspect that the API has ready access to the country code; is it worth changing the API to include that?

### Test Coverage:

Manually tested by registering an educator, generating a classroom link, and viewing the student registration steps resulting from that link. Both US and Afghanistan work: Afghanistan covers the case where there is no country label so the name is used as the label, and the US option covers the case where the country label is present and differs from the country name.
