### PR TITLE
Fix "Load more" scrolling

### DIFF
--- a/src/views/explore/explore.scss
+++ b/src/views/explore/explore.scss
@@ -110,6 +110,7 @@ $base-bg: $ui-white;
         padding-top: 16px;
         padding-bottom: 32px;
         width: 100%;
+        overflow-anchor: none;
 
         .button {
             display: block;

--- a/src/views/messages/messages.scss
+++ b/src/views/messages/messages.scss
@@ -33,6 +33,10 @@
     margin-bottom: 3rem;
 }
 
+.messages-social {
+    overflow-anchor: none;
+}
+
 .messages-admin-list,
 .messages-social-list {
     padding: 0;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -230,6 +230,7 @@ $stage-width: 480px;
         min-width: 65%;
         max-width: 100%;
         flex: 1;
+        overflow-anchor: none;
 
         @media #{$medium-and-smaller} {
             padding: 0;


### PR DESCRIPTION
### Resolves:

Resolves #4260

### Changes:

Currently Load more buttons incorrectly scroll the page down in Chrome. This pull request should fix that.
cc @benjiwheeler

### Test Coverage:

Manually tested.