### PR TITLE
Exponentially back off the time between message polling instead of do…

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -37,14 +37,16 @@ class Navigation extends React.Component {
     componentDidMount () {
         if (this.props.user) {
             // Setup polling for messages to start in 2 minutes.
-            setTimeout(this.pollForMessages.bind(this, 2), 2 * 60 * 1000);
+            const twoMinInMs = 2 * 60 * 1000;
+            setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
         }
     }
     componentDidUpdate (prevProps) {
         if (prevProps.user !== this.props.user) {
             this.props.handleCloseAccountNav();
             if (this.props.user) {
-                setTimeout(this.pollForMessages.bind(this, 2), 2 * 60 * 1000);
+                const twoMinInMs = 2 * 60 * 1000;
+                setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
             } else {
                 // clear message count check, and set to default id.
                 clearTimeout(this.state.messageCountIntervalId);
@@ -70,16 +72,16 @@ class Navigation extends React.Component {
         return `/users/${this.props.user.username}/`;
     }
 
-    pollForMessages (minutes) {
+    pollForMessages (ms) {
         this.props.getMessageCount(this.props.user.username);
         // We only poll if it has been less than 30 minutes.
         // Chances of someone actively using the page for that long without
         // a navigation is low.
-        if (minutes < 32) {
-            const nextFetch = minutes * 2;
+        if (ms < 32 * 60 * 1000) { // 32 minutes
+            const nextFetch = ms * 2; // exponentially back off next fetch time.
             const timeoutId = setTimeout(() => {
                 this.pollForMessages(nextFetch);
-            }, nextFetch * 60000);
+            }, nextFetch);
             this.setState({ // eslint-disable-line react/no-did-mount-set-state
                 messageCountIntervalId: timeoutId
             });

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -69,7 +69,7 @@ class Navigation extends React.Component {
 
     pollForMessages (ms) {
         this.props.getMessageCount(this.props.user.username);
-        // We only poll if it has been less than 30 minutes.
+        // We only poll if it has been less than 32 minutes.
         // Chances of someone actively using the page for that long without
         // a navigation is low.
         if (ms < 32 * 60 * 1000) { // 32 minutes

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -28,7 +28,7 @@ class Navigation extends React.Component {
         bindAll(this, [
             'getProfileUrl',
             'handleSearchSubmit',
-            'setupMessagePolling'
+            'pollForMessages'
         ]);
         this.state = {
             messageCountIntervalId: -1 // javascript method interval id for getting messsage count.
@@ -37,14 +37,14 @@ class Navigation extends React.Component {
     componentDidMount () {
         if (this.props.user) {
             // Setup polling for messages to start in 2 minutes.
-            setTimeout(this.setupMessagePolling.bind(this, 2), 2 * 60 * 1000);
+            setTimeout(this.pollForMessages.bind(this, 2), 2 * 60 * 1000);
         }
     }
     componentDidUpdate (prevProps) {
         if (prevProps.user !== this.props.user) {
             this.props.handleCloseAccountNav();
             if (this.props.user) {
-                setTimeout(this.setupMessagePolling.bind(this, 2), 2 * 60 * 1000);
+                setTimeout(this.pollForMessages.bind(this, 2), 2 * 60 * 1000);
             } else {
                 // clear message count check, and set to default id.
                 clearTimeout(this.state.messageCountIntervalId);
@@ -70,7 +70,7 @@ class Navigation extends React.Component {
         return `/users/${this.props.user.username}/`;
     }
 
-    setupMessagePolling (minutes) {
+    pollForMessages (minutes) {
         this.props.getMessageCount(this.props.user.username);
         // We only poll if it has been less than 30 minutes.
         // Chances of someone actively using the page for that long without
@@ -78,7 +78,7 @@ class Navigation extends React.Component {
         if (minutes < 32) {
             const nextFetch = minutes * 2;
             const timeoutId = setTimeout(() => {
-                this.setupMessagePolling(nextFetch);
+                this.pollForMessages(nextFetch);
             }, nextFetch * 60000);
             this.setState({ // eslint-disable-line react/no-did-mount-set-state
                 messageCountIntervalId: timeoutId

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -30,15 +30,14 @@ class Navigation extends React.Component {
             'handleSearchSubmit',
             'pollForMessages'
         ]);
-        this.state = {
-            messageCountIntervalId: -1 // javascript method interval id for getting messsage count.
-        };
+        // Keep the timeout id so we can cancel it (e.g. when we unmount)
+        this.messageCountTimeoutId = -1;
     }
     componentDidMount () {
         if (this.props.user) {
             // Setup polling for messages to start in 2 minutes.
             const twoMinInMs = 2 * 60 * 1000;
-            setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
+            this.messageCountTimeoutId = setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
         }
     }
     componentDidUpdate (prevProps) {
@@ -46,25 +45,21 @@ class Navigation extends React.Component {
             this.props.handleCloseAccountNav();
             if (this.props.user) {
                 const twoMinInMs = 2 * 60 * 1000;
-                setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
+                this.messageCountTimeoutId = setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
             } else {
                 // clear message count check, and set to default id.
-                clearTimeout(this.state.messageCountIntervalId);
+                clearTimeout(this.messageCountTimeoutId);
                 this.props.setMessageCount(0);
-                this.setState({ // eslint-disable-line react/no-did-update-set-state
-                    messageCountIntervalId: -1
-                });
+                this.messageCountTimeoutId = -1;
             }
         }
     }
     componentWillUnmount () {
         // clear message interval if it exists
-        if (this.state.messageCountIntervalId !== -1) {
-            clearTimeout(this.state.messageCountIntervalId);
+        if (this.messageCountTimeoutId !== -1) {
+            clearTimeout(this.messageCountTimeoutId);
             this.props.setMessageCount(0);
-            this.setState({
-                messageCountIntervalId: -1
-            });
+            this.messageCountTimeoutId = -1;
         }
     }
     getProfileUrl () {
@@ -82,9 +77,7 @@ class Navigation extends React.Component {
             const timeoutId = setTimeout(() => {
                 this.pollForMessages(nextFetch);
             }, nextFetch);
-            this.setState({ // eslint-disable-line react/no-did-mount-set-state
-                messageCountIntervalId: timeoutId
-            });
+            this.messageCountTimeoutId = timeoutId;
         }
     }
 

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -47,8 +47,10 @@ class Navigation extends React.Component {
                 const twoMinInMs = 2 * 60 * 1000;
                 this.messageCountTimeoutId = setTimeout(this.pollForMessages.bind(this, twoMinInMs), twoMinInMs);
             } else {
-                // clear message count check, and set to default id.
-                clearTimeout(this.messageCountTimeoutId);
+                // Clear message count check, and set to default id.
+                if (this.messageCountTimeoutId !== -1) {
+                    clearTimeout(this.messageCountTimeoutId);
+                }
                 this.props.setMessageCount(0);
                 this.messageCountTimeoutId = -1;
             }

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -167,7 +167,6 @@ describe('Navigation', () => {
         const twoMin = 2 * 60 * 1000;
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), twoMin);
         expect(navInstance.messageCountTimeoutId).not.toEqual(-1);
-        debugger;
         navInstance.componentWillUnmount();
         expect(clearTimeout).toHaveBeenCalledWith(expect.any(Number));
         expect(navInstance.messageCountTimeoutId).toEqual(-1);

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -1,5 +1,5 @@
 const React = require('react');
-const {shallowWithIntl} = require('../../helpers/intl-helpers.jsx');
+const {shallowWithIntl, mountWithIntl} = require('../../helpers/intl-helpers.jsx');
 import configureStore from 'redux-mock-store';
 const Navigation = require('../../../src/components/navigation/www/navigation.jsx');
 const Registration = require('../../../src/components/registration/registration.jsx');
@@ -11,6 +11,7 @@ describe('Navigation', () => {
 
     beforeEach(() => {
         store = null;
+        jest.useFakeTimers();
     });
 
     const getNavigationWrapper = props => {
@@ -102,5 +103,89 @@ describe('Navigation', () => {
 
         navWrapper.find('a.registrationLink').simulate('click', {preventDefault () {}});
         expect(navInstance.props.handleClickRegistration).toHaveBeenCalled();
+    });
+
+    test('Component sets up message polling when it mounts', () => {
+        store = mockStore({
+            navigation: {
+                registrationOpen: false
+            },
+            messageCount: {
+                messageCount: 5
+            }
+        });
+        const props = {
+            user: {
+                thumbnailUrl: 'scratch.mit.edu',
+                username: 'auser'
+            },
+            getMessageCount: jest.fn()
+        };
+        const intlWrapper = mountWithIntl(
+            <Navigation
+                {...props}
+            />, {context: {store},
+                childContextTypes: {store}
+            });
+
+        intlWrapper.children().find('Navigation')
+            .instance();
+        const twoMin = 2 * 60 * 1000;
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), twoMin);
+        // Advance timers passed the intial two minutes.
+        jest.advanceTimersByTime(twoMin + 1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), twoMin * 2);
+        expect(props.getMessageCount).toHaveBeenCalled();
+    });
+
+    test('SetupMessagePolling polls for messages 5 times', () => {
+        store = mockStore({
+            navigation: {
+                registrationOpen: false
+            },
+            messageCount: {
+                messageCount: 5
+            }
+        });
+        const props = {
+            user: {
+                thumbnailUrl: 'scratch.mit.edu',
+                username: 'auser'
+            },
+            getMessageCount: jest.fn()
+        };
+        const intlWrapper = mountWithIntl(
+            <Navigation
+                {...props}
+            />, {context: {store},
+                childContextTypes: {store}
+            });
+
+        const navInstance = intlWrapper.children().find('Navigation')
+            .instance();
+        // Clear the timers and mocks because componentDidMount
+        // has already called setupMessagePolling.
+        jest.clearAllTimers();
+        jest.clearAllMocks();
+
+        navInstance.setupMessagePolling(2);
+
+        // Check that we set the timeout to backoff exponentially
+        let minutes = 2 * 60 * 1000;
+        for (let count = 1; count < 5; ++count) {
+            jest.advanceTimersByTime(minutes + 1);
+            expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), minutes * 2);
+            expect(props.getMessageCount).toHaveBeenCalledTimes(count);
+            minutes = minutes * 2;
+        }
+
+        // Exhaust all timers (there shouldn't be any left)
+        jest.runAllTimers();
+        // We exponentially back off checking for messages, starting at 2 min
+        // and stop after 32 minutes so it should happen 5 times total.
+        expect(props.getMessageCount).toHaveBeenCalledTimes(5);
+        // setTimeout happens 1 fewer since the original call to
+        // setupMessagePolling isn't counted here.
+        expect(setTimeout).toHaveBeenCalledTimes(4);
     });
 });

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -167,16 +167,16 @@ describe('Navigation', () => {
         // has already called pollForMessages.
         jest.clearAllTimers();
         jest.clearAllMocks();
-
-        navInstance.pollForMessages(2);
+        let twoMinInMs = 2 * 60 * 1000; // 2 minutes in ms.
+        navInstance.pollForMessages(twoMinInMs);
 
         // Check that we set the timeout to backoff exponentially
-        let minutes = 2 * 60 * 1000;
+
         for (let count = 1; count < 5; ++count) {
-            jest.advanceTimersByTime(minutes + 1);
-            expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), minutes * 2);
+            jest.advanceTimersByTime(twoMinInMs + 1);
+            expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), twoMinInMs * 2);
             expect(props.getMessageCount).toHaveBeenCalledTimes(count);
-            minutes = minutes * 2;
+            twoMinInMs = twoMinInMs * 2;
         }
 
         // Exhaust all timers (there shouldn't be any left)

--- a/test/unit/components/navigation.test.jsx
+++ b/test/unit/components/navigation.test.jsx
@@ -138,7 +138,7 @@ describe('Navigation', () => {
         expect(props.getMessageCount).toHaveBeenCalled();
     });
 
-    test('SetupMessagePolling polls for messages 5 times', () => {
+    test('pollForMessages polls for messages 5 times', () => {
         store = mockStore({
             navigation: {
                 registrationOpen: false
@@ -164,11 +164,11 @@ describe('Navigation', () => {
         const navInstance = intlWrapper.children().find('Navigation')
             .instance();
         // Clear the timers and mocks because componentDidMount
-        // has already called setupMessagePolling.
+        // has already called pollForMessages.
         jest.clearAllTimers();
         jest.clearAllMocks();
 
-        navInstance.setupMessagePolling(2);
+        navInstance.pollForMessages(2);
 
         // Check that we set the timeout to backoff exponentially
         let minutes = 2 * 60 * 1000;
@@ -185,7 +185,7 @@ describe('Navigation', () => {
         // and stop after 32 minutes so it should happen 5 times total.
         expect(props.getMessageCount).toHaveBeenCalledTimes(5);
         // setTimeout happens 1 fewer since the original call to
-        // setupMessagePolling isn't counted here.
+        // pollForMessages isn't counted here.
         expect(setTimeout).toHaveBeenCalledTimes(4);
     });
 });


### PR DESCRIPTION
…ing it every two minutes.

### Resolves:

https://github.com/LLK/scratch-www/issues/4079

### Changes:

Back off how often we poll for new messages

### Test Coverage:

There are unit tests for the new setupMessagePolling function.
