### PR TITLE
Replace "Tips Page" with "Ideas Page"

### DIFF
--- a/src/views/about/l10n.json
+++ b/src/views/about/l10n.json
@@ -13,7 +13,7 @@
     "about.quotesDescription": "The Scratch Team has received many emails from youth, parents, and educators expressing thanks for Scratch. Want to see what people are saying? You can read a collection of the {quotesLink} we've received.",
     "about.quotesLinkText": "quotes",
     "about.learnMore": "Learn More About Scratch",
-    "about.learnMoreHelp": "Tips Page",
+    "about.learnMoreHelp": "Ideas Page",
     "about.learnMoreFaq": "Frequently Asked Questions",
     "about.learnMoreParents": "Information for Parents",
     "about.learnMoreCredits": "Credits",


### PR DESCRIPTION
### Resolves:

Resolves #4188.

### Changes:

Replace "Tips Page" with "Ideas Page" in the About page.

//cc @benjiwheeler 
