### PR TITLE
Add link to annual report from about page

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -149,6 +149,9 @@ const About = () => (
                         <li>
                             <a href="/credits"><FormattedMessage id="about.learnMoreCredits" /></a>
                         </li>
+                        <li>
+                            <a href="/annual-report"><FormattedMessage id="about.learnMoreAnnualReport" /></a>
+                        </li>
                     </ul>
                 </li>
 

--- a/src/views/about/l10n.json
+++ b/src/views/about/l10n.json
@@ -17,6 +17,7 @@
     "about.learnMoreFaq": "Frequently Asked Questions",
     "about.learnMoreParents": "Information for Parents",
     "about.learnMoreCredits": "Credits",
+    "about.learnMoreAnnualReport": "Annual Report 2019",
     "about.literacy": "Learn to Code, Code to Learn",
     "about.literacyDescription": "The ability to code computer programs is an important part of literacy in today’s society. When people learn to code in Scratch, they learn important strategies for solving problems, designing projects, and communicating ideas.",
     "about.schools": "Scratch in Schools",


### PR DESCRIPTION
### Resolves:

Follow up from the annual report work, add a link to the Annual Report page from the About page.

### Test Coverage:
- Tested locally:

![image](https://user-images.githubusercontent.com/1786240/98560221-89011680-2275-11eb-9603-d7c113d1d3a9.png)
