### PR TITLE
Remove tap.plan() from footer links test

### DIFF
--- a/test/integration-legacy/smoke-testing/test_footer_links.js
+++ b/test/integration-legacy/smoke-testing/test_footer_links.js
@@ -17,9 +17,6 @@ const rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 // timeout for each test; timeout for suite set at command line level
 const options = {timeout: 30000};
 
-// number of tests in the plan
-tap.plan(24);
-
 tap.tearDown(function () {
     // quit the instance of the browser
     driver.quit();


### PR DESCRIPTION
### Resolves:

The tests were failing on Travis, this should make them work smoothly.

### Changes:

Just removes the tap.plan() option.  After removing some tests, it didn't like that the number didn't match.

