### PR TITLE
Fix "Load more" scrolling on search results

### DIFF
--- a/src/views/search/search.scss
+++ b/src/views/search/search.scss
@@ -152,6 +152,7 @@ $base-bg: $ui-white;
         background-color: $ui-gray;
         padding-bottom: 32px;
         width: 100%;
+        overflow-anchor: none;
 
         .button {
             display: block;


### PR DESCRIPTION
### Resolves:

Resolves #4624 

### Changes:

Fixes a bug where clicking "Load more" on search results would scroll the page down.

### Test Coverage:

None
