### PR TITLE
circleci update get-pip link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ aliases:
       - run:
           name: "setup python"
           command: |
-            curl https://bootstrap.pypa.io/3.5/get-pip.py -o get-pip.py
+            curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
             python3 get-pip.py pip==21.0.1
             pip install s3cmd==2.1.0
       - run:


### PR DESCRIPTION
### Resolves:

Deploying to staging stopped working because url we use to install pip changed.  We suddenly got this error in the setup python in circle:

<img width="733" alt="Screen Shot 2021-03-30 at 6 01 48 PM" src="https://user-images.githubusercontent.com/1088291/113062749-3bcd0500-9182-11eb-80ad-18f933307720.png">

### Changes:

This PR changes the circleci config to use the new url suggested in the error message above.

This should not affect travis since it does not have a get-pip step.
