### PR TITLE
set, purge static_assets surrogate key on deploy

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -270,8 +270,8 @@ async.auto({
         fastly.activateVersion(results.version, function (e, resp) {
             if (e) throw new Error(e);
             process.stdout.write('Successfully configured and activated version ' + resp.number + '\n');
-            // purge static_assets using surrogate key
-            fastly.purgeKey(FASTLY_SERVICE_ID, 'static_assets', function (error) {
+            // purge static-assets using surrogate key
+            fastly.purgeKey(FASTLY_SERVICE_ID, 'static-assets', function (error) {
                 if (error) throw new Error(error);
                 process.stdout.write('Purged static assets.\n');
             });

--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -270,12 +270,11 @@ async.auto({
         fastly.activateVersion(results.version, function (e, resp) {
             if (e) throw new Error(e);
             process.stdout.write('Successfully configured and activated version ' + resp.number + '\n');
-            if (process.env.FASTLY_PURGE_ALL) {
-                fastly.purgeAll(FASTLY_SERVICE_ID, function (error) {
-                    if (error) throw new Error(error);
-                    process.stdout.write('Purged all.\n');
-                });
-            }
+            // purge static_assets using surrogate key
+            fastly.purgeKey(FASTLY_SERVICE_ID, 'static_assets', function (error) {
+                if (error) throw new Error(error);
+                process.stdout.write('Purged static assets.\n');
+            });
         });
     }
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "npm run deploy:s3 && npm run deploy:fastly",
     "deploy:fastly": "node ./bin/configure-fastly.js",
     "deploy:s3": "npm run deploy:s3:all && npm run deploy:s3:svg && npm run deploy:s3:js",
-    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600",
+    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600 --add-header=Surrogate-Key:static_assets",
     "deploy:s3:all": "npm run deploy:s3cmd -- --exclude '.DS_Store' --exclude '*.svg' --exclude '*.js' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:svg": "npm run deploy:s3cmd -- --exclude '*' --include '*.svg' --mime-type 'image/svg+xml' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:js": "npm run deploy:s3cmd -- --exclude '*' --include '*.js' --mime-type 'application/javascript' ./build/ s3://$S3_BUCKET_NAME/",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "npm run deploy:s3 && npm run deploy:fastly",
     "deploy:fastly": "node ./bin/configure-fastly.js",
     "deploy:s3": "npm run deploy:s3:all && npm run deploy:s3:svg && npm run deploy:s3:js",
-    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600 --add-header=x-amz-meta-surrogate-key:static_assets",
+    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600 --add-header=x-amz-meta-surrogate-key:static-assets",
     "deploy:s3:all": "npm run deploy:s3cmd -- --exclude '.DS_Store' --exclude '*.svg' --exclude '*.js' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:svg": "npm run deploy:s3cmd -- --exclude '*' --include '*.svg' --mime-type 'image/svg+xml' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:js": "npm run deploy:s3cmd -- --exclude '*' --include '*.js' --mime-type 'application/javascript' ./build/ s3://$S3_BUCKET_NAME/",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "npm run deploy:s3 && npm run deploy:fastly",
     "deploy:fastly": "node ./bin/configure-fastly.js",
     "deploy:s3": "npm run deploy:s3:all && npm run deploy:s3:svg && npm run deploy:s3:js",
-    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600 --add-header=Surrogate-Key:static_assets",
+    "deploy:s3cmd": "s3cmd sync -P --delete-removed --add-header=Cache-Control:no-cache,public,max-age=3600 --add-header=x-amz-meta-surrogate-key:static_assets",
     "deploy:s3:all": "npm run deploy:s3cmd -- --exclude '.DS_Store' --exclude '*.svg' --exclude '*.js' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:svg": "npm run deploy:s3cmd -- --exclude '*' --include '*.svg' --mime-type 'image/svg+xml' ./build/ s3://$S3_BUCKET_NAME/",
     "deploy:s3:js": "npm run deploy:s3cmd -- --exclude '*' --include '*.js' --mime-type 'application/javascript' ./build/ s3://$S3_BUCKET_NAME/",


### PR DESCRIPTION
### Resolves:

Resolves https://github.com/LLK/scratch-www/issues/4791

### Changes:

* when deploying static assets to S3, sets the "Surrogate-Key" header to value "static-assets".
* when finished with upload part of deploy, purges Fastly surrogate key "static-assets", instead of purging all.

### Test Coverage:

none