### PR TITLE
Fix bad variable interpolation/calculation in frameless scss

### DIFF
--- a/src/_frameless.scss
+++ b/src/_frameless.scss
@@ -48,20 +48,20 @@ $mobile: 480px;
 *          ... intermediate-and-smaller |
 */
 
-$small: "only screen and (max-width : #{$mobile}-1)";
-$medium: "only screen and (min-width : #{$mobile}) and (max-width : #{$tabletPortrait}-1)";
-$intermediate: "only screen and (min-width : #{$tabletPortrait}) and (max-width : #{$desktop}-1)";
+$small: "only screen and (max-width : #{$mobile - 1})";
+$medium: "only screen and (min-width : #{$mobile}) and (max-width : #{$tabletPortrait - 1})";
+$intermediate: "only screen and (min-width : #{$tabletPortrait}) and (max-width : #{$desktop - 1})";
 $big: "only screen and (min-width : #{$desktop})";
 
-$medium-and-smaller: "only screen and (max-width : #{$tabletPortrait}-1)";
-$intermediate-and-smaller: "only screen and (max-width : #{$desktop}-1)";
+$medium-and-smaller: "only screen and (max-width : #{$tabletPortrait - 1})";
+$intermediate-and-smaller: "only screen and (max-width : #{$desktop - 1})";
 
-$medium-and-intermediate: "only screen and (min-width : #{$mobile}) and (max-width : #{$desktop}-1)";
+$medium-and-intermediate: "only screen and (min-width : #{$mobile}) and (max-width : #{$desktop - 1})";
 
 /* Height */
 
-$small-height: "only screen and (max-height : #{$mobile} - 1)";
-$medium-height: "only screen and (min-height : #{$mobile}) and (max-height : #{$tabletPortrait} - 1)";
+$small-height: "only screen and (max-height : #{$mobile - 1})";
+$medium-height: "only screen and (min-height : #{$mobile}) and (max-height : #{$tabletPortrait - 1})";
 
 
 //


### PR DESCRIPTION
This used to work, even though it shouldn’t have. Upgrading node-sass caused our breakpoints to … break.  Without this, the compiler outputs invalid CSS including the "- 1", which causes the media query definitions to be ignored.

### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._

Resolves #4168 

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Update syntax for operations in frameless.scss

### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._

Tests for CSS are hard. @BryceLTaylor and I looked at scratch.ly to visually compare to production.