### PR TITLE
World map fixes - Border thickness, Eswatini, remove unused css

### DIFF
--- a/src/components/world-map/world-map.jsx
+++ b/src/components/world-map/world-map.jsx
@@ -20,9 +20,7 @@ const WorldMap = props => (
                 locations: props.countryNames,
                 z: props.colorIndex,
                 text: props.countryData,
-                hovertemplate: '<b>  %{location}  </b>' +
-                               '<br>' +
-                               '  %{text:,.0f}  ' +
+                hovertemplate: '%{text}' +
                                '<extra></extra>',
                 hoverlabel: {
                     bgcolor: '#FFF',
@@ -38,7 +36,7 @@ const WorldMap = props => (
                 marker: {
                     line: {
                         color: '#FFFF',
-                        width: 1
+                        width: .4
                     }
                 }
             }

--- a/src/components/world-map/world-map.jsx
+++ b/src/components/world-map/world-map.jsx
@@ -20,8 +20,7 @@ const WorldMap = props => (
                 locations: props.countryNames,
                 z: props.colorIndex,
                 text: props.countryData,
-                hovertemplate: '%{text}' +
-                               '<extra></extra>',
+                hovertemplate: '%{text}<extra></extra>',
                 hoverlabel: {
                     bgcolor: '#FFF',
                     bordercolor: '#5B6671',

--- a/src/views/annual-report/annual-report.jsx
+++ b/src/views/annual-report/annual-report.jsx
@@ -52,10 +52,10 @@ const SECTION_NAMES = {
 };
 
 // Constants used for world map data processing/formatting for use with Plotly
-const countryKeys = Object.keys(CountryUsage);
-const countryNames = countryKeys.map(key => CountryUsage[key].display);
-const countryData = countryKeys.map(key => CountryUsage[key].count);
-const colorIndex = countryKeys.map(key => CountryUsage[key]['log count']);
+const countryNames = Object.keys(CountryUsage);
+// const countryNames = countryKeys.map(key => CountryUsage[key].display);
+const countryData = countryNames.map(key => `<b>${CountryUsage[key].display}</b><br>${CountryUsage[key].count.toLocaleString('en')}`);
+const colorIndex = countryNames.map(key => CountryUsage[key]['log count']);
 
 // Create the div given a list of supporter names,
 // this will contain two columns of names either of equal size

--- a/src/views/annual-report/annual-report.jsx
+++ b/src/views/annual-report/annual-report.jsx
@@ -53,8 +53,9 @@ const SECTION_NAMES = {
 
 // Constants used for world map data processing/formatting for use with Plotly
 const countryNames = Object.keys(CountryUsage);
-// const countryNames = countryKeys.map(key => CountryUsage[key].display);
-const countryData = countryNames.map(key => `<b>${CountryUsage[key].display}</b><br>${CountryUsage[key].count.toLocaleString('en')}`);
+const countryData = countryNames.map(key =>
+    `<b>${CountryUsage[key].display}</b><br>${CountryUsage[key].count.toLocaleString('en')}`
+);
 const colorIndex = countryNames.map(key => CountryUsage[key]['log count']);
 
 // Create the div given a list of supporter names,

--- a/src/views/annual-report/annual-report.scss
+++ b/src/views/annual-report/annual-report.scss
@@ -2681,12 +2681,6 @@ p {
                 background-color: $box-shadow-light-gray;
             }
         }
-
-        // Would be good to see if this works in RTL...
-        [dir="rtl"] a {
-            margin-left: 10px;
-            margin-right: 0px;
-        }
     }
 
 }


### PR DESCRIPTION
### Changes:
* Decreases the thickness of country borders on the map so small countries and islands are more visible (see Hawaii and Indonesia for examples)
* Show data for the country Eswatini. This required changing the way we display country name in the map so that the display name can be different than the country name Plotly uses, as Plotly only knows Eswatini by its old name (Swaziland)
* Remove untested CSS for RTL

### To test:
* Compare the country border thickness to production. It should be thinner. You should be able to see more of Hawaii and Indonesia.
* Eswatini (east of South Africa) should have data and should be called Eswatini. 