### PR TITLE
Add redirects for Animate a Character and Video Sensing Tutorials

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -506,6 +506,16 @@
         "redirect": "/projects/editor/?tutorial=pong"
     },
     {
+        "name": "animateacharcater-tutorial-redirect",
+        "pattern": "^/animate-a-character/?$",
+        "redirect": "/projects/editor/?tutorial=animate-a-character"
+    },
+    {
+        "name": "videosensing-tutorial-redirect",
+        "pattern": "^/video-sensing/?$",
+        "redirect": "/projects/editor/?tutorial=video-sensing"
+    },
+    {
         "name": "clicker-tutorial-redirect",
         "pattern": "^/clicker/?$",
         "redirect": "/projects/editor/?tutorial=clicker-game"

--- a/src/routes.json
+++ b/src/routes.json
@@ -506,7 +506,7 @@
         "redirect": "/projects/editor/?tutorial=pong"
     },
     {
-        "name": "animateacharcater-tutorial-redirect",
+        "name": "animateacharacter-tutorial-redirect",
         "pattern": "^/animate-a-character/?$",
         "redirect": "/projects/editor/?tutorial=animate-a-character"
     },


### PR DESCRIPTION
### Resolves:

Resolves #4203 

### Changes:

This Pull Request adds redirects for the [Animate a Character](https://scratch.mit.edu/projects/editor/?tutorial=animate-a-character) and [Video Sensing](https://scratch.mit.edu/projects/editor/?tutorial=video-sensing) tutorials. https://scratch.mit.edu/animate-a-character will redirect to the Animate a Character tutorial, and https://scratch.mit.edu/video-sensing will redirect to the Video Sensing tutorial.
