### PR TITLE
Only show feedback link for new mute

### DIFF
--- a/src/components/modal/mute/modal.jsx
+++ b/src/components/modal/mute/modal.jsx
@@ -162,7 +162,7 @@ class MuteModal extends React.Component {
                                     )}}
                                 />
                             </p>
-                            {this.state.step === this.numSteps ? feedbackPrompt : null}
+                            {this.state.step === this.numSteps && this.props.showFeedback ? feedbackPrompt : null}
                         </MuteStep>
                         <MuteStep
                             header={this.props.intl.formatMessage({id: 'comments.muted.mistakeHeader'})}

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -23,6 +23,7 @@ require('./comment.scss');
 const onUpdate = update => update;
 
 const MAX_COMMENT_LENGTH = 500;
+const JUST_MUTED_ERROR = 'isBad';
 
 const ComposeStatus = keyMirror({
     EDITING: null,
@@ -363,7 +364,9 @@ class ComposeComment extends React.Component {
                         commentContent={this.state.message}
                         muteModalMessages={this.getMuteMessageInfo()}
                         shouldCloseOnOverlayClick={false}
-                        showFeedback={this.state.status === ComposeStatus.REJECTED_MUTE}
+                        showFeedback={
+                            this.state.status === ComposeStatus.REJECTED_MUTE && this.state.error === JUST_MUTED_ERROR
+                        }
                         showWarning={this.state.showWarning}
                         startStep={this.getMuteModalStartStep()}
                         timeMuted={formatTime.formatRelativeTime(this.state.muteExpiresAtMs, window._locale)}

--- a/test/unit/components/compose-comment.test.jsx
+++ b/test/unit/components/compose-comment.test.jsx
@@ -304,6 +304,59 @@ describe('Compose Comment test', () => {
         expect(component.find('MuteModal').props().showWarning).toBe(true);
     });
 
+    test('Mute Modal gets showFeedback props from state', () => {
+        const store = mockStore({
+            session: {
+                session: {
+                    user: {},
+                    permissions: {
+                        mute_status: {}
+                    }
+                }
+            }
+        });
+
+        const component = mountWithIntl(
+            <ComposeComment
+                {...defaultProps()}
+            />
+            , {context: {store}}
+        );
+
+        const commentInstance = component.find('ComposeComment').instance();
+        commentInstance.setState({
+            status: 'REJECTED_MUTE',
+            error: 'isBad',
+            muteOpen: true
+        });
+
+        component.update();
+        expect(component.find('MuteModal').exists()).toEqual(true);
+        expect(component.find('MuteModal').props().showFeedback).toBe(true);
+
+        commentInstance.setState({
+            status: 'REJECTED_MUTE',
+            error: 'isMute',
+            showWarning: true,
+            muteOpen: true
+        });
+
+        component.update();
+        expect(component.find('MuteModal').exists()).toEqual(true);
+        expect(component.find('MuteModal').props().showFeedback).toBe(false);
+
+        commentInstance.setState({
+            status: 'REJECTED',
+            error: 'isBad',
+            showWarning: true,
+            muteOpen: true
+        });
+
+        component.update();
+        expect(component.find('MuteModal').exists()).toEqual(true);
+        expect(component.find('MuteModal').props().showFeedback).toBe(false);
+    });
+
     test('shouldShowMuteModal is false when muteStatus is undefined ', () => {
         const commentInstance = getComposeCommentWrapper({}).instance();
         expect(commentInstance.shouldShowMuteModal()).toBe(false);
@@ -449,4 +502,15 @@ describe('Compose Comment test', () => {
         commentInstance.setState({muteType: 'spaghetti'});
         expect(commentInstance.getMuteMessageInfo().commentType).toBe('comment.type.general');
     });
+
+    // test('Show feedback link when comment is initially rejected', () => {
+    //     const component = getComposeCommentWrapper({});
+    //     const commentInstance = component.instance();
+    //     commentInstance.setState({error: 'isBad', mute_status: {}});
+    //     component.update();
+    //     expect(component.find('FlexRow.compose-error-row').exists()).toEqual(true);
+    //     // Buttons stay enabled when comment rejected for non-mute reasons
+    //     expect(component.find('Button.compose-post').props().disabled).toBe(false);
+    //     expect(component.find('Button.compose-cancel').props().disabled).toBe(false);
+    // });
 });

--- a/test/unit/components/compose-comment.test.jsx
+++ b/test/unit/components/compose-comment.test.jsx
@@ -502,15 +502,4 @@ describe('Compose Comment test', () => {
         commentInstance.setState({muteType: 'spaghetti'});
         expect(commentInstance.getMuteMessageInfo().commentType).toBe('comment.type.general');
     });
-
-    // test('Show feedback link when comment is initially rejected', () => {
-    //     const component = getComposeCommentWrapper({});
-    //     const commentInstance = component.instance();
-    //     commentInstance.setState({error: 'isBad', mute_status: {}});
-    //     component.update();
-    //     expect(component.find('FlexRow.compose-error-row').exists()).toEqual(true);
-    //     // Buttons stay enabled when comment rejected for non-mute reasons
-    //     expect(component.find('Button.compose-post').props().disabled).toBe(false);
-    //     expect(component.find('Button.compose-cancel').props().disabled).toBe(false);
-    // });
 });

--- a/test/unit/components/mute-modal.test.jsx
+++ b/test/unit/components/mute-modal.test.jsx
@@ -160,6 +160,23 @@ describe('MuteModalTest', () => {
         expect(component.find('p.feedback-prompt').exists()).toEqual(true);
     });
 
+    test('Mute modal does not for feedback on extra showWarning step if not showFeedback', () => {
+        const component = mountWithIntl(
+            <MuteModal
+                showWarning
+                muteModalMessages={defaultMessages}
+            />
+        );
+        component.find('MuteModal').instance()
+            .setState({step: 1});
+        component.update();
+        expect(component.find('p.feedback-prompt').exists()).toEqual(false);
+        component.find('MuteModal').instance()
+            .setState({step: 2});
+        component.update();
+        expect(component.find('p.feedback-prompt').exists()).toEqual(false);
+    });
+
     test('Mute modal handle go to feedback', () => {
         const component = shallowWithIntl(
             <MuteModal


### PR DESCRIPTION
Addresses issue #5091, prevent moderation feedback on comments that did not trigger the mod event

Things to test in bughunt:
- When you get muted from a www page and look at the modal, you see a link prompting for feedback
- After you get muted by an admin, when you open up the mute modal, you do not see the feedback prompt
- Using Scratch in multiple tabs does not result in seeing the feedback prompt when you shouldn't.