### PR TITLE
Change link to Teacher Account Setup Guide on Educators page

### DIFF
--- a/src/views/teachers/landing/landing.jsx
+++ b/src/views/teachers/landing/landing.jsx
@@ -341,7 +341,7 @@ const Landing = props => (
                             id="teacherlanding.accountsRequestInfo"
                             values={{
                                 setupGuideLink: (
-                                    <a href="https://drive.google.com/file/d/1CGFzkZAHm53FHpjKbVqgVauXGdWJiUdQ/view" >
+                                    <a href="https://resources.scratch.mit.edu/www/guides/en/scratch-teacher-accounts-guide.pdf" >
                                         <FormattedMessage id="teacherlanding.accountsSetupGuide" />
                                     </a>
                                 ),

--- a/src/views/teachers/landing/landing.jsx
+++ b/src/views/teachers/landing/landing.jsx
@@ -341,7 +341,7 @@ const Landing = props => (
                             id="teacherlanding.accountsRequestInfo"
                             values={{
                                 setupGuideLink: (
-                                    <a href="https://docs.google.com/document/d/1Qb8Lyeiivr-oB49p5Bo17iXU5qxGpBJHuFa_KR5aW-o/view" >
+                                    <a href="https://drive.google.com/file/d/1CGFzkZAHm53FHpjKbVqgVauXGdWJiUdQ/view" >
                                         <FormattedMessage id="teacherlanding.accountsSetupGuide" />
                                     </a>
                                 ),


### PR DESCRIPTION
Changes: 
-  On the Educators page, changes the "Teacher Account Setup Guide" link from a .doc link to a PDF link: https://resources.scratch.mit.edu/www/guides/en/scratch-teacher-accounts-guide.pdf 

This link can be found in the Teacher Accounts section of the Educators page: https://scratch.mit.edu/educators#teacher-accounts