### PR TITLE
circleci deploy to staging with circle instead of travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
     # <<: *integration_tap
 
 workflows:
-  build-staging-production: # build-test-deploy
+  build-test-deploy:
     jobs:
       - build-staging:
           context:
@@ -154,42 +154,39 @@ workflows:
             branches:
               only:
                 - master
-      # - deploy-staging:
-      #     context:
-      #       - scratch-www-all
-      #       - scratch-www-staging
-      #     requires:
-      #       - build-staging
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #           - /^hotfix\/.*/
-      #           - /^release\/.*/
-      #           - circleCI-configure-tests
-      # - integration-staging-jest:
-      #     context:
-      #       - scratch-www-all
-      #       - scratch-www-staging
-      #     requires:
-      #       - deploy-staging
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #           - /^hotfix\/.*/
-      #           - /^release\/.*/
-      #           - circleCI-configure-tests
-      # - integration-staging-tap:
-      #     context:
-      #       - scratch-www-all
-      #       - scratch-www-staging
-      #     requires:
-      #       - deploy-staging
-      #     filters:
-      #       branches:
-      #         only:
-      #           - develop
-      #           - /^hotfix\/.*/
-      #           - /^release\/.*/
-      #           - circleCI-configure-tests
+      - deploy-staging:
+          context:
+            - scratch-www-all
+            - scratch-www-staging
+          requires:
+            - build-staging
+          filters:
+            branches:
+              only:
+                - develop
+                - /^hotfix\/.*/
+                - /^release\/.*/
+      - integration-staging-jest:
+          context:
+            - scratch-www-all
+            - scratch-www-staging
+          requires:
+            - deploy-staging
+          filters:
+            branches:
+              only:
+                - develop
+                - /^hotfix\/.*/
+                - /^release\/.*/
+      - integration-staging-tap:
+          context:
+            - scratch-www-all
+            - scratch-www-staging
+          requires:
+            - deploy-staging
+          filters:
+            branches:
+              only:
+                - develop
+                - /^hotfix\/.*/
+                - /^release\/.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,15 +120,6 @@ jobs:
       on:
         repo: LLK/scratch-www
         branch:
-        - develop
-        - hotfix/*
-        - release/*
-    - provider: script
-      skip_cleanup: $SKIP_CLEANUP
-      script: npm run deploy
-      on:
-        repo: LLK/scratch-www
-        branch:
         - master
   - stage: smoke
     script: npm run test:integration:remote
@@ -138,6 +129,6 @@ stages:
 - name: test
   if: type != cron
 - name: smoke
-  if: type NOT IN (cron, pull_request) AND (branch =~ /^(develop|master|release\/|hotfix\/)/)
+  if: type NOT IN (cron, pull_request) AND (branch =~ /^(master)/)
 - name: update translations
   if: branch == develop AND type == cron


### PR DESCRIPTION
### Changes:

Turns on the deploy and integration jobs for develop, hotfix/*, and release/* branches for CircleCI and turns them off for those same branches in Travis.

### Test Coverage:

Includes running integration tests for the deploy to staging.
