### PR TITLE
move country name lookup to library

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -466,7 +466,7 @@ class DemographicsStep extends React.Component {
     // look up country code from country label ('United States' -> 'us')
     // if `countryName` is not found, including if it's null or undefined, then this function will return undefined.
     getCountryCode (countryName) {
-        const country = countryData.countryInfo.find(countryItem => countryItem.name === countryName);
+        const country = countryData.lookupCountryName(countryName);
         return country && country.code;
     }
     handleValidSubmit (formData) {

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -456,7 +456,7 @@ class DemographicsStep extends React.Component {
     // look up country name using user's country code selection ('us' -> 'United States')
     getCountryName (values) {
         if (values.countryCode) {
-            const countryInfo = countryData.lookupCountryInfo(values.countryCode);
+            const countryInfo = countryData.lookupCountryByCode(values.countryCode);
             if (countryInfo) {
                 return countryInfo.name;
             }
@@ -466,7 +466,7 @@ class DemographicsStep extends React.Component {
     // look up country code from country label ('United States' -> 'us')
     // if `countryName` is not found, including if it's null or undefined, then this function will return undefined.
     getCountryCode (countryName) {
-        const country = countryData.lookupCountryName(countryName);
+        const country = countryData.lookupCountryByName(countryName);
         return country && country.code;
     }
     handleValidSubmit (formData) {

--- a/src/lib/country-data.js
+++ b/src/lib/country-data.js
@@ -1036,11 +1036,11 @@ const countryOptions = module.exports.countryOptions = (startingCountryInfo, val
     ))
 );
 
-module.exports.lookupCountryInfo = countryCode => (
+module.exports.lookupCountryByCode = countryCode => (
     countryInfo.find(country => country.code === countryCode)
 );
 
-module.exports.lookupCountryName = countryName => (
+module.exports.lookupCountryByName = countryName => (
     countryInfo.find(country => country.name === countryName)
 );
 

--- a/src/lib/country-data.js
+++ b/src/lib/country-data.js
@@ -1040,6 +1040,10 @@ module.exports.lookupCountryInfo = countryCode => (
     countryInfo.find(country => country.code === countryCode)
 );
 
+module.exports.lookupCountryName = countryName => (
+    countryInfo.find(country => country.name === countryName)
+);
+
 /**
  * Function dupeCommonCountries():
  * takes startingCountryInfo, and duplicates any number of its country labels

--- a/test/unit/lib/country-data.test.js
+++ b/test/unit/lib/country-data.test.js
@@ -1,7 +1,8 @@
 const {
     countryInfo,
     countryOptions,
-    lookupCountryInfo,
+    lookupCountryByCode,
+    lookupCountryByName,
     dupeCommonCountries,
     registrationCountryCodeOptions,
     registrationCountryNameOptions,
@@ -45,9 +46,17 @@ describe('unit test lib/country-data.js', () => {
         expect(szInfo.label).toEqual('Eswatini');
     });
 
-    test('lookupCountryInfo() will find country info', () => {
-        expect(typeof lookupCountryInfo).toBe('function');
-        const eswatiniInfo = lookupCountryInfo('sz');
+    test('lookupCountryByCode() will find country info', () => {
+        expect(typeof lookupCountryByCode).toBe('function');
+        const eswatiniInfo = lookupCountryByCode('sz');
+        expect(eswatiniInfo.name).toEqual('Swaziland');
+        expect(eswatiniInfo.display).toEqual('Eswatini');
+        expect(eswatiniInfo.code).toEqual('sz');
+    });
+
+    test('lookupCountryByName() will find country info', () => {
+        expect(typeof lookupCountryByName).toBe('function');
+        const eswatiniInfo = lookupCountryByName('Swaziland');
         expect(eswatiniInfo.name).toEqual('Swaziland');
         expect(eswatiniInfo.display).toEqual('Eswatini');
         expect(eswatiniInfo.code).toEqual('sz');


### PR DESCRIPTION
Small refactor as follow-up to https://github.com/LLK/scratch-www/pull/3856

Moves country code lookup logic into the country data library