### PR TITLE
Fix ?mode=trending

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -62,17 +62,17 @@ class Search extends React.Component {
         const query = decodeURIComponent(window.location.search.split('+').join('%20'));
         let term = query;
 
-        const stripQueryValue = function (queryTerm) {
+        const stripQueryValue = function (queryTerm, canReturnEmpty) {
             const queryIndex = query.indexOf('q=');
             if (queryIndex !== -1) {
                 queryTerm = query.substring(queryIndex + 2, query.length).toLowerCase();
             }
-            return queryTerm;
+            return canReturnEmpty ? '' : queryTerm;
         };
         // Strip off the initial "?q="
-        term = stripQueryValue(term);
+        term = stripQueryValue(term, true);
         // Strip off user entered "?q="
-        term = stripQueryValue(term);
+        term = stripQueryValue(term, false);
 
         while (term.indexOf('/') > -1) {
             term = term.substring(0, term.indexOf('/'));


### PR DESCRIPTION
### Resolves:

Resolves #3696 

### Changes:

Clicking the search icon without searching anything and setting mode to "Trending" now works correctly instead of searching for `?mode=trending`.

I don't know if the extra `canReturnEmpty` parameter is necessary or not because I don't understand what the second call to `stripQueryValue()` does.

### Test Coverage:

Manually tested.
![image](https://user-images.githubusercontent.com/51849865/101919276-a86bc600-3bca-11eb-8bf8-8cbc08d5e18d.png)
