### PR TITLE
Fix hasOwnProperty username on join flow

### DIFF
--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -58,7 +58,7 @@ class UsernameStep extends React.Component {
     }
     // simple function to memoize remote requests for usernames
     validateUsernameRemotelyWithCache (username) {
-        if (this.usernameRemoteCache.hasOwnProperty(username)) {
+        if (Object.prototype.hasOwnProperty.call(this.usernameRemoteCache, username)) {
             return Promise.resolve(this.usernameRemoteCache[username]);
         }
         // username is not in our cache


### PR DESCRIPTION
### Resolves:
Resolves #3850 

### Changes:
Instead of calling hasOwnProperty, call Object.prototype.hasOwnProperty.call