### PR TITLE
Changed text strings on SEC page

### DIFF
--- a/src/views/sec/l10n.json
+++ b/src/views/sec/l10n.json
@@ -25,7 +25,7 @@
   "sec.expectationsFromOrgsPoint5": "Promote your organization’s work and impact through Scratch Foundation social-channels, websites, newsletters, and the Scratch Conference",
   "sec.expectationsFromOrgsPoint6": "Facilitate a Scratch Day for your community with support from the Scratch Foundation",
   "sec.eligibilityPrefix": "Your organization is:",
-  "sec.eligibilityPoint1": "Primarily focused on supporting traditionally underrepresented youth, including Black, LatinX, and Indigenous Americans in the United States and/or globally",
+  "sec.eligibilityPoint1": "Primarily focused on supporting traditionally underrepresented youth, including Black, Latinx, and Indigenous people in the United States and/or globally",
   "sec.eligibilityPoint2": "Directly serving youth through creative learning and/or creative coding initiatives",
   "sec.eligibilityPoint3": "Designated as a non-profit, or a school district that has demonstrated a commitment to equitable creative learning practices",
   "sec.eligibilityPoint4": "Willing to collaborate with Scratch and the SEC community to develop and utilize creative computing resources that can be shared globally",


### PR DESCRIPTION
In the section "Eligibility," the first bullet point should say: 
Primarily focused on supporting traditionally underrepresented youth, including Black, Latinx, and Indigenous people in the United States and/or globally

Key changes: 
- This PR changes "Indigenous Americans" to "Indigenous people"
- This PR makes the 'x' in Latinx be lowercase