### PR TITLE
In the Annual Report Team section, open link to Scratch Team members in new tab

### DIFF
--- a/src/components/people-grid/people-grid.jsx
+++ b/src/components/people-grid/people-grid.jsx
@@ -13,7 +13,11 @@ const PeopleGrid = props => (
             >
                 <div>
                     {person.userName ? (
-                        <a href={`https://scratch.mit.edu/users/${person.userName}/`}>
+                        <a
+                            href={`https://scratch.mit.edu/users/${person.userName}/`}
+                            rel="noreferrer noopener"
+                            target={props.linkToNewTab ? '_blank' : '_self'}
+                        >
                             <Avatar
                                 alt=""
                                 src={`https://cdn.scratch.mit.edu/get_image/user/${person.userId || 'default'}_80x80.png`}
@@ -36,11 +40,16 @@ const PeopleGrid = props => (
 );
 
 PeopleGrid.propTypes = {
+    linkToNewTab: PropTypes.bool,
     people: PropTypes.arrayOf(PropTypes.shape({
         name: PropTypes.string,
         userId: PropTypes.number,
         userName: PropTypes.string
     }))
+};
+
+PeopleGrid.defaultProps = {
+    linkToNewTab: false
 };
 
 module.exports = PeopleGrid;

--- a/src/views/annual-report/annual-report.jsx
+++ b/src/views/annual-report/annual-report.jsx
@@ -2178,6 +2178,7 @@ class AnnualReport extends React.Component {
                                 </h3>
                                 <div className="executive-director">
                                     <PeopleGrid
+                                        linkToNewTab
                                         people={[{
                                             userName: 'Champ99',
                                             userId: 900283,
@@ -2186,7 +2187,10 @@ class AnnualReport extends React.Component {
                                     />
                                     <FormattedMessage id="annualReport.leadershipInterim" />
                                 </div>
-                                <PeopleGrid people={People} />
+                                <PeopleGrid
+                                    linkToNewTab
+                                    people={People}
+                                />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Changes:

Clicking on a Scratch Team member in the Annual Report Team section opens their profile in a new tab

### Test

* Clicking on a Scratch Team member in the Annual Report Team section opens their profile in a new tab
* Clicking on a Scratch Team member in the Credits page opens their profile in the _same_ tab