### PR TITLE
update translation URL

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -63,6 +63,7 @@ const About = () => (
                     <p><FormattedMessage
                         id="about.aroundTheWorldDescription"
                         values={{
+                            languageCount: 60,
                             translationLink: (
                                 <a href="https://github.com/LLK/scratch-l10n/wiki/Guide-for-Scratch-Translators">
                                     <FormattedMessage id="about.translationLinkText" />

--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -64,7 +64,7 @@ const About = () => (
                         id="about.aroundTheWorldDescription"
                         values={{
                             translationLink: (
-                                <a href="https://en.scratch-wiki.info/wiki/How_to_Translate_Scratch">
+                                <a href="https://github.com/LLK/scratch-l10n/wiki/Guide-for-Scratch-Translators">
                                     <FormattedMessage id="about.translationLinkText" />
                                 </a>
                             )

--- a/src/views/about/l10n.json
+++ b/src/views/about/l10n.json
@@ -7,7 +7,7 @@
     "about.whoUsesScratch": "Who Uses Scratch?",
     "about.whoUsesScratchDescription": "Scratch is designed especially for ages 8 to 16, but is used by people of all ages. Millions of people are creating Scratch projects in a wide variety of settings, including homes, schools, museums, libraries, and community centers.",
     "about.aroundTheWorld": "Around the World",
-    "about.aroundTheWorldDescription": "Scratch is used in more than 150 different countries and available in more than 40 languages. To change languages, click the menu at the bottom of the page. Or, in the Project Editor, click the globe at the top of the page. To add or improve a translation, see the {translationLink} page.",
+    "about.aroundTheWorldDescription": "Scratch is used in more than 150 different countries and available in more than {languageCount} languages. To change languages, click the menu at the bottom of the page. Or, in the Project Editor, click the globe at the top of the page. To add or improve a translation, see the {translationLink} page.",
     "about.translationLinkText": "translation",
     "about.quotes": "Quotes",
     "about.quotesDescription": "The Scratch Team has received many emails from youth, parents, and educators expressing thanks for Scratch. Want to see what people are saying? You can read a collection of the {quotesLink} we've received.",


### PR DESCRIPTION
### Resolves:

Resolves #4273

### Changes:
Changes the URL of the translation guide from [https://en.scratch-wiki.info/wiki/How_to_Translate_Scratch](https://en.scratch-wiki.info/wiki/How_to_Translate_Scratch) to [https://github.com/LLK/scratch-l10n/wiki/Guide-for-Scratch-Translators](https://github.com/LLK/scratch-l10n/wiki/Guide-for-Scratch-Translators)

