### PR TITLE
Fix gh-4913: MacOS version string update

### DIFF
--- a/src/views/scratch_1.4/l10n.json
+++ b/src/views/scratch_1.4/l10n.json
@@ -4,7 +4,7 @@
   "onePointFour.introNote": "{noteLabel} You can still share projects from 1.4 to the Scratch website. However, projects created in newer versions of Scratch cannot be opened in 1.4.",
   "onePointFour.downloads": "Downloads",
   "onePointFour.macTitle": "Mac OS X",
-  "onePointFour.macBody": "Compatible with Mac OSX 10.4 or later",
+  "onePointFour.macBody": "Compatible with Mac OSX 10.4 through 10.14",
   "onePointFour.windowsTitle": "Windows",
   "onePointFour.windowsBody": "Compatible with Windows 2000, XP, Vista, 7, and 8",
   "onePointFour.windowsNetworkInstaller": "installer",


### PR DESCRIPTION
### Resolves: 

#4913 

### Changes: 

l10n string changed from "Compatible with Mac OSX 10.4 or later" to "Compatible with Mac OSX 10.4 through 10.14".

I also checked to make sure that there weren't any other instances of "Compatible with Mac OSX 10.4 or later" left in the repo, seems that there was only this one instance.

(Though notably, the "through 10.14" substring was already present in the same l10n file, on line 25: https://github.com/LLK/scratch-www/blob/develop/src/views/scratch_1.4/l10n.json#L25 )

### Test Coverage:

No tests were conducted since this is just a simple l10n string change.
