### PR TITLE
Change time library to default to 1 minute when the time remaining is less than 30 seconds.

### DIFF
--- a/src/lib/format-time.js
+++ b/src/lib/format-time.js
@@ -1,3 +1,6 @@
+// IMPORTANT: any changes to the time algorithm also need to be made in the corresponding
+// scratchr2 file 'lib/format-time.js'
+
 /**
  Given a timestamp in the future, calculate the largest, closest unit to show.
  On the high end we stop at hours. e.g. 15 days is still counted in hours not days or weeks.

--- a/src/lib/format-time.js
+++ b/src/lib/format-time.js
@@ -18,8 +18,10 @@ const getTimeUnitAndDuration = timeStamp => {
         unit = 'hour';
         duration = diff / oneHourInMs;
     }
-    // Round to nearest hour or minute.
-    duration = Math.round(duration);
+    // Round to nearest hour or minute, but always have at least 1
+    // so we don't show something like "0 minutes". Hours isn't
+    // affected by the math.max because we choose minutes up to 2 hours.
+    duration = Math.max(1, Math.round(duration));
     return {
         unit: unit,
         duration: duration

--- a/test/unit/lib/format-time.test.js
+++ b/test/unit/lib/format-time.test.js
@@ -26,6 +26,13 @@ describe('unit test lib/format-time.js', () => {
         expect(mockFormatExpression.format).toHaveBeenCalledWith(2, 'minute');
     });
 
+    test('test timestamp that is 15 seconds in the future displays 1', () => {
+        const fifteenSec = 15 * 1000;
+        mockFormatExpression.format.mockReturnValue('in 1 minute');
+        format.formatRelativeTime(fifteenSec, 'en');
+        expect(mockFormatExpression.format).toHaveBeenCalledWith(1, 'minute');
+    });
+
     test('test rounding timestamp that is 4.4 minutes rounds to 4', () => {
         const fourPlusMin = 4.4 * 60 * 1000;
         mockFormatExpression.format.mockReturnValue('in 4 minutes');


### PR DESCRIPTION

### Resolves:
#4886 

### Changes:

Round to the nearest minute, except for when there is less than 1 minute. In that case pin to 1.

### Test Coverage:

Unit test added for 15sec remaining.
