### PR TITLE
Create Plotly bundle to load only choropleth

### DIFF
--- a/src/components/world-map/world-map.jsx
+++ b/src/components/world-map/world-map.jsx
@@ -1,4 +1,14 @@
-import Plot from 'react-plotly.js';
+const Plotly = require('plotly.js/lib/core');
+
+// Load in the trace type for choropleth
+Plotly.register([
+    require('plotly.js/lib/choropleth')
+]);
+
+// create plotly bundle that only has choropleth plots
+import createPlotlyComponent from 'react-plotly.js/factory';
+const Plot = createPlotlyComponent(Plotly);
+
 const React = require('react');
 const PropTypes = require('prop-types');
 


### PR DESCRIPTION
This reduced the size of the library that we are loading for WorldMap, by creating a Plotly bundle that only supports the choropleth visualization type.

To test, we should verify that this decreases the size of Plotly in www. We should also check that the world map continues to show up on the annual report.