### PR TITLE
Add spam mute message

### DIFF
--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -224,6 +224,12 @@ class ComposeComment extends React.Component {
                 muteStepHeader: 'comment.vulgarity.header',
                 muteStepContent: ['comment.vulgarity.content1', 'comment.vulgarity.content2']
             },
+            spam: {
+                name: 'spam',
+                commentType: 'comment.type.spam',
+                muteStepHeader: 'comment.spam.header',
+                muteStepContent: ['comment.spam.content1', 'comment.spam.content2']
+            },
             general: {
                 name: 'general',
                 commentType: 'comment.type.general',

--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -61,5 +61,9 @@
     "comment.type.vulgarity": "Your most recent comment appeared to include a bad word.",
     "comment.vulgarity.header": "We encourage you to use language that’s appropriate for all ages.",
     "comment.vulgarity.content1": "It appears that your comment contains a bad word.",
-    "comment.vulgarity.content2": "Scratch has users of all ages, so it’s important to use language that is appropriate for all Scratchers."
+    "comment.vulgarity.content2": "Scratch has users of all ages, so it’s important to use language that is appropriate for all Scratchers.",
+    "comment.type.spam": "Your most recent comment appeared to contain advertising, text art, or a chain message.",
+    "comment.spam.header": "We encourage you to not advertise, copy and paste text art, or ask others to copy comments",
+    "comment.spam.content1": "Even though advertisements, text art, and chain mail can be fun, they start to fill up the website, and we want to make sure there is room for other comments.",
+    "comment.spam.content2": "Thank you for helping us keep Scratch a friendly, creative community!"
 }

--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -63,7 +63,7 @@
     "comment.vulgarity.content1": "It appears that your comment contains a bad word.",
     "comment.vulgarity.content2": "Scratch has users of all ages, so it’s important to use language that is appropriate for all Scratchers.",
     "comment.type.spam": "Your most recent comment appeared to contain advertising, text art, or a chain message.",
-    "comment.spam.header": "We encourage you to not advertise, copy and paste text art, or ask others to copy comments",
+    "comment.spam.header": "We encourage you not to advertise, copy and paste text art, or ask others to copy comments.",
     "comment.spam.content1": "Even though advertisements, text art, and chain mail can be fun, they start to fill up the website, and we want to make sure there is room for other comments.",
     "comment.spam.content2": "Thank you for helping us keep Scratch a friendly, creative community!"
 }


### PR DESCRIPTION
Adds a mute message for spam comments: https://docs.google.com/document/d/1FNEB8LN-VrlzcKwRATRjYjqT45buHDQ6bBEBErFJ6OA/edit#

To test, we should try making spam comments on projects (example comment: "10 facts about you") to see the new modal messaging. Other types of muted comments should work the same as before.