### PR TITLE
[draft] Studio comment actions and basic display

### DIFF
--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -1,0 +1,181 @@
+const eachLimit = require('async/eachLimit');
+
+const api = require('../lib/api');
+const log = require('../lib/log');
+
+const COMMENT_LIMIT = 20;
+
+const {
+    addNewComment,
+    resetComments,
+    Status,
+    setFetchStatus,
+    setCommentDeleted,
+    setCommentReported,
+    setCommentRestored,
+    setMoreCommentsToLoad,
+    setComments,
+    setError,
+    setReplies,
+    setRepliesDeleted,
+    setRepliesRestored
+} = require('./comments.js');
+
+const getReplies = (studioId, commentIds, offset, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('replies', Status.FETCHING));
+    const fetchedReplies = {};
+    eachLimit(commentIds, 10, (parentId, callback) => {
+        api({
+            uri: `${isAdmin ? '/admin' : ''}/studios/${studioId}/comments/${parentId}/replies`,
+            authentication: token ? token : null,
+            params: {offset: offset || 0, limit: COMMENT_LIMIT}
+        }, (err, body, res) => {
+            if (err) {
+                return callback(`Error fetching comment replies: ${err}`);
+            }
+            if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
+                return callback('No comment reply information');
+            }
+            fetchedReplies[parentId] = body;
+            callback(null, body);
+        });
+    }, err => {
+        if (err) {
+            dispatch(setFetchStatus('replies', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        dispatch(setFetchStatus('replies', Status.FETCHED));
+        dispatch(setReplies(fetchedReplies));
+    });
+});
+
+const getTopLevelComments = (id, offset, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('comments', Status.FETCHING));
+    api({
+        uri: `${isAdmin ? '/admin' : ''}/studios/${id}/comments`,
+        authentication: token ? token : null,
+        params: {offset: offset || 0, limit: COMMENT_LIMIT}
+    }, (err, body, res) => {
+        if (err) {
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError('No comment info'));
+            return;
+        }
+        dispatch(setFetchStatus('comments', Status.FETCHED));
+        dispatch(setComments(body));
+        const commentsWithReplies = body.filter(comment => comment.reply_count > 0);
+        dispatch(getReplies(id, commentsWithReplies.map(comment => comment.id), 0, isAdmin, token));
+
+        // If we loaded a full page of comments, assume there are more to load.
+        // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
+        // any more server query complexity, so seems worth it. In the case of a studio with
+        // number of comments divisible by the COMMENT_LIMIT, the load more button will be
+        // clickable, but upon clicking it will go away.
+        dispatch(setMoreCommentsToLoad(body.length === COMMENT_LIMIT));
+    });
+});
+
+const getCommentById = (studioId, commentId, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('comments', Status.FETCHING));
+    api({
+        uri: `${isAdmin ? '/admin' : ''}/studios/${studioId}/comments/${commentId}`,
+        authentication: token ? token : null
+    }, (err, body, res) => {
+        if (err) {
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        if (!body || res.statusCode >= 400) { // NotFound
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError('No comment info'));
+            return;
+        }
+
+        if (body.parent_id) {
+            // If the comment is a reply, load the parent
+            return dispatch(getCommentById(studioId, body.parent_id, isAdmin, token));
+        }
+
+        // If the comment is not a reply, show it as top level and load replies
+        dispatch(setFetchStatus('comments', Status.FETCHED));
+        dispatch(setComments([body]));
+        dispatch(getReplies(studioId, [body.id], 0, isAdmin, token));
+    });
+});
+
+const deleteComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    /* TODO fetching/fetched/error states updates for comment deleting */
+    api({
+        uri: `/proxy/comments/studio/${studioId}/comment/${commentId}`,
+        authentication: token,
+        withCredentials: true,
+        method: 'DELETE',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        dispatch(setCommentDeleted(commentId, topLevelCommentId));
+        if (!topLevelCommentId) {
+            dispatch(setRepliesDeleted(commentId));
+        }
+    });
+});
+
+const reportComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    api({
+        uri: `/proxy/studio/${studioId}/comment/${commentId}/report`,
+        authentication: token,
+        withCredentials: true,
+        method: 'POST',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        // TODO use the reportId in the response for unreporting functionality
+        dispatch(setCommentReported(commentId, topLevelCommentId));
+    });
+});
+
+const restoreComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    api({
+        uri: `/proxy/admin/studio/${studioId}/comment/${commentId}/undelete`,
+        authentication: token,
+        withCredentials: true,
+        method: 'PUT',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        dispatch(setCommentRestored(commentId, topLevelCommentId));
+        if (!topLevelCommentId) {
+            dispatch(setRepliesRestored(commentId));
+        }
+    });
+});
+
+module.exports = {
+    getTopLevelComments,
+    getCommentById,
+    getReplies,
+    deleteComment,
+    reportComment,
+    restoreComment,
+    
+    // Re-export these specific action creators directly so the implementer
+    // does not need to go to two places for comment actions
+    addNewComment,
+    resetComments
+};

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -1,15 +1,91 @@
-import React from 'react';
+import React, {useEffect, useCallback} from 'react';
+import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
+import {connect} from 'react-redux';
 
