### PR TITLE
add missing space to teacher request form

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -180,7 +180,7 @@ class UsernameStep extends React.Component {
                         this.props.description
                     ) : (
                         <span>
-                            <intl.FormattedMessage id="registration.usernameStepDescription" />
+                            <intl.FormattedMessage id="registration.usernameStepDescription" />&nbsp
                             <b>
                                 <intl.FormattedMessage id="registration.usernameStepRealName" />
                             </b>

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -180,7 +180,7 @@ class UsernameStep extends React.Component {
                         this.props.description
                     ) : (
                         <span>
-                            <intl.FormattedMessage id="registration.usernameStepDescription" />&nbsp
+                            <intl.FormattedMessage id="registration.usernameStepDescription" />&nbsp;
                             <b>
                                 <intl.FormattedMessage id="registration.usernameStepRealName" />
                             </b>


### PR DESCRIPTION
### Resolves:

#4308 

### Changes:

I added a non breaking space, so the teacher account request form name warning should now have a space (assuming I did it correctly)

### Test Coverage:

unfortunately, I do not have a setup where I can easily test scratch-www, but this is a small change and my fingers are crossed that I didn't mess up