### PR TITLE
Set wiki link per user's selected language

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -2,6 +2,8 @@ const FormattedMessage = require('react-intl').FormattedMessage;
 const injectIntl = require('react-intl').injectIntl;
 const intlShape = require('react-intl').intlShape;
 const MediaQuery = require('react-responsive').default;
+const connect = require('react-redux').connect;
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const FooterBox = require('../container/footer.jsx');
@@ -109,7 +111,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href={getScratchWikiLink(props.intl.locale)}>
+                        <a href={props.scratchWikiLink}>
                             <FormattedMessage id="general.wiki" />
                         </a>
                     </dd>
@@ -214,7 +216,13 @@ const Footer = props => (
 );
 
 Footer.propTypes = {
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    scratchWikiLink: PropTypes.string
 };
 
-module.exports = injectIntl(Footer);
+const mapStateToProps = (state, ownProps) => ({
+    scratchWikiLink: getScratchWikiLink(ownProps.intl.locale)
+});
+
+const ConnectedFooter = connect(mapStateToProps)(Footer);
+module.exports = injectIntl(ConnectedFooter);

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -8,6 +8,7 @@ const FooterBox = require('../container/footer.jsx');
 const LanguageChooser = require('../../languagechooser/languagechooser.jsx');
 
 const frameless = require('../../../lib/frameless');
+const getScratchWikiLink = require('../../../lib/scratch-wiki');
 
 require('./footer.scss');
 
@@ -108,7 +109,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="https://en.scratch-wiki.info/">
+                        <a href={getScratchWikiLink(props.intl.locale)}>
                             <FormattedMessage id="general.wiki" />
                         </a>
                     </dd>

--- a/src/lib/scratch-wiki.js
+++ b/src/lib/scratch-wiki.js
@@ -1,0 +1,24 @@
+// This list has to be updated when a new Scratch Wiki is made.
+// Note that wikis under testwiki are not included.
+const wwwLocaleToScratchWikiLocale = {
+    en: 'en',
+    ja: 'ja',
+    fr: 'fr',
+    de: 'de',
+    ru: 'ru',
+    hu: 'hu',
+    nl: 'nl',
+    id: 'id'
+};
+
+const getScratchWikiLink = locale => {
+    if (!wwwLocaleToScratchWikiLocale.hasOwnProperty(locale)) {
+        locale = locale.split('-')[0];
+        if (!wwwLocaleToScratchWikiLocale.hasOwnProperty(locale)) {
+            locale = 'en';
+        }
+    }
+    return `https://${wwwLocaleToScratchWikiLocale[locale]}.scratch-wiki.info/`;
+};
+
+module.exports = getScratchWikiLink;

--- a/test/unit/lib/scratch-wiki.test.js
+++ b/test/unit/lib/scratch-wiki.test.js
@@ -1,0 +1,19 @@
+const getScratchWikiLink = require('../../../src/lib/scratch-wiki');
+
+describe('unit test lib/scratch-wiki.js', () => {
+    test('getScratchWikiLink exists', () => {
+        expect(typeof getScratchWikiLink).toBe('function');
+    });
+
+    test('it returns link to jawiki when ja is given', () => {
+        expect(getScratchWikiLink('ja')).toBe('https://ja.scratch-wiki.info/');
+    });
+
+    test('it returns link to jawiki when ja-Hira is given', () => {
+        expect(getScratchWikiLink('ja-Hira')).toBe('https://ja.scratch-wiki.info/');
+    });
+
+    test('it returns link to enwiki when invalid locale is given', () => {
+        expect(getScratchWikiLink('test')).toBe('https://en.scratch-wiki.info/');
+    });
+});


### PR DESCRIPTION
### Resolves:
Resolves #815 

### Changes:
This is similar to #4114 except two things:
- `getScratchWikiLink` is a library.
- `xx-yy`  fallbacks to `xx` first, then `en`

### Test Coverage:
Added a unit test