### PR TITLE
add overflow settings to css for remix credit

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -444,6 +444,8 @@ $stage-width: 480px;
         font-size: .875rem;
         flex-shrink: 1;
         text-align: left;
+        overflow: auto;
+        overflow-wrap: break-word;
     }
 
     .description-block {


### PR DESCRIPTION
### Resolves:

Follow up to https://github.com/LLK/scratch-www/pull/4149 and https://github.com/LLK/scratch-www/pull/2518

### Changes:

* Added `overflow: auto` and `overflow-wrap: break-word` to credit-text class

Before:

![image](https://user-images.githubusercontent.com/3431616/86964270-d2105500-c133-11ea-8ee1-722ef34f1760.png)

After:

![image](https://user-images.githubusercontent.com/3431616/86964278-d472af00-c133-11ea-98e2-25e7d104bf74.png)


### Test Coverage:

I tested in Mac Chrome, Firefox and Safari.