### PR TITLE
Changed address on DMCA page

### DIFF
--- a/src/views/dmca/dmca.jsx
+++ b/src/views/dmca/dmca.jsx
@@ -13,12 +13,11 @@ const Dmca = () => (
 
             <p><FormattedMessage id="dmca.intro" /></p>
             <p>
-                Copyright Agent / Mitchel Resnick<br />
-                MIT Media Laboratory<br />
-                77 Massachusetts Ave<br />
-                Room E14-445A<br />
-                Cambridge, MA 02139<br />
-                Tel: (617) 253-9783
+                Copyright Agent / Mitchel Resnick
+                Scratch Foundation
+                201 South St. Suite 1-102
+                Boston, MA 02111
+                Tel: 857-233-5422
             </p>
             <p><FormattedMessage id="dmca.llkresponse" /></p>
             <p><FormattedMessage id="dmca.assessment" /></p>


### PR DESCRIPTION
### Resolves: #4508 
Address used to be incorrect and I have updated it to the correct address.


### Changes:
Changed the address on the DMCA page so it is now correct.

Changed from:

Copyright Agent / Mitchel Resnick
MIT Media Laboratory
77 Massachusetts Ave
Room E14-445A
Cambridge, MA 02139
Tel: (617) 253-9783


And corrected it to:

Copyright Agent / Mitchel Resnick
Scratch Foundation
201 South St. Suite 1-102
Boston, MA 02111
Tel: 857-233-5422

