### PR TITLE
Fix Title Case for 'Account settings'

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -1,5 +1,5 @@
 {
-    "general.accountSettings": "Account settings",
+    "general.accountSettings": "Account Settings",
     "general.about": "About",
     "general.aboutScratch": "About Scratch",
     "general.apiError": "Whoops, Scratch had an error.",


### PR DESCRIPTION
### Resolves:

https://scratch.mit.edu/discuss/topic/461302/

ETA: I didn't see that the issue was closed, sorry: https://github.com/LLK/scratch-www/pull/4771

Maybe we can still have this though, since it seems to be a problem for people with OCD.

### Changes:

Fix Title Case for "Account settings" to improve accessibility for people with OCD.

### Test Coverage:

N/A