### PR TITLE
Set overflow:hidden on a, not div

### DIFF
--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -14,8 +14,6 @@
 
     .thumbnail-title,
     #{$extras} {
-        overflow: hidden;
-        text-overflow: ellipsis;
         line-height: 1.2em;
         white-space: nowrap;
         word-wrap: break-word;
@@ -27,11 +25,15 @@
         font-weight: 800;
 
         a {
+            overflow: hidden;
+            text-overflow: ellipsis;
             display: block;
         }
     }
 
     #{$extras} {
+        overflow: hidden;
+        text-overflow: ellipsis;
         color: $type-gray;
         font-size: .8462em;
 


### PR DESCRIPTION
### Resolves:
Resolves #3998

### Changes:
Move `overflow:hidden` and `text-overflow:ellipsis` to `a` tag

### Test Coverage:
Manually tested on Inspect
![image](https://user-images.githubusercontent.com/33279053/82751496-9a06ba00-9df2-11ea-8fef-2655471cd0be.png)
