### PR TITLE
fix Safari fullscreen CSS bugs

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -364,7 +364,7 @@ $stage-width: 480px;
     .guiPlayer {
         display: inline-block;
         position: relative;
-        max-width: $player-width;
+        width: $player-width;
         z-index: 1;
 
         $alert-bg: rgba(255, 255, 255, .85);

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -38,7 +38,6 @@ $stage-width: 480px;
 
     .inner {
         margin: 0 auto;
-        overflow: auto;
 
         @media #{$medium-and-smaller} {
             // subtract page padding
@@ -402,6 +401,7 @@ $stage-width: 480px;
         flex: 1;
         flex-flow: column;
         margin-top: .3125rem;
+        overflow: auto;
 
         @media #{$medium-and-smaller} {
             margin-top: .5rem;
@@ -479,7 +479,6 @@ $stage-width: 480px;
         line-height: 1.5rem;
         flex: 1;
         overflow-wrap: break-word;
-        word-break: break-word;
     }
 
     .project-description:last-of-type {


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/4098
Resolves https://github.com/LLK/scratch-www/issues/4089
Resolves https://github.com/LLK/scratch-www/issues/4090


### Changes:

* Per @adroitwhiz's suggestion, moves `overflow: auto` and removes use of the deprecated `word-break: break-work`
* reverts change to guiPlayer's `max-width` which seems to coincide with a Safari rendering bug

These were introduced in https://github.com/LLK/scratch-www/pull/2518 .

### Test Coverage:

Should be tested in multiple browsers. I have tested on Mac Chrome, Safari, and Firefox.

Test plan:

* on project page:
    * go in and out of fullsrceen. confirm that fullscreen mode looks correct.
    * go into fullsrceen, reload, click the back button. confirm that instructions/notes and credits take up normal width.
    * resize page width and confirm all widths look good

