### PR TITLE
Pin chrome version for saucelabs to chromedriver version

### DIFF
--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,6 +1,7 @@
 const webdriver = require('selenium-webdriver');
 const bindAll = require('lodash.bindall');
 require('chromedriver');
+let chromedriverVersion = require('chromedriver').version;
 
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
@@ -8,7 +9,6 @@ const ci = process.env.CI || false;
 const buildID = process.env.TRAVIS_BUILD_NUMBER;
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
-const pkg = require('../../package.json');
 
 const DEFAULT_TIMEOUT_MILLISECONDS = 20 * 1000;
 
@@ -64,9 +64,11 @@ class SeleniumHelper {
     }
 
     getChromeVersionNumber () {
-        let chromedriverVersion = pkg.devDependencies.chromedriver;
         let versionFinder = /\d+\.\d+/;
         let versionArray = versionFinder.exec(chromedriverVersion);
+        if (versionArray === null) {
+            throw new Error('couldn\'t find version of chromedriver');
+        }
         return versionArray[0];
     }
 

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -8,6 +8,7 @@ const ci = process.env.CI || false;
 const buildID = process.env.TRAVIS_BUILD_NUMBER;
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
+const pkg = require('../../package.json');
 
 const DEFAULT_TIMEOUT_MILLISECONDS = 20 * 1000;
 
@@ -62,13 +63,21 @@ class SeleniumHelper {
         return driver;
     }
 
+    getChromeVersionNumber () {
+        let chromedriverVersion = pkg.devDependencies.chromedriver;
+        let versionFinder = /\d+\.\d+/;
+        let versionArray = versionFinder.exec(chromedriverVersion);
+        return versionArray[0];
+    }
+
     getSauceDriver (username, accessKey, name) {
+        let chromeVersion = this.getChromeVersionNumber();
         // Driver configs can be generated with the Sauce Platform Configurator
         // https://wiki.saucelabs.com/display/DOCS/Platform+Configurator
         let driverConfig = {
             browserName: 'chrome',
             platform: 'macOS 10.14',
-            version: '84.0'
+            version: chromeVersion
         };
         var driver = new webdriver.Builder()
             .withCapabilities({

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,7 +1,7 @@
 const webdriver = require('selenium-webdriver');
 const bindAll = require('lodash.bindall');
 require('chromedriver');
-let chromedriverVersion = require('chromedriver').version;
+const chromedriverVersion = require('chromedriver').version;
 
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -64,8 +64,8 @@ class SeleniumHelper {
     }
 
     getChromeVersionNumber () {
-        let versionFinder = /\d+\.\d+/;
-        let versionArray = versionFinder.exec(chromedriverVersion);
+        const versionFinder = /\d+\.\d+/;
+        const versionArray = versionFinder.exec(chromedriverVersion);
         if (versionArray === null) {
             throw new Error('couldn\'t find version of chromedriver');
         }
@@ -73,7 +73,7 @@ class SeleniumHelper {
     }
 
     getSauceDriver (username, accessKey, name) {
-        let chromeVersion = this.getChromeVersionNumber();
+        const chromeVersion = this.getChromeVersionNumber();
         // Driver configs can be generated with the Sauce Platform Configurator
         // https://wiki.saucelabs.com/display/DOCS/Platform+Configurator
         let driverConfig = {


### PR DESCRIPTION
### Resolves:

Occasionally newer versions of chromedriver will not work with older versions of Chrome and vice versa.  Remote tests will then fail due to a mismatch between Chrome and Chromedriver.   

### Changes:

This change will cause the automated tests that run through Saucelabs to always use a version of chrome based on the chromedriver version.  Chromedriver versions are numbered to match the chrome versions they support, so it extracts the first two version number from the chromedriver package number to get the chrome version.  

This way we only need to update the version in one place.  
