### PR TITLE
remove version number from micro:bit firmware URL

### DIFF
--- a/src/views/microbit/microbit.jsx
+++ b/src/views/microbit/microbit.jsx
@@ -105,7 +105,7 @@ class MicroBit extends ExtensionLanding {
                                     <a
                                         download
                                         className="download"
-                                        href="https://downloads.scratch.mit.edu/microbit/scratch-microbit-1.1.0.hex.zip"
+                                        href="https://downloads.scratch.mit.edu/microbit/scratch-microbit.hex.zip"
                                     >
                                         <FormattedMessage id="microbit.downloadHex" />
                                     </a>


### PR DESCRIPTION
### Changes:

The firmware download URL on the micro:bit page no longer contains a version number. The download bucket has been configured to treat this new URL as a redirect to the actual file, including the version number. This way we'll be able to deploy firmware updates without needing to change any content in this repository.

### Test Coverage:

Tested that the new URL redirects correctly. Right now it should redirect to `scratch-microbit-1.1.0.hex.zip`, the same file that was explicitly listed before this change.