-const StudioComments = () => {
+import studioCommentActions from '../../redux/studio-comment-actions';
+import TopLevelComment from '../preview/comment/top-level-comment.jsx';
+import Button from '../../components/forms/button.jsx';
+
+const StudioComments = ({
+    isAdmin,
+    token,
+    comments,
+    replies,
+    moreCommentsToLoad,
+    getTopLevelComments,
+    getReplies
+}) => {
     const {studioId} = useParams();
+
+    // useCallback creates a stable function reference based on the given dependencies
+    // Ensures there won't be extra re-renders caused by anonymous functions
+    const onLoadMore = useCallback(() => {
+        getTopLevelComments(studioId, comments.length, isAdmin, token);
+    }, [studioId, comments.length, isAdmin, token]);
+
+    const onLoadMoreReplies = useCallback((commentId, offset) => {
+        getReplies(studioId, [commentId], offset, isAdmin, token);
+    }, [studioId, isAdmin, token]);
+
+    // Trigger initial load if comments are empty. Comments may not be empty if
+    // the user is returning to the comments tab after visiting another tab.
+    useEffect(() => {
+        if (studioId && comments.length === 0) {
+            onLoadMore();
+        }
+    }, [studioId, comments.length]);
 
     return (
         <div>
             <h2>Comments</h2>
-            <p>Studio {studioId}</p>
+            <div>
+                {comments.map(comment => (
+                    <TopLevelComment
+                        author={comment.author}
+                        content={comment.content}
+                        datetimeCreated={comment.datetime_created}
+                        id={comment.id}
+                        key={comment.id}
+                        moreRepliesToLoad={comment.moreRepliesToLoad}
+                        parentId={comment.parent_id}
+                        replies={replies && replies[comment.id] ? replies[comment.id] : []}
+                        visibility={comment.visibility}
+                        onLoadMoreReplies={onLoadMoreReplies}
+                    />
+                ))}
+                {moreCommentsToLoad &&
+                    <Button
+                        className="button load-more-button"
+                        onClick={onLoadMore}
+                    >
+                        Load more
+                    </Button>
+                }
+            </div>
         </div>
     );
 };
 
-export default StudioComments;
+StudioComments.propTypes = {
+    comments: PropTypes.arrayOf(PropTypes.object),
+    isAdmin: PropTypes.bool,
+    token: PropTypes.string,
+    replies: PropTypes.objectOf(PropTypes.array),
+    moreCommentsToLoad: PropTypes.bool,
+    getTopLevelComments: PropTypes.func,
+    getReplies: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        studioId: state.studio.id,
+        comments: state.comments.comments,
+        replies: state.comments.replies,
+        moreCommentsToLoad: state.comments.moreCommentsToLoad,
+        isAdmin: state.permissions.admin,
+        token: state.session.session.user && state.session.session.user.token
+    }),
+    // mapDispatch can take an object, will automatically bind dispatch
+    studioCommentActions
+)(StudioComments);

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -23,6 +23,7 @@ import {
     managers,
     activity
 } from './lib/redux-modules';
+import {commentsReducer} from '../../redux/comments.js';
 
 const {studioReducer} = require('../../redux/studio');
 
@@ -75,6 +76,7 @@ render(
         [curators.key]: curators.reducer,
         [managers.key]: managers.reducer,
         [activity.key]: activity.reducer,
-        studio: studioReducer
+        studio: studioReducer,
+        comments: commentsReducer
     }
 );


### PR DESCRIPTION
This PR adds `studio-comment-actions.js`, a collection of actions parallel to the `project-comment-actions.js` introduced in #5100, but specialized for retrieving studio comments.

These actions are then passed into the `studio-comments.jsx` component and used to display a basic (read-only) list of comments using the existing `top-level-comments.jsx` component. This PR is read-only because the `compose-comment` component for replying is currently specialized for projects and needs refactoring, but the display of comments is general enough to use directly. 