### PR TITLE
Make the cookie library set the SameSite cookie value to Lax by default

### DIFF
--- a/src/lib/jar.js
+++ b/src/lib/jar.js
@@ -78,7 +78,8 @@ const Jar = {
     set: (name, value, opts) => {
         opts = opts || {};
         defaults(opts, {
-            expires: new Date(new Date().setYear(new Date().getFullYear() + 1))
+            expires: new Date(new Date().setYear(new Date().getFullYear() + 1)),
+            sameSite: 'Lax' // cookie library requires this capitialization of sameSite
         });
         opts.path = '/';
         const obj = cookie.serialize(name, value, opts);

--- a/test/unit/lib/jar.test.js
+++ b/test/unit/lib/jar.test.js
@@ -1,0 +1,53 @@
+const jar = require('../../../src/lib/jar');
+const cookie = require('cookie');
+
+jest.mock('cookie', () => ({serialize: jest.fn()}));
+describe('unit test lib/jar.js', () => {
+
+    test('simple set test with no opts', () => {
+        jar.set('name', 'value');
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('name', 'value',
+            expect.objectContaining({
+                path: '/',
+                sameSite: 'Lax',
+                expires: expect.anything() // not specifically matching the date because it is hard to mock
+            }));
+    });
+    test('test with opts', () => {
+        jar.set('a', 'b', {option: 'one'});
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                path: '/',
+                sameSite: 'Lax',
+                expires: expect.anything() // not specifically matching the date because it is hard to mock
+            }));
+    });
+    test('expires opts overrides default', () => {
+        jar.set('a', 'b', {
+            option: 'one',
+            expires: 'someday'
+        });
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                path: '/',
+                expires: 'someday'
+            }));
+    });
+    test('sameSite opts overrides default', () => {
+        jar.set('a', 'b', {
+            option: 'one',
+            sameSite: 'override'
+        });
+        expect(cookie.serialize).toHaveBeenCalled();
+        expect(cookie.serialize).toHaveBeenCalledWith('a', 'b',
+            expect.objectContaining({
+                option: 'one',
+                sameSite: 'override'
+            }));
+    });
+});


### PR DESCRIPTION
Changes the default behavior of the cookie jar library to set the sameSite cookie to Lax. Browsers (e.g. Chrome and Firefox) have recently (or are about to) defaulted to sameSite=Lax. If we ever need another value, the library supports that via the opts object just like it does the expires value.

If we default to strict here, the language for scratchr2 pages will be wrong when the user navigates to a scratchr2 page via a 3rd party (e.g. a Google search link)

Test Coverage:
Added a new unittest for the jar library. I'm only testing Jar.set in this PR since that's what I changed.


This is a the same as #4219, except with a default value of Lax instead of Strict.
Resolves #3874