### PR TITLE
Don't require a big phone number validation library on every page

### DIFF
--- a/src/components/forms/phone-input.jsx
+++ b/src/components/forms/phone-input.jsx
@@ -17,6 +17,21 @@ const validationHOCFactory = require('./validations.jsx').validationHOCFactory;
 require('./row.scss');
 require('./phone-input.scss');
 
+const Formsy = require('formsy-react');
+const libphonenumber = require('google-libphonenumber');
+const phoneNumberUtil = libphonenumber.PhoneNumberUtil.getInstance();
+
+Formsy.addValidationRule('isPhone', (values, value) => {
+    if (typeof value === 'undefined') return true;
+    if (value && value.national_number === '+') return true;
+    try {
+        const parsed = phoneNumberUtil.parse(value.national_number, value.country_code.iso2);
+        return phoneNumberUtil.isValidNumber(parsed);
+    } catch (err) {
+        return false;
+    }
+});
+
 class PhoneInput extends React.Component {
     constructor (props) {
         super(props);

--- a/src/components/forms/validations.jsx
+++ b/src/components/forms/validations.jsx
@@ -1,24 +1,12 @@
 const defaults = require('lodash.defaultsdeep');
 const intl = require('../../lib/intl.jsx');
-const libphonenumber = require('google-libphonenumber');
 const omit = require('lodash.omit');
-const phoneNumberUtil = libphonenumber.PhoneNumberUtil.getInstance();
 const PropTypes = require('prop-types');
 const React = require('react');
 
 module.exports.validations = {
     notEquals: (values, value, neq) => (value !== neq),
-    notEqualsField: (values, value, field) => (value !== values[field]),
-    isPhone: (values, value) => {
-        if (typeof value === 'undefined') return true;
-        if (value && value.national_number === '+') return true;
-        try {
-            const parsed = phoneNumberUtil.parse(value.national_number, value.country_code.iso2);
-            return phoneNumberUtil.isValidNumber(parsed);
-        } catch (err) {
-            return false;
-        }
-    }
+    notEqualsField: (values, value, field) => (value !== values[field])
 };
 
 module.exports.validations.notEqualsUsername = module.exports.validations.notEquals;

--- a/src/components/registration/phone-number-step.jsx
+++ b/src/components/registration/phone-number-step.jsx
@@ -1,0 +1,107 @@
+/* eslint-disable react/no-multi-comp */
+const bindAll = require('lodash.bindall');
+const injectIntl = require('react-intl').injectIntl;
+const intlShape = require('react-intl').intlShape;
+const PropTypes = require('prop-types');
+const React = require('react');
+
+const intl = require('../../lib/intl.jsx');
+
+const Card = require('../../components/card/card.jsx');
+const Checkbox = require('../../components/forms/checkbox.jsx');
+const Form = require('../../components/forms/form.jsx');
+const PhoneInput = require('../../components/forms/phone-input.jsx');
+const Slide = require('../../components/slide/slide.jsx');
+const StepNavigation = require('../../components/stepnavigation/stepnavigation.jsx');
+const Tooltip = require('../../components/tooltip/tooltip.jsx');
+
+require('./steps.scss');
+
+/*
+ * This step is separate from the other steps because it includes a large library
+ * for phone number validation. 
+ */
+class PhoneNumberStep extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleValidSubmit'
+        ]);
+    }
+    handleValidSubmit(formData, reset, invalidate) {
+        if (!formData.phone || formData.phone.national_number === '+') {
+            return invalidate({
+                phone: this.props.intl.formatMessage({id: 'form.validationRequired'})
+            });
+        }
+        return this.props.onNextStep(formData);
+    }
+    render() {
+        return (
+            <Slide className="registration-step phone-step">
+                <h2>
+                    <intl.FormattedMessage id="teacherRegistration.phoneNumber" />
+                </h2>
+                <p className="description">
+                    <intl.FormattedMessage id="teacherRegistration.phoneStepDescription" />
+                    <Tooltip
+                        tipContent={
+                            this.props.intl.formatMessage({id: 'registration.nameStepTooltip'})
+                        }
+                        title={'?'}
+                    />
+                </p>
+                <Card>
+                    <Form onValidSubmit={this.handleValidSubmit}>
+                        <PhoneInput
+                            required
+                            defaultCountry={this.props.defaultCountry}
+                            label={
+                                this.props.intl.formatMessage({id: 'teacherRegistration.phoneNumber'})
+                            }
+                            name="phone"
+                        />
+                        <Checkbox
+                            name="phoneConsent"
+                            required="isFalse"
+                            validationErrors={{
+                                isFalse: this.props.intl.formatMessage({
+                                    id: 'teacherRegistration.validationPhoneConsent'
+                                })
+                            }}
+                            valueLabel={
+                                this.props.intl.formatMessage({id: 'teacherRegistration.phoneConsent'})
+                            }
+                        />
+                        <NextStepButton
+                            text={<intl.FormattedMessage id="registration.nextStep" />}
+                            waiting={this.props.waiting}
+                        />
+                    </Form>
+                </Card>
+                <StepNavigation
+                    active={this.props.activeStep}
+                    steps={this.props.totalSteps - 1}
+                />
+            </Slide>
+        );
+    }
+}
+
+PhoneNumberStep.propTypes = {
+    activeStep: PropTypes.number,
+    defaultCountry: PropTypes.string,
+    intl: intlShape,
+    onNextStep: PropTypes.func,
+    totalSteps: PropTypes.number,
+    waiting: PropTypes.bool
+};
+
+PhoneNumberStep.defaultProps = {
+    defaultCountry: DEFAULT_COUNTRY,
+    waiting: false
+};
+
+const IntlPhoneNumberStep = injectIntl(PhoneNumberStep);
+
+module.exports = IntlPhoneNumberStep;

--- a/src/components/registration/phone-number-step.jsx
+++ b/src/components/registration/phone-number-step.jsx
@@ -15,11 +15,13 @@ const Slide = require('../../components/slide/slide.jsx');
 const StepNavigation = require('../../components/stepnavigation/stepnavigation.jsx');
 const Tooltip = require('../../components/tooltip/tooltip.jsx');
 
+const {DEFAULT_COUNTRY, NextStepButton} = require('./steps.jsx');
+
 require('./steps.scss');
 
 /*
  * This step is separate from the other steps because it includes a large library
- * for phone number validation. 
+ * for phone number validation.
  */
 class PhoneNumberStep extends React.Component {
     constructor (props) {
@@ -28,7 +30,7 @@ class PhoneNumberStep extends React.Component {
             'handleValidSubmit'
         ]);
     }
-    handleValidSubmit(formData, reset, invalidate) {
+    handleValidSubmit (formData, reset, invalidate) {
         if (!formData.phone || formData.phone.national_number === '+') {
             return invalidate({
                 phone: this.props.intl.formatMessage({id: 'form.validationRequired'})
@@ -36,7 +38,7 @@ class PhoneNumberStep extends React.Component {
         }
         return this.props.onNextStep(formData);
     }
-    render() {
+    render () {
         return (
             <Slide className="registration-step phone-step">
                 <h2>

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -20,7 +20,6 @@ const CheckboxGroup = require('../../components/forms/checkbox-group.jsx');
 const Form = require('../../components/forms/form.jsx');
 const GeneralError = require('../../components/forms/general-error.jsx');
 const Input = require('../../components/forms/input.jsx');
-const PhoneInput = require('../../components/forms/phone-input.jsx');
 const RadioGroup = require('../../components/forms/radio-group.jsx');
 const Select = require('../../components/forms/select.jsx');
 const Slide = require('../../components/slide/slide.jsx');
@@ -701,93 +700,6 @@ NameStep.defaultProps = {
 };
 
 const IntlNameStep = injectIntl(NameStep);
-
-
-/*
- * PHONE NUMBER STEP
- */
-class PhoneNumberStep extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'handleValidSubmit'
-        ]);
-    }
-    handleValidSubmit (formData, reset, invalidate) {
-        if (!formData.phone || formData.phone.national_number === '+') {
-            return invalidate({
-                phone: this.props.intl.formatMessage({id: 'form.validationRequired'})
-            });
-        }
-        return this.props.onNextStep(formData);
-    }
-    render () {
-        return (
-            <Slide className="registration-step phone-step">
-                <h2>
-                    <intl.FormattedMessage id="teacherRegistration.phoneNumber" />
-                </h2>
-                <p className="description">
-                    <intl.FormattedMessage id="teacherRegistration.phoneStepDescription" />
-                    <Tooltip
-                        tipContent={
-                            this.props.intl.formatMessage({id: 'registration.nameStepTooltip'})
-                        }
-                        title={'?'}
-                    />
-                </p>
-                <Card>
-                    <Form onValidSubmit={this.handleValidSubmit}>
-                        <PhoneInput
-                            required
-                            defaultCountry={this.props.defaultCountry}
-                            label={
-                                this.props.intl.formatMessage({id: 'teacherRegistration.phoneNumber'})
-                            }
-                            name="phone"
-                        />
-                        <Checkbox
-                            name="phoneConsent"
-                            required="isFalse"
-                            validationErrors={{
-                                isFalse: this.props.intl.formatMessage({
-                                    id: 'teacherRegistration.validationPhoneConsent'
-                                })
-                            }}
-                            valueLabel={
-                                this.props.intl.formatMessage({id: 'teacherRegistration.phoneConsent'})
-                            }
-                        />
-                        <NextStepButton
-                            text={<intl.FormattedMessage id="registration.nextStep" />}
-                            waiting={this.props.waiting}
-                        />
-                    </Form>
-                </Card>
-                <StepNavigation
-                    active={this.props.activeStep}
-                    steps={this.props.totalSteps - 1}
-                />
-            </Slide>
-        );
-    }
-}
-
-PhoneNumberStep.propTypes = {
-    activeStep: PropTypes.number,
-    defaultCountry: PropTypes.string,
-    intl: intlShape,
-    onNextStep: PropTypes.func,
-    totalSteps: PropTypes.number,
-    waiting: PropTypes.bool
-};
-
-PhoneNumberStep.defaultProps = {
-    defaultCountry: DEFAULT_COUNTRY,
-    waiting: false
-};
-
-const IntlPhoneNumberStep = injectIntl(PhoneNumberStep);
 
 
 /*
@@ -1670,7 +1582,6 @@ module.exports.UsernameStep = IntlUsernameStep;
 module.exports.ChoosePasswordStep = IntlChoosePasswordStep;
 module.exports.DemographicsStep = IntlDemographicsStep;
 module.exports.NameStep = IntlNameStep;
-module.exports.PhoneNumberStep = IntlPhoneNumberStep;
 module.exports.OrganizationStep = IntlOrganizationStep;
 module.exports.AddressStep = IntlAddressStep;
 module.exports.UseScratchStep = IntlUseScratchStep;

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -1578,6 +1578,8 @@ RegistrationError.propTypes = {
 
 const IntlRegistrationError = injectIntl(RegistrationError);
 
+module.exports.DEFAULT_COUNTRY = DEFAULT_COUNTRY;
+module.exports.NextStepButton = NextStepButton;
 module.exports.UsernameStep = IntlUsernameStep;
 module.exports.ChoosePasswordStep = IntlChoosePasswordStep;
 module.exports.DemographicsStep = IntlDemographicsStep;

--- a/src/views/teacherregistration/teacherregistration.jsx
+++ b/src/views/teacherregistration/teacherregistration.jsx
@@ -12,6 +12,7 @@ const sessionActions = require('../../redux/session.js');
 const Deck = require('../../components/deck/deck.jsx');
 const Progression = require('../../components/progression/progression.jsx');
 const Steps = require('../../components/registration/steps.jsx');
+const PhoneNumberStep = require('../../components/registration/phone-number-step.jsx');
 
 const render = require('../../lib/render.jsx');
 
@@ -119,7 +120,7 @@ class TeacherRegistration extends React.Component {
                             waiting={this.state.waiting}
                             onNextStep={this.handleAdvanceStep}
                         />
-                        <Steps.PhoneNumberStep
+                        <PhoneNumberStep
                             defaultCountry={this.state.formData.countryCode}
                             waiting={this.state.waiting}
                             onNextStep={this.handleAdvanceStep}


### PR DESCRIPTION
Paired on this with @picklesrus 

### Resolves:

This fixes an issue (unfiled) where the `libphonenumber` dependency was being loaded on every page, even though only one of our pages actually uses phone number validation (teacher registration). 

### Changes:

There are two parts: 
1. da2ca40 moves the `isPhone` formsy validation out of the common validations registered from `forms/form.jsx` out into the `forms/phone-input.jsx` component itself so that the `isPhone` validation is only registered when you require the `PhoneInput` component. This allows forms that do not use that validation (e.g. login, language switcher) to not load the 500k+ libphonenumber dependency. This change removed that library from the `common.bundle.js` and made it only get required from `teacherregistration.html` but also `teacher waiting room` and `student registration`.
2. 0353135 splits the `PhoneNumberStep` out of `registration/steps.jsx` into its own file. Previously any view that used any of the steps from `registration/steps` would load the phone-input validation. Now you have to load the `PhoneStep` separately, confining its dependencies to that specific view. 

### Tests

The splitting of the bundles was tested by using the `webpack-bundle-analyzer`. In combination with the libphonenumber package update, we should manually verify that the phone input in teacher registration is still working, and that the other step-wise registration flows are still working as well (since those files are touched as well). /cc @BryceLTaylor 