### PR TITLE
[Develop] use 'evergreen' URLs for Scratch Desktop downloads

### DIFF
--- a/src/components/install-scratch/install-scratch.jsx
+++ b/src/components/install-scratch/install-scratch.jsx
@@ -13,8 +13,8 @@ const Step = require('../../components/steps/step.jsx');
 require('./install-scratch.scss');
 
 const downloadUrls = {
-    mac: 'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-3.11.1.dmg',
-    win: 'https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop%20Setup%203.11.1.exe',
+    mac: 'https://downloads.scratch.mit.edu/desktop/Scratch.dmg',
+    win: 'https://downloads.scratch.mit.edu/desktop/Scratch%20Setup.exe',
     googlePlayStore: 'https://play.google.com/store/apps/details?id=org.scratch',
     microsoftStore: 'https://www.microsoft.com/store/apps/9pfgj25jl6x3?cid=storebadge&ocid=badge',
     macAppStore: 'https://apps.apple.com/us/app/scratch-desktop/id1446785996?mt=12'


### PR DESCRIPTION
### Changes:

Future Scratch Desktop releases will use redirects to point a stable URL for each platform to the latest version of that platform's installer. This means we will no longer need to make a `scratch-www` change for each Scratch Desktop release. This change is also the first of many steps toward renaming "Scratch Desktop" to "Scratch".

See also #4146

### Test Coverage:

URLs tested by hand.