### PR TITLE
Remove use of FormattedHTMLMessage in Annual Report

### DIFF
--- a/src/views/annual-report/annual-report.jsx
+++ b/src/views/annual-report/annual-report.jsx
@@ -2,7 +2,6 @@ const bindAll = require('lodash.bindall');
 const classNames = require('classnames');
 const React = require('react');
 const MediaQuery = require('react-responsive').default;
-const FormattedHTMLMessage = require('react-intl').FormattedHTMLMessage;
 const FormattedMessage = require('react-intl').FormattedMessage;
 const injectIntl = require('react-intl').injectIntl;
 const intlShape = require('react-intl').intlShape;
@@ -1994,11 +1993,11 @@ class AnnualReport extends React.Component {
                                     <FormattedMessage id="annualReport.supportersTitle" />
                                 </h2>
                                 <p>
-                                    <FormattedHTMLMessage id="annualReport.supportersIntro" />
+                                    <FormattedMessage id="annualReport.supportersIntro" />
                                 </p>
                             </div>
                             <div className="subsection-tag">
-                                <FormattedHTMLMessage id="annualReport.supportersSpotlightTitle" />
+                                <FormattedMessage id="annualReport.supportersSpotlightTitle" />
                             </div>
                             <div className="supporters-subsection">
                                 <div className="supporters-blurb">
@@ -2033,53 +2032,53 @@ class AnnualReport extends React.Component {
                             <div className="supporters-subsection supporters-lists">
                                 <div className="supporters-blurb">
                                     <h4>
-                                        <FormattedHTMLMessage id="annualReport.supportersThankYou" />
+                                        <FormattedMessage id="annualReport.supportersThankYou" />
                                     </h4>
                                     <p>
-                                        <FormattedHTMLMessage id="annualReport.supportersAllDescription" />
+                                        <FormattedMessage id="annualReport.supportersAllDescription" />
                                     </p>
                                     <p className="founding-partners-blurb">
-                                        <FormattedHTMLMessage id="annualReport.supportersFoundingDescription" />
+                                        <FormattedMessage id="annualReport.supportersFoundingDescription" />
                                     </p>
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersFoundingTitle" />
+                                        <FormattedMessage id="annualReport.supportersFoundingTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.founding)}
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersCreativityTitle" />
+                                        <FormattedMessage id="annualReport.supportersCreativityTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.creativity)}
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersCollaborationTitle" />
+                                        <FormattedMessage id="annualReport.supportersCollaborationTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.collaboration)}
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersImaginationTitle" />
+                                        <FormattedMessage id="annualReport.supportersImaginationTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.imagination)}
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersInspirationTitle" />
+                                        <FormattedMessage id="annualReport.supportersInspirationTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.inspiration)}
                                 </div>
                                 <div className="supporters-level">
                                     <h5>
-                                        <FormattedHTMLMessage id="annualReport.supportersExplorationTitle" />
+                                        <FormattedMessage id="annualReport.supportersExplorationTitle" />
                                     </h5>
                                     <hr />
                                     {createSupportersLists(Supporters.exploration)}
@@ -2088,7 +2087,7 @@ class AnnualReport extends React.Component {
                             <div className="supporters-subsection supporters-lists">
                                 <div className="supporters-level">
                                     <h3>
-                                        <FormattedHTMLMessage id="annualReport.supportersInKindTitle" />
+                                        <FormattedMessage id="annualReport.supportersInKindTitle" />
                                     </h3>
                                     {createSupportersLists(Supporters.inKind)}
                                 </div>


### PR DESCRIPTION
Removes all usage of FormattedHTMLMessage in Annual Report and replaces them with FormattedMessage. All of the uses were in the Supporters section and had no actual HTML in the strings. There should be no visible changes to that or any section.

**In bughunt...**
* Test that the Supporters section text is the same in production and staging when language is English
* Test that production and staging are the same amount translated when language is not English (Italian, French, and Korean have a lot of translations)