### PR TITLE
Make the cookie library set the SameSite cookie value to strict by default

### DIFF
--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -78,7 +78,8 @@ const Jar = {
     set: (name, value, opts) => {
         opts = opts || {};
         defaults(opts, {
-            expires: new Date(new Date().setYear(new Date().getFullYear() + 1))
+            expires: new Date(new Date().setYear(new Date().getFullYear() + 1)),
+            SameSite: 'Strict'
         });
         opts.path = '/';
         const obj = cookie.serialize(name, value, opts);

--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -79,7 +79,7 @@ const Jar = {
         opts = opts || {};
         defaults(opts, {
             expires: new Date(new Date().setYear(new Date().getFullYear() + 1)),
-            SameSite: 'Strict'
+            sameSite: 'Strict' // cookie library requires this capitialization of sameSite
         });
         opts.path = '/';
         const obj = cookie.serialize(name, value, opts);

--- a/test/unit/lib/jar.test.js
+++ b/test/unit/lib/jar.test.js
@@ -1,0 +1,53 @@
+const jar = require('../../../src/lib/jar');
+const cookie = require('cookie');
+
+jest.mock('cookie', () => ({serialize: jest.fn()}));
+describe('unit test lib/jar.js', () => {
+
+    test('simple set test with no opts', () => {
+        jar.set('name', 'value');
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('name', 'value',
+            expect.objectContaining({
+                path: '/',
+                SameSite: 'Strict',
+                expires: expect.anything() // not specifically matching the date because it is hard to mock
+            }));
+    });
+    test('test with opts', () => {
+        jar.set('a', 'b', {option: 'one'});
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                path: '/',
+                SameSite: 'Strict',
+                expires: expect.anything() // not specifically matching the date because it is hard to mock
+            }));
+    });
+    test('expires opts overrides default', () => {
+        jar.set('a', 'b', {
+            option: 'one',
+            expires: 'someday'
+        });
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                path: '/',
+                expires: 'someday'
+            }));
+    });
+    test('SameSite opts overrides default', () => {
+        jar.set('a', 'b', {
+            option: 'one',
+            SameSite: 'override'
+        });
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                SameSite: 'override'
+            }));
+    });
+});

--- a/test/unit/lib/jar.test.js
+++ b/test/unit/lib/jar.test.js
@@ -10,7 +10,7 @@ describe('unit test lib/jar.js', () => {
         expect(cookie.serialize).toHaveBeenCalledWith('name', 'value',
             expect.objectContaining({
                 path: '/',
-                SameSite: 'Strict',
+                sameSite: 'Strict',
                 expires: expect.anything() // not specifically matching the date because it is hard to mock
             }));
     });
@@ -21,7 +21,7 @@ describe('unit test lib/jar.js', () => {
             expect.objectContaining({
                 option: 'one',
                 path: '/',
-                SameSite: 'Strict',
+                sameSite: 'Strict',
                 expires: expect.anything() // not specifically matching the date because it is hard to mock
             }));
     });
@@ -38,16 +38,16 @@ describe('unit test lib/jar.js', () => {
                 expires: 'someday'
             }));
     });
-    test('SameSite opts overrides default', () => {
+    test('sameSite opts overrides default', () => {
         jar.set('a', 'b', {
             option: 'one',
-            SameSite: 'override'
+            sameSite: 'override'
         });
         expect(cookie.serialize).toHaveBeenCalled();
         expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
             expect.objectContaining({
                 option: 'one',
-                SameSite: 'override'
+                sameSite: 'override'
             }));
     });
 });


### PR DESCRIPTION
### Resolves:

https://github.com/LLK/scratch-www/issues/3874

### Changes:
Changes the default behavior of the cookie jar library to set the sameSite cookie. This should be the right value for all of our existing cookies set from www. Browsers (e.g. Chrome and Firefox) have recently (or are about to) defaulted to sameSite=Lax. If we ever need another value, the library supports that via the opts object just like it does the expires value.
 
### Test Coverage:

Added a new unittest for the jar library. I'm only testing Jar.set in this PR since that's what I changed.
