### PR TITLE
Localize email banner on splash

### DIFF
--- a/src/views/splash/l10n.json
+++ b/src/views/splash/l10n.json
@@ -44,7 +44,11 @@
     "welcome.learn": "Learn how to make a project in Scratch",
     "welcome.tryOut": "Try out starter projects",
     "welcome.connect": "Connect with other Scratchers",
-    
+
     "activity.seeUpdates": "This is where you will see updates from Scratchers you follow",
-    "activity.checkOutScratchers": "Check out some Scratchers you might like to follow"
+    "activity.checkOutScratchers": "Check out some Scratchers you might like to follow",
+
+    "emailbanner.confirmEmail": "{link} to enable sharing",
+    "emailbanner.confirmEmailLink": "Confirm your email",
+    "emailbanner.havingTrouble": "Having trouble?"
 }

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -384,14 +384,21 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                             this.props.onDismiss('confirmed_email');
                         }}
                     >
-                        <a
-                            href="#"
-                            onClick={this.props.onShowEmailConfirmationModal}
-                        >
-                            Confirm your email
-                        </a>{' '}to enable sharing.{' '}
+                        <FormattedMessage
+                            id="emailbanner.confirmEmail"
+                            values={{
+                                link: (
+                                    <a
+                                        href="#"
+                                        onClick={this.props.onShowEmailConfirmationModal}
+                                    >
+                                        <FormattedMessage id="emailbanner.confirmEmailLink" />
+                                    </a>
+                                )
+                            }}
+                        />
                         <a href="/info/faq/#accounts">
-                            Having trouble?
+                            <FormattedMessage id="emailbanner.havingTrouble" />
                         </a>
                     </DropdownBanner>,
                     <IframeModal


### PR DESCRIPTION
### Resolves:
Resolves #4251

### Changes:
Localizes email banner on splash page, with 3 strings added to splash-l10njson

### Test Coverage:
Cannot test locally, but the code is same as one I sent on the issue