### PR TITLE
Stop running smoke tests unless the branch pushes to prod or staging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,6 @@ stages:
 - name: test
   if: type != cron
 - name: smoke
-  if: type NOT IN (cron, pull_request)
+  if: type NOT IN (cron, pull_request) AND (branch =~ /^(develop|master|release|hotfix/)/)
 - name: update translations
   if: branch == develop AND type == cron


### PR DESCRIPTION
Motivation: stop running them on dependapot branches/PRs since they don't make sense.

Dependabot makes PRs from branches on LLK/scratch-www and travis was running the smoke tests there needlessly.

We're still running builds twice on these PRs... but this is progress.