### PR TITLE
Update gui version hotfix/rever-scratch-render branch version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16236,9 +16236,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20200715032543",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200715032543.tgz",
-      "integrity": "sha512-FXWqmkA/HxgHaDhcF0Ky9RHqr8ZtN4K0LvA3RkXC1eCnBNSgw227mQVXvalGfxK5hwPKGn5AXaJZ3JYpH3oD/A==",
+      "version": "0.1.0-prerelease.20200716204544",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20200716204544.tgz",
+      "integrity": "sha512-VzZzrOYnfZ9NC+io4DCtJzXwQAfbOMjFu7KilZf6F+r1tUUpg6aynpZ+YuNDOLty4f+3QMcnQuJu75Q1H05kpg==",
       "dev": true
     },
     "scratch-l10n": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20200715032543",
+    "scratch-gui": "0.1.0-prerelease.20200716204544",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Pulls https://github.com/LLK/scratch-render/pull/660 (which reverts some changes to scratch-render) into the release branch.