### PR TITLE
Update Translators page URL

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -109,7 +109,7 @@ const Credits = () => (
                         id="credits.acknowledgementsTranslators"
                         values={{
                             translatorsLink: (
-                                <a href="http://wiki.scratch.mit.edu/wiki/Translators">
+                                <a href="https://en.scratch-wiki.info/wiki/Translators">
                                     <FormattedMessage id="credits.acknowledgementsTranslatorsLinkText" />
                                 </a>
                             )


### PR DESCRIPTION
### Resolves:

Resolves #4051.

### Changes:

Updates the link to the Translators page on the Scratch Wiki.
 
// cc @benjiwheeler 
