### PR TITLE
Fetch studio info and roles in redux

### DIFF
--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -32,26 +32,26 @@ const studioReducer = (state, action) => {
     }
 
     switch (action.type) {
-        case 'SET_INFO':
-            return {
-                ...state,
-                ...action.info
-            };
-        case 'SET_ROLES':
-            return {
-                ...state,
-                ...action.roles
-            };
-        case 'SET_FETCH_STATUS':
-            if (action.error) {
-                log.error(action.error);
-            }
-            return {
-                ...state,
-                [action.fetchType]: action.fetchStatus
-            };
-        default:
-            return state;
+    case 'SET_INFO':
+        return {
+            ...state,
+            ...action.info
+        };
+    case 'SET_ROLES':
+        return {
+            ...state,
+            ...action.roles
+        };
+    case 'SET_FETCH_STATUS':
+        if (action.error) {
+            log.error(action.error);
+        }
+        return {
+            ...state,
+            [action.fetchType]: action.fetchStatus
+        };
+    default:
+        return state;
     }
 };
 
@@ -62,19 +62,19 @@ const setFetchStatus = (fetchType, fetchStatus, error) => ({
     error
 });
 
-const setInfo = (info) => ({
+const setInfo = info => ({
     type: 'SET_INFO',
     info: info
 });
 
-const setRoles = (roles) => ({
+const setRoles = roles => ({
     type: 'SET_ROLES',
     roles: roles
 });
 
-const getInfo = (studioId) => (dispatch => {
+const getInfo = studioId => (dispatch => {
     dispatch(setFetchStatus('infoStatus', Status.FETCHING));
-    api({uri: `/studios/${studioId}`,}, (err, body, res) => {
+    api({uri: `/studios/${studioId}`}, (err, body, res) => {
         if (err || typeof body === 'undefined' || res.statusCode !== 200) {
             dispatch(setFetchStatus('infoStatus', Status.ERROR, err));
             return;
@@ -117,4 +117,4 @@ module.exports = {
     Status,
     getInfo,
     getRoles
-}
+};

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -1,0 +1,120 @@
+const keyMirror = require('keymirror');
+
+const api = require('../lib/api');
+const log = require('../lib/log');
+
+const Status = keyMirror({
+    FETCHED: null,
+    NOT_FETCHED: null,
+    FETCHING: null,
+    ERROR: null
+});
+
+const getInitialState = () => ({
+    infoStatus: Status.NOT_FETCHED,
+    title: '',
+    description: '',
+    openToAll: false,
+    commentingAllowed: false,
+    thumbnail: '',
+    followers: 0,
+
+    rolesStatus: Status.NOT_FETCHED,
+    manager: false,
+    curator: false,
+    follower: false,
+    invited: false
+});
+
+const studioReducer = (state, action) => {
+    if (typeof state === 'undefined') {
+        state = getInitialState();
+    }
+
+    switch (action.type) {
+        case 'SET_INFO':
+            return {
+                ...state,
+                ...action.info
+            };
+        case 'SET_ROLES':
+            return {
+                ...state,
+                ...action.roles
+            };
+        case 'SET_FETCH_STATUS':
+            if (action.error) {
+                log.error(action.error);
+            }
+            return {
+                ...state,
+                [action.fetchType]: action.fetchStatus
+            };
+        default:
+            return state;
+    }
+};
+
+const setFetchStatus = (fetchType, fetchStatus, error) => ({
+    type: 'SET_FETCH_STATUS',
+    fetchType,
+    fetchStatus,
+    error
+});
+
+const setInfo = (info) => ({
+    type: 'SET_INFO',
+    info: info
+});
+
+const setRoles = (roles) => ({
+    type: 'SET_ROLES',
+    roles: roles
+});
+
+const getInfo = (studioId) => (dispatch => {
+    dispatch(setFetchStatus('infoStatus', Status.FETCHING));
+    api({uri: `/studios/${studioId}`,}, (err, body, res) => {
+        if (err || typeof body === 'undefined' || res.statusCode !== 200) {
+            dispatch(setFetchStatus('infoStatus', Status.ERROR, err));
+            return;
+        }
+        dispatch(setFetchStatus('infoStatus', Status.FETCHED));
+        dispatch(setInfo({
+            title: body.title,
+            description: body.description,
+            openToAll: body.open_to_all,
+            commentingAllowed: body.commenting_allowed,
+            updated: new Date(body.history.modified),
+            followers: body.stats.followers
+        }));
+    });
+});
+
+const getRoles = (studioId, username, token) => (dispatch => {
+    dispatch(setFetchStatus('rolesStatus', Status.FETCHING));
+    api({
+        uri: `/studios/${studioId}/users/${username}`,
+        authentication: token
+    }, (err, body, res) => {
+        if (err || typeof body === 'undefined' || res.statusCode !== 200) {
+            dispatch(setFetchStatus('rolesStatus', Status.ERROR, err));
+            return;
+        }
+        dispatch(setFetchStatus('rolesStatus', Status.FETCHED));
+        dispatch(setRoles({
+            manager: body.manager,
+            curator: body.curator,
+            following: body.following,
+            invited: body.invited
+        }));
+    });
+});
+
+module.exports = {
+    getInitialState,
+    studioReducer,
+    Status,
+    getInfo,
+    getRoles
+}

--- a/src/views/studio/lib/fetchers.js
+++ b/src/views/studio/lib/fetchers.js
@@ -1,8 +1,5 @@
 const ITEM_LIMIT = 4;
 
-const infoFetcher = studioId => fetch(`${process.env.API_HOST}/studios/${studioId}`)
-    .then(response => response.json());
-
 const projectFetcher = (studioId, offset) =>
     fetch(`${process.env.API_HOST}/studios/${studioId}/projects?limit=${ITEM_LIMIT}&offset=${offset}`)
         .then(response => response.json())
@@ -25,7 +22,6 @@ const activityFetcher = studioId =>
 
 export {
     activityFetcher,
-    infoFetcher,
     projectFetcher,
     curatorFetcher,
     managerFetcher

--- a/src/views/studio/studio-info.jsx
+++ b/src/views/studio/studio-info.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
 import {connect} from 'react-redux';
 import Debug from './debug.jsx';
-import {Status as SessionStatus} from '../../redux/session';
 import {getInfo, getRoles} from '../../redux/studio';
 
 const StudioInfo = ({username, studio, token, onLoadInfo, onLoadRoles}) => {
@@ -33,11 +32,13 @@ StudioInfo.propTypes = {
     token: PropTypes.string,
     studio: PropTypes.shape({
         // Fill this in as the data is used, just for demo now
-    })
+    }),
+    onLoadInfo: PropTypes.func,
+    onLoadRoles: PropTypes.func
 };
 
 export default connect(
-    (state) => {
+    state => {
         const user = state.session.session.user;
         return {
             studio: state.studio,
@@ -45,8 +46,8 @@ export default connect(
             token: user && user.token
         };
     },
-    (dispatch) => ({
-        onLoadInfo: (studioId) => dispatch(getInfo(studioId)),
+    dispatch => ({
+        onLoadInfo: studioId => dispatch(getInfo(studioId)),
         onLoadRoles: (studioId, username, token) => dispatch(
             getRoles(studioId, username, token))
     })

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -24,6 +24,8 @@ import {
     activity
 } from './lib/redux-modules';
 
+const {studioReducer} = require('../../redux/studio');
+
 const StudioShell = () => {
     const match = useRouteMatch();
 
@@ -72,6 +74,7 @@ render(
         [projects.key]: projects.reducer,
         [curators.key]: curators.reducer,
         [managers.key]: managers.reducer,
-        [activity.key]: activity.reducer
+        [activity.key]: activity.reducer,
+        studio: studioReducer
     }
 );


### PR DESCRIPTION
Create a reducer for the studio info and studio roles data. Nothing too interesting, changed the `useState` call that was previously there to use redux instead. The roles information is based on an upcoming API for getting the logged in users relationship to the studio. 

With the role information in redux, we can start making selectors to slice permissions information out of the store, like whether the current user can add/remove projects, edit the studio description, invite/promote curators, etc... That is next up.