### PR TITLE
Localize mute

### DIFF
--- a/src/components/modal/mute/modal.jsx
+++ b/src/components/modal/mute/modal.jsx
@@ -1,6 +1,9 @@
 const bindAll = require('lodash.bindall');
 const PropTypes = require('prop-types');
 const React = require('react');
+const FormattedMessage = require('react-intl').FormattedMessage;
+const injectIntl = require('react-intl').injectIntl;
+const intlShape = require('react-intl').intlShape;
 const Modal = require('../base/modal.jsx');
 const ModalInnerContent = require('../base/modal-inner-content.jsx');
 const Button = require('../../forms/button.jsx');
@@ -48,25 +51,32 @@ class MuteModal extends React.Component {
                         <MuteStep
                             bottomImg="/svgs/commenting/comment_feedback.svg"
                             bottomImgClass="bottom-img"
-                            header="Make sure to be respectful to others when commenting on Scratch."
+                            header={this.props.intl.formatMessage({id: this.props.muteModalMessages.muteStepHeader})}
                         >
                             <p>
-                            The Scratch comment filter thinks that your comment was disrespectful. Remember
-                            that there is a person behind this Scratch account, and sometimes, a mean comment
-                            can really hurt someone&apos;s feelings.
+                                <FormattedMessage id={this.props.muteModalMessages.muteStepContent} />
                             </p>
                         </MuteStep>
                         <MuteStep
-                            header={`You will be able to comment again  ${this.props.timeMuted}.`}
+                            header={this.props.intl.formatMessage(
+                                {id: 'comments.muted.duration'},
+                                {inDuration: this.props.timeMuted}
+                            )}
                             sideImg="/svgs/commenting/mute_time.svg"
                             sideImgClass="side-img"
                         >
                             <p>
-                                Your account has been paused from commenting until then.
+                                <FormattedMessage id="comments.muted.commentingPaused" />
                             </p>
                             <p>
-                            If you would like more information, you can read
-                            the <a href="/community_guidelines"> Scratch community guidelines</a>.
+                                <FormattedMessage
+                                    id="comments.muted.moreInfoGuidelines"
+                                    values={{CommunityGuidelinesLink: (
+                                        <a href="/community_guidelines">
+                                            <FormattedMessage id="report.CommunityGuidelinesLinkText" />
+                                        </a>
+                                    )}}
+                                />
                             </p>
                         </MuteStep>
                     </Progression>
@@ -80,7 +90,7 @@ class MuteModal extends React.Component {
                                 onClick={this.handlePrevious}
                             >
                                 <div className="action-button-text">
-                                    Back
+                                    <FormattedMessage id="general.back" />
                                 </div>
                             </Button>
                         ) : null }
@@ -90,7 +100,7 @@ class MuteModal extends React.Component {
                                 onClick={this.props.onRequestClose}
                             >
                                 <div className="action-button-text">
-                                    Close
+                                    <FormattedMessage id="general.close" />
                                 </div>
                             </Button>
                         ) : (
@@ -99,7 +109,7 @@ class MuteModal extends React.Component {
                                 onClick={this.handleNext}
                             >
                                 <div className="action-button-text">
-                                    Next
+                                    <FormattedMessage id="general.next" />
                                 </div>
                             </Button>
                         )}
@@ -111,8 +121,14 @@ class MuteModal extends React.Component {
 }
 
 MuteModal.propTypes = {
+    intl: intlShape,
+    muteModalMessages: PropTypes.shape({
+        commentType: PropTypes.string,
+        muteStepHeader: PropTypes.string,
+        muteStepContent: PropTypes.string
+    }),
     onRequestClose: PropTypes.func,
     timeMuted: PropTypes.string
 };
 
-module.exports = MuteModal;
+module.exports = injectIntl(MuteModal);

--- a/src/components/modal/mute/modal.jsx
+++ b/src/components/modal/mute/modal.jsx
@@ -53,9 +53,12 @@ class MuteModal extends React.Component {
                             bottomImgClass="bottom-img"
                             header={this.props.intl.formatMessage({id: this.props.muteModalMessages.muteStepHeader})}
                         >
-                            <p>
-                                <FormattedMessage id={this.props.muteModalMessages.muteStepContent} />
-                            </p>
+                            {this.props.muteModalMessages.muteStepContent.map(message => (
+                                <p key={message}>
+                                    <FormattedMessage id={message} />
+                                </p>
+                            ))}
+
                         </MuteStep>
                         <MuteStep
                             header={this.props.intl.formatMessage(

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -349,6 +349,11 @@
     "comments.status.acctdel": "Account deleted",
     "comments.status.deleted": "Deleted",
     "comments.status.reported": "Reported",
+    "comments.muted.duration": "You will be able to comment again {inDuration}.",
+    "comments.muted.commentingPaused": "Your account has been paused from commenting until then.",
+    "comments.muted.moreInfoGuidelines": "If you would like more information, you can read the {CommunityGuidelinesLink}.",
+    "comments.muted.moreInfoModal": "For more information, {clickHereLink}.",
+    "comments.muted.clickHereLinkText": "click here",
 
     "social.embedLabel": "Embed",
     "social.copyEmbedLinkText": "Copy embed",

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -164,7 +164,7 @@ class ComposeComment extends React.Component {
         return {
             commentType: 'comment.type.disrespectful',
             muteStepHeader: 'comment.disrespectful.header',
-            muteStepContent: 'comment.disrespectful.content'
+            muteStepContent: ['comment.disrespectful.content1', 'comment.disrespectful.content2']
         };
     }
 

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -157,6 +157,17 @@ class ComposeComment extends React.Component {
         return creationTimeMinutesAgo < 2 && numOffenses === 1;
     }
 
+    getMuteMessageInfo () {
+        // return the ids for the messages that are shown for this mute type
+        // Note, it will probably be passed a 'type', but right now there's only one
+        // If mute modals have more than one unique "step" we could pass an array of steps
+        return {
+            commentType: 'comment.type.disrespectful',
+            muteStepHeader: 'comment.disrespectful.header',
+            muteStepContent: 'comment.disrespectful.content'
+        };
+    }
+
     handleCancel () {
         this.setState({
             message: '',
@@ -172,17 +183,30 @@ class ComposeComment extends React.Component {
                 {this.isMuted() ? (
                     <FlexRow className="comment">
                         <CommentingStatus>
-                            <p>Scratch thinks your comment was disrespectful.</p>
-                            <p> You will be able to comment
-                                again {formatTime.formatRelativeTime(this.state.muteExpiresAt, window._locale)}.
-                                Your account has been paused from commenting until then.
+                            <p><FormattedMessage id={this.getMuteMessageInfo().commentType} /></p>
+                            <p>
+                                <FormattedMessage
+                                    id="comments.muted.duration"
+                                    values={{
+                                        inDuration:
+                                        formatTime.formatRelativeTime(this.state.muteExpiresAt, window._locale)
+                                    }}
+                                /> <FormattedMessage id="comments.muted.commentingPaused" />
+                            </p>
+                            <p className="bottom-text">
+                                <FormattedMessage
+                                    id="comments.muted.moreInfoModal"
+                                    values={{clickHereLink: (
+                                        <a
+                                            href="#comment"
+                                            onClick={this.handleMuteOpen}
+                                        >
+                                            <FormattedMessage id="comments.muted.clickHereLinkText" />
+                                        </a>
+                                    )}}
+                                />
 
                             </p>
-                            <p className="bottom-text">For more information,
-                                <a
-                                    href="#comment"
-                                    onClick={this.handleMuteOpen}
-                                > click here</a>.</p>
                         </CommentingStatus>
                     </FlexRow>
                 ) : null }
@@ -262,6 +286,7 @@ class ComposeComment extends React.Component {
                         showCloseButton
                         useStandardSizes
                         className="mod-mute"
+                        muteModalMessages={this.getMuteMessageInfo()}
                         shouldCloseOnOverlayClick={false}
                         timeMuted={formatTime.formatRelativeTime(this.state.muteExpiresAt, window._locale)}
                         onRequestClose={this.handleMuteClose}

--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -47,6 +47,7 @@
     "project.usernameBlockAlert": "This project can detect who is using it, through the \"username\" block. To hide your identity, sign out before using the project.",
     "project.inappropriateUpdate": "Hmm...the bad word detector thinks there is a problem with your text. Please change it and remember to be respectful.",
     "comment.type.disrespectful": "Scratch thinks your most recent comment was disrespectful.",
-    "comment.disrespectful.header": "Make sure to be respectful to others when commenting on Scratch.",
-    "comment.disrespectful.content": "The Scratch comment filter thinks that your comment was disrespectful. Remember that there is a person behind this Scratch account, and sometimes, a mean comment can really hurt someone&apos;s feelings."
+    "comment.disrespectful.header": "Make sure to be friendly and respectful when using Scratch.",
+    "comment.disrespectful.content1": "The Scratch comment filter thinks your comment was disrespectful.",
+    "comment.disrespectful.content2": "Remember: There is a person behind every Scratch account and unfriendly comments can really hurt someone's feelings."
 }

--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -45,5 +45,8 @@
     "project.cloudVariables": "Cloud Variables",
     "project.cloudDataLink": "See Data",
     "project.usernameBlockAlert": "This project can detect who is using it, through the \"username\" block. To hide your identity, sign out before using the project.",
-    "project.inappropriateUpdate": "Hmm...the bad word detector thinks there is a problem with your text. Please change it and remember to be respectful."
+    "project.inappropriateUpdate": "Hmm...the bad word detector thinks there is a problem with your text. Please change it and remember to be respectful.",
+    "comment.type.disrespectful": "Scratch thinks your most recent comment was disrespectful.",
+    "comment.disrespectful.header": "Make sure to be respectful to others when commenting on Scratch.",
+    "comment.disrespectful.content": "The Scratch comment filter thinks that your comment was disrespectful. Remember that there is a person behind this Scratch account, and sometimes, a mean comment can really hurt someone&apos;s feelings."
 }

--- a/test/unit/components/compose-comment.test.jsx
+++ b/test/unit/components/compose-comment.test.jsx
@@ -1,5 +1,6 @@
 const React = require('react');
 const {shallowWithIntl} = require('../../helpers/intl-helpers.jsx');
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
 const ComposeComment = require('../../../src/views/preview/comment/compose-comment.jsx');
 import configureStore from 'redux-mock-store';
 
@@ -138,8 +139,14 @@ describe('Compose Comment test', () => {
     test('Mute Modal shows when muteOpen is true ', () => {
         const realDateNow = Date.now.bind(global.Date);
         global.Date.now = () => 0;
-        const component = getComposeCommentWrapper({});
-        const commentInstance = component.instance();
+        const component = mountWithIntl(
+            <ComposeComment
+                {...defaultProps()}
+            />
+            , {context: {store}}
+        );
+        // set state on the ComposeComment component, not the wrapper
+        const commentInstance = component.find('ComposeComment').instance();
         commentInstance.setState({muteOpen: true});
         component.update();
         expect(component.find('MuteModal').exists()).toEqual(true);

--- a/test/unit/components/mute-modal.test.jsx
+++ b/test/unit/components/mute-modal.test.jsx
@@ -6,52 +6,60 @@ import Modal from '../../../src/components/modal/base/modal';
 
 
 describe('MuteModalTest', () => {
+    const defaultMessages = {
+        commentType: 'comment.type.disrespectful',
+        muteStepHeader: 'comment.disrespectful.header',
+        muteStepContent: 'comment.disrespectful.content'
+    };
 
     test('Mute Modal rendering', () => {
         const component = shallowWithIntl(
-            <MuteModal />
-        );
+            <MuteModal muteModalMessages={defaultMessages} />
+        ).dive();
         expect(component.find('div.mute-modal-header').exists()).toEqual(true);
 
     });
 
     test('Mute Modal only shows next button on initial step', () => {
         const component = mountWithIntl(
-            <MuteModal />
+            <MuteModal muteModalMessages={defaultMessages} />
         );
+
         expect(component.find('div.mute-nav').exists()).toEqual(true);
         expect(component.find('button.next-button').exists()).toEqual(true);
         expect(component.find('button.next-button').getElements()[0].props.onClick)
-            .toEqual(component.instance().handleNext);
+            .toEqual(component.find('MuteModal').instance().handleNext);
         expect(component.find('button.close-button').exists()).toEqual(false);
         expect(component.find('button.back-button').exists()).toEqual(false);
     });
 
     test('Mute Modal shows back & close button on last step', () => {
         const component = mountWithIntl(
-            <MuteModal />
+            <MuteModal muteModalMessages={defaultMessages} />
         );
         // Step 1 is the last step.
-        component.instance().setState({step: 1});
+        component.find('MuteModal').instance()
+            .setState({step: 1});
         component.update();
 
         expect(component.find('div.mute-nav').exists()).toEqual(true);
         expect(component.find('button.next-button').exists()).toEqual(false);
         expect(component.find('button.back-button').exists()).toEqual(true);
         expect(component.find('button.back-button').getElements()[0].props.onClick)
-            .toEqual(component.instance().handlePrevious);
+            .toEqual(component.find('MuteModal').instance().handlePrevious);
         expect(component.find('button.close-button').exists()).toEqual(true);
         expect(component.find('button.close-button').getElements()[0].props.onClick)
-            .toEqual(component.instance().props.onRequestClose);
+            .toEqual(component.find('MuteModal').instance().props.onRequestClose);
     });
 
     test('Mute modal sends correct props to Modal', () => {
         const closeFn = jest.fn();
         const component = shallowWithIntl(
             <MuteModal
+                muteModalMessages={defaultMessages}
                 onRequestClose={closeFn}
             />
-        );
+        ).dive();
         const modal = component.find(Modal);
         expect(modal).toHaveLength(1);
         expect(modal.props().showCloseButton).toBe(false);
@@ -64,9 +72,10 @@ describe('MuteModalTest', () => {
         const closeFn = jest.fn();
         const component = shallowWithIntl(
             <MuteModal
+                muteModalMessages={defaultMessages}
                 onRequestClose={closeFn}
             />
-        );
+        ).dive();
         expect(component.instance().state.step).toBe(0);
         component.instance().handleNext();
         expect(component.instance().state.step).toBe(1);
@@ -74,8 +83,8 @@ describe('MuteModalTest', () => {
 
     test('Mute modal handle previous step', () => {
         const component = shallowWithIntl(
-            <MuteModal />
-        );
+            <MuteModal muteModalMessages={defaultMessages} />
+        ).dive();
         component.instance().setState({step: 1});
 
         component.instance().handlePrevious();
@@ -84,8 +93,8 @@ describe('MuteModalTest', () => {
 
     test('Mute modal handle previous step stops at 0', () => {
         const component = shallowWithIntl(
-            <MuteModal />
-        );
+            <MuteModal muteModalMessages={defaultMessages} />
+        ).dive();
         component.instance().setState({step: 0});
         component.instance().handlePrevious();
         expect(component.instance().state.step).toBe(0);

--- a/test/unit/components/mute-modal.test.jsx
+++ b/test/unit/components/mute-modal.test.jsx
@@ -9,7 +9,7 @@ describe('MuteModalTest', () => {
     const defaultMessages = {
         commentType: 'comment.type.disrespectful',
         muteStepHeader: 'comment.disrespectful.header',
-        muteStepContent: 'comment.disrespectful.content'
+        muteStepContent: ['comment.disrespectful.content1', 'comment.disrespectful.content2']
     };
 
     test('Mute Modal rendering', () => {


### PR DESCRIPTION
### Resolves:

resolves #4691 

### Changes:
Wraps the MuteModal in the Intl HOC and moves all strings into l10n files.

The strings about muting are in the general `l10n.json` because they will be used in both the commenting status and mute modal components. `next`, `back`, and `close` were already in the general strings, so just reused them.

Strings needed for the compose-comment component are only on the project page (preview view), so they are in the view's `l10n.json` file.

### Test Coverage:

Updated the mute modal tests to handle being wrapped in the intl HOC. For the tests that actually mount the component, it meant finding and checking the `MuteModal` component within the wrapper instead of testing the wrapper component.
