### PR TITLE
switch educator registration checkusername endpoint from scratchr2 to api

### DIFF
--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -109,17 +109,20 @@ class UsernameStep extends React.Component {
         }
 
         api({
-            host: '',
-            uri: `/accounts/check_username/${username}/`
+            uri: `/accounts/checkusername/${username}/`
         }, (err, body, res) => {
             if (err || res.statusCode !== 200) {
                 err = err || this.props.intl.formatMessage({id: 'general.error'});
                 this.form.formsy.updateInputsWithError({all: err});
                 return callback(false);
             }
-            body = body[0];
+            // get the message in a way that will work for both scratchr2 and api
+            // versions of the checkusername endpoint
+            let msg = '';
+            if (body && body.msg) msg = body.msg;
+            else if (body && body[0]) msg = body[0].msg;
 
-            switch (body.msg) {
+            switch (msg) {
             case 'valid username':
                 this.setState({
                     validUsername: 'pass'

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -25,6 +25,8 @@ module.exports.validateUsernameRemotely = username => (
             if (err || res.statusCode !== 200) {
                 resolve({requestSucceeded: false, valid: false, errMsgId: 'general.error'});
             }
+            // get the message in a way that will work for both scratchr2 and api
+            // versions of the checkusername endpoint
             let msg = '';
             if (body && body.msg) msg = body.msg;
             else if (body && body[0]) msg = body[0].msg;


### PR DESCRIPTION
### Resolves:

Step towards resolving https://github.com/LLK/scratchr2/issues/5563

This is step 1 of 2. Step 2 will be to remove the deprecated check_username code from scratchr2.

### Changes:

In educator registration, uses the newer api checkusername endpoint rather than the older scratchr2 check_username endpoint.

Adds some logic (and comments) to make the handling more robust to errors.

### Test Coverage:

It's not clear to me whether there's a good way to add tests for this.