### PR TITLE
Add overflow, white-space and text-overflow CSS elements

### DIFF
--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -14,8 +14,6 @@
 
     .thumbnail-title,
     #{$extras} {
-        overflow: hidden;
-        text-overflow: ellipsis;
         line-height: 1.2em;
         white-space: nowrap;
         word-wrap: break-word;
@@ -28,10 +26,16 @@
 
         a {
             display: block;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
         }
     }
 
     #{$extras} {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
         color: $type-gray;
         font-size: .8462em;
 


### PR DESCRIPTION
### Resolves:

Partially addresses #3998.

### Changes:

Adds overflow, white-space, and text-overflow CSS elements

### Test Coverage:

Tested with Inspect Element for both project and studio search.
Studio:
![Screenshot (79)](https://user-images.githubusercontent.com/61620631/87852713-37c7c280-c926-11ea-89f3-b8cd2b881138.png)
Project:
![Screenshot (80)](https://user-images.githubusercontent.com/61620631/87852723-5a59db80-c926-11ea-8c1d-a28171533867.png)

//cc @benjiwheeler