### PR TITLE
Only run integration/smoke tests on specific branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,6 @@ stages:
 - name: test
   if: type != cron
 - name: smoke
-  if: type NOT IN (cron, pull_request)
+  if: type NOT IN (cron, pull_request) AND (branch =~ /^(develop|master|release\/|hotfix\/)/)
 - name: update translations
   if: branch == develop AND type == cron


### PR DESCRIPTION
This keeps the integration tests from running on PRs that are made from branches on LLK/www (e.g. all dependabot PRs)

It is a redo of #4450 that's regex had messed up slashes. In this one, /'s are escaped in the appropriate places (I think at least!) 
Thanks to @BryceLTaylor for pointing at the / problem.