### PR TITLE
Revert "Revert "Bump scratch-gui from 0.1.0-prerelease.20201025103629 to 0.1.…"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,9 +1320,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -4620,9 +4620,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001151",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz",
-      "integrity": "sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==",
+      "version": "1.0.30001154",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
+      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==",
       "dev": true
     },
     "canvas-fit": {
@@ -15719,9 +15719,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.64",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.64.tgz",
-      "integrity": "sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg==",
+      "version": "1.1.65",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.65.tgz",
+      "integrity": "sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==",
       "dev": true
     },
     "node-sass": {
@@ -20689,9 +20689,9 @@
       }
     },
     "scratch-blocks": {
-      "version": "0.1.0-prerelease.20201025031515",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-0.1.0-prerelease.20201025031515.tgz",
-      "integrity": "sha512-L0lr7lhrKbNdls0ISbXKlAxVfy87qsumGLwcoWIj4msFfNZj5Q/RyFnXV7c39A3tX+QqjxQhi3u+s6hewaxEBA==",
+      "version": "0.1.0-prerelease.20201104035801",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-0.1.0-prerelease.20201104035801.tgz",
+      "integrity": "sha512-ckKc7xB081eIlE+7FmP7z3ruOTkdPknPX009is+kM9pr+UoK2zemIdgAJhif5KH3P18BMt8KNEk0EaOMEhkM9A==",
       "dev": true,
       "requires": {
         "exports-loader": "0.6.3",
@@ -20699,9 +20699,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20201025103629",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20201025103629.tgz",
-      "integrity": "sha512-8UpQqCUAvApPt86Q+0MgmNFuI5BasAdjZBI6bLz5gOdZpHYWjJR1oDtJi3892Qh9iMmKSd9S8NVhqcduoyK8ag==",
+      "version": "0.1.0-prerelease.20201104042153",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20201104042153.tgz",
+      "integrity": "sha512-yuDLAvIHKl4hx4HayitO3vcuXgX36zXCQ5IZNPupBLMYfinlde7QW3SuC5/qKc0/Tf+Xej0YUx5TmjSO8RXCSg==",
       "dev": true,
       "requires": {
         "arraybuffer-loader": "^1.0.6",
@@ -20752,10 +20752,10 @@
         "redux": "3.7.2",
         "redux-throttle": "0.1.1",
         "scratch-audio": "0.1.0-prerelease.20200528195344",
-        "scratch-blocks": "0.1.0-prerelease.20201025031515",
-        "scratch-l10n": "3.10.20201025030731",
+        "scratch-blocks": "0.1.0-prerelease.20201104035801",
+        "scratch-l10n": "3.10.20201104030908",
         "scratch-paint": "0.2.0-prerelease.20201020103914",
-        "scratch-render": "0.1.0-prerelease.20201020104037",
+        "scratch-render": "0.1.0-prerelease.20201029234547",
         "scratch-storage": "1.3.3",
         "scratch-svg-renderer": "0.2.0-prerelease.20201019174008",
         "scratch-vm": "0.2.0-prerelease.20201016122132",
@@ -20798,15 +20798,15 @@
           "dev": true
         },
         "browserslist": {
-          "version": "4.14.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
-          "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
+          "version": "4.14.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
+          "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001135",
-            "electron-to-chromium": "^1.3.571",
-            "escalade": "^3.1.0",
-            "node-releases": "^1.1.61"
+            "caniuse-lite": "^1.0.30001154",
+            "electron-to-chromium": "^1.3.585",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.65"
           }
         },
         "chalk": {
@@ -20936,9 +20936,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.583",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.583.tgz",
-          "integrity": "sha512-L9BwLwJohjZW9mQESI79HRzhicPk1DFgM+8hOCfGgGCFEcA3Otpv7QK6SGtYoZvfQfE3wKLh0Hd5ptqUFv3gvQ==",
+          "version": "1.3.587",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.587.tgz",
+          "integrity": "sha512-8XFNxzNj0R8HpTQslWAw6UWpGSuOKSP3srhyFHVbGUGb8vTHckZGCyWi+iQlaXJx5DNeTQTQLd6xN11WSckkmA==",
           "dev": true
         },
         "file-loader": {
@@ -21181,9 +21181,9 @@
           "dev": true
         },
         "scratch-l10n": {
-          "version": "3.10.20201025030731",
-          "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.10.20201025030731.tgz",
-          "integrity": "sha512-48+UKw6TsGHcfyecJhFJaIlyaVePDoiEdBzq38e17xNIwBSVsqJGM7+bqb3htkHz/dxhtFCqgnqPM2PMGiJvxA==",
+          "version": "3.10.20201104030908",
+          "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.10.20201104030908.tgz",
+          "integrity": "sha512-wRQbvMwO4iKXsAvoEXduHvJM92y5TsRUpF79HSPOw0qTpYeRlE3Qd+4EsBQMdH1Nt6Jcwkzk6Y7ovgrMYu30PQ==",
           "dev": true,
           "requires": {
             "@babel/cli": "^7.1.2",
@@ -21333,9 +21333,9 @@
       }
     },
     "scratch-render": {
-      "version": "0.1.0-prerelease.20201020104037",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20201020104037.tgz",
-      "integrity": "sha512-HHbsf5oUahDzuF51/730yVjY9Xdv4ugnYc/mcAjPScR07aF1gVx8PIHBetRbZAC2BjPtOc//V8IZX6aPOQUpXQ==",
+      "version": "0.1.0-prerelease.20201029234547",
+      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-0.1.0-prerelease.20201029234547.tgz",
+      "integrity": "sha512-0Ur6rUDN7dSThCO2KFbjqh1EJrkkXO/384kMZwJ2t6QiaMVcLb5U0g/Qp7hKJxrycNhg2eAEBtEq0ydX+dRsHA==",
       "dev": true,
       "requires": {
         "grapheme-breaker": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "2.0.1",
     "sass-loader": "6.0.6",
-    "scratch-gui": "0.1.0-prerelease.20201025103629",
+    "scratch-gui": "0.1.0-prerelease.20201104042153",
     "scratch-l10n": "latest",
     "selenium-webdriver": "3.6.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Reverts LLK/scratch-www#4602

It looks like the render bug we found in bug hunt already exists on production, see discussion here: 
https://github.com/LLK/scratch-render/issues/719