### PR TITLE
[hotfix/master] Include funding support on Education Collaborative intro

### DIFF
--- a/src/views/sec/l10n.json
+++ b/src/views/sec/l10n.json
@@ -8,7 +8,7 @@
   "sec.subscribeCallToAction": "sign up for our mailing list",
   "sec.applyDeadline": "The deadline for applying to the Scratch Education Collaborative is January 10th, 2021",
   "sec.applyButton": "Click here to apply",
-  "sec.projectsIntro": "The Scratch Foundation is launching the Scratch Education Collaborative (SEC), to bring together organizations committed to supporting creative coding experiences with a focus on educators, students, and communities historically excluded from computing.",
+  "sec.projectsIntro": "The Scratch Foundation, with help from Google.org, is launching the Scratch Education Collaborative (SEC), to bring together organizations committed to supporting creative coding experiences with a focus on educators, students, and communities historically excluded from computing.",
   "sec.projectsIntro2": "In 2021, during the pilot year of the SEC, 5 organizations from across the globe will be selected to share their work, learn from one another, and help to develop best practices and examples for implementing {culturallySustainingLink} creative computing with Scratch.",
   "sec.culturallySustaining": "culturally sustaining",
   "sec.expectationsFromSec": "What participating organizations can expect from the SEC",


### PR DESCRIPTION
Include the "with help from Google.org" in the SEC intro paragraph. 