### PR TITLE
[Master] Release/2020-06-11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15721,15 +15721,15 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20200610141359",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200610141359.tgz",
-      "integrity": "sha512-hQthP7RbbISmq67+Ivo4djxKAiEO8Bj/pyZWs9BTTyD20zeNPZfxaNffoNOK/uxX4kwvs8kuCZP/8hz9k7mQ0A==",
+      "version": "0.1.0-prerelease.20200610225210",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200610225210.tgz",
+      "integrity": "sha512-ZhaJT9tV/cA0+IbSJc0vuj3oLUL2SmHgagtz/tVGIdE1dL9zKfAcFIgTVCm1QVBLJLjvgk/hPDol4c9Li06ISA==",
       "dev": true
     },
     "scratch-l10n": {
-      "version": "3.9.20200603151351",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.9.20200603151351.tgz",
-      "integrity": "sha512-gepBvXyy8ki8gbVXSD7/bYhat0UBnmz3EOJs14OE/pJVESC15QCDHjYHuO0pi5VO193XkgzJPONxHLsfvXCT1Q==",
+      "version": "3.9.20200609200912",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.9.20200609200912.tgz",
+      "integrity": "sha512-i4PPKIT6erMgNizTNHoAx4ziC25FVUBUQkR29ocj0l+11hz8OtIJLsOfVjOVpegMMXPAtwLpz5ZQqyzL/eeLvg==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15721,9 +15721,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20200603203751",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200603203751.tgz",
-      "integrity": "sha512-LbCBQZsrNlcNLUHA4gwMLjLIV3tiIwE4BWykV87qXrPVqzVkdO/l9spX+GdTHtjrutg6RB5mk6HbnU8WJbmBSw==",
+      "version": "0.1.0-prerelease.20200610141359",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200610141359.tgz",
+      "integrity": "sha512-hQthP7RbbISmq67+Ivo4djxKAiEO8Bj/pyZWs9BTTyD20zeNPZfxaNffoNOK/uxX4kwvs8kuCZP/8hz9k7mQ0A==",
       "dev": true
     },
     "scratch-l10n": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20200603203751",
+    "scratch-gui": "0.1.0-prerelease.20200610141359",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20200610141359",
+    "scratch-gui": "0.1.0-prerelease.20200610225210",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -38,9 +38,11 @@ $stage-width: 480px;
 
     .inner {
         margin: 0 auto;
+        overflow: auto;
 
         @media #{$medium-and-smaller} {
-            max-width: 90%;
+            // subtract page padding
+            max-width: calc(100% - 1rem);
         }
 
         @media #{$intermediate} {
@@ -146,7 +148,8 @@ $stage-width: 480px;
         flex-grow: 1;
 
         @media #{$medium-and-smaller} {
-            min-width: calc(100% - 2rem);
+            // subtract margin and border
+            min-width: calc(100% - 2rem - 4px);
         }
     }
 
@@ -362,7 +365,7 @@ $stage-width: 480px;
     .guiPlayer {
         display: inline-block;
         position: relative;
-        width: $player-width;
+        max-width: $player-width;
         z-index: 1;
 
         $alert-bg: rgba(255, 255, 255, .85);
@@ -421,7 +424,7 @@ $stage-width: 480px;
         border-radius: 8px;
         background-color: $ui-blue-10percent;
         padding: .75rem;
-        width: calc(100% - 1.5rem);
+        width: calc(100% - 1.5rem - 2px);
         flex-wrap: nowrap;
         align-items: center;
         justify-content: flex-start;
@@ -476,6 +479,7 @@ $stage-width: 480px;
         line-height: 1.5rem;
         flex: 1;
         overflow-wrap: break-word;
+        word-break: break-word;
     }
 
     .project-description:last-of-type {


### PR DESCRIPTION
Features

- Adding points in the middle of segments with the reshape tool no longer affects those segments’ shapes
- In reshape mode, points should now have larger hitboxes and hence be easier to drag
- The space between paint editor scrollbars and canvas edges now counts as part of the scrollbar hitbox

Bug fixes

- Gradient outlines now render properly on the stage
- Prevent memory leaks when dragging huge sprites around
- The pen should now draw long lines instead of dots on tablets where long lines weren’t working before
- Fewer AudioContext warnings (thanks, @watilde and @JinXJinX!!)
- Project Instructions and Notes and Credits should obey page width more consistently
- Project page background should extend fully across project page
