### PR TITLE
Use scratch-wiki.info as wiki link in the footer

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -108,7 +108,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="https://en.scratch-wiki.info/">
+                        <a href="https://scratch-wiki.info/">
                             <FormattedMessage id="general.wiki" />
                         </a>
                     </dd>


### PR DESCRIPTION
### Resolves:

https://scratch.mit.edu/discuss/topic/406150/

### Changes:

This changes the wiki URL in the footer to scratch-wiki.info, instead of en.scratch-wiki.info, so people come at [this screen](https://scratch-wiki.info/). Before, the link always redirects to en.scratch-wiki.info, meaning the wiki will be English.