### PR TITLE
Studio Comments Fetching & Initial UI

### DIFF
--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -1,0 +1,180 @@
+const eachLimit = require('async/eachLimit');
+
+const api = require('../lib/api');
+const log = require('../lib/log');
+
+const COMMENT_LIMIT = 20;
+
+const {
+    addNewComment,
+    resetComments,
+    Status,
+    setFetchStatus,
+    setCommentDeleted,
+    setCommentReported,
+    setCommentRestored,
+    setMoreCommentsToLoad,
+    setComments,
+    setError,
+    setReplies,
+    setRepliesDeleted,
+    setRepliesRestored
+} = require('../redux/comments.js');
+
+const getReplies = (studioId, commentIds, offset, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('replies', Status.FETCHING));
+    const fetchedReplies = {};
+    eachLimit(commentIds, 10, (parentId, callback) => {
+        api({
+            uri: `${isAdmin ? '/admin' : ''}/studios/${studioId}/comments/${parentId}/replies`,
+            authentication: token ? token : null,
+            params: {offset: offset || 0, limit: COMMENT_LIMIT}
+        }, (err, body, res) => {
+            if (err) {
+                return callback(`Error fetching comment replies: ${err}`);
+            }
+            if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
+                return callback('No comment reply information');
+            }
+            fetchedReplies[parentId] = body;
+            callback(null, body);
+        });
+    }, err => {
+        if (err) {
+            dispatch(setFetchStatus('replies', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        dispatch(setFetchStatus('replies', Status.FETCHED));
+        dispatch(setReplies(fetchedReplies));
+    });
+});
+
+const getTopLevelComments = (id, offset, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('comments', Status.FETCHING));
+    api({
+        uri: `${isAdmin ? '/admin' : ''}/studios/${id}/comments`,
+        authentication: token ? token : null,
+        params: {offset: offset || 0, limit: COMMENT_LIMIT}
+    }, (err, body, res) => {
+        if (err) {
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        if (typeof body === 'undefined' || res.statusCode >= 400) { // NotFound
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError('No comment info'));
+            return;
+        }
+        dispatch(setFetchStatus('comments', Status.FETCHED));
+        dispatch(setComments(body));
+        dispatch(getReplies(id, body.map(comment => comment.id), 0, isAdmin, token));
+
+        // If we loaded a full page of comments, assume there are more to load.
+        // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
+        // any more server query complexity, so seems worth it. In the case of a project with
+        // number of comments divisible by the COMMENT_LIMIT, the load more button will be
+        // clickable, but upon clicking it will go away.
+        dispatch(setMoreCommentsToLoad(body.length === COMMENT_LIMIT));
+    });
+});
+
+const getCommentById = (studioId, commentId, isAdmin, token) => (dispatch => {
+    dispatch(setFetchStatus('comments', Status.FETCHING));
+    api({
+        uri: `${isAdmin ? '/admin' : ''}/studios/${studioId}/comments/${commentId}`,
+        authentication: token ? token : null
+    }, (err, body, res) => {
+        if (err) {
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError(err));
+            return;
+        }
+        if (!body || res.statusCode >= 400) { // NotFound
+            dispatch(setFetchStatus('comments', Status.ERROR));
+            dispatch(setError('No comment info'));
+            return;
+        }
+
+        if (body.parent_id) {
+            // If the comment is a reply, load the parent
+            return dispatch(getCommentById(studioId, body.parent_id, isAdmin, token));
+        }
+
+        // If the comment is not a reply, show it as top level and load replies
+        dispatch(setFetchStatus('comments', Status.FETCHED));
+        dispatch(setComments([body]));
+        dispatch(getReplies(studioId, [body.id], 0, isAdmin, token));
+    });
+});
+
+const deleteComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    /* TODO fetching/fetched/error states updates for comment deleting */
+    api({
+        uri: `/proxy/comments/studio/${studioId}/comment/${commentId}`,
+        authentication: token,
+        withCredentials: true,
+        method: 'DELETE',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        dispatch(setCommentDeleted(commentId, topLevelCommentId));
+        if (!topLevelCommentId) {
+            dispatch(setRepliesDeleted(commentId));
+        }
+    });
+});
+
+const reportComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    api({
+        uri: `/proxy/studio/${studioId}/comment/${commentId}/report`,
+        authentication: token,
+        withCredentials: true,
+        method: 'POST',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        // TODO use the reportId in the response for unreporting functionality
+        dispatch(setCommentReported(commentId, topLevelCommentId));
+    });
+});
+
+const restoreComment = (studioId, commentId, topLevelCommentId, token) => (dispatch => {
+    api({
+        uri: `/proxy/admin/studio/${studioId}/comment/${commentId}/undelete`,
+        authentication: token,
+        withCredentials: true,
+        method: 'PUT',
+        useCsrf: true
+    }, (err, body, res) => {
+        if (err || res.statusCode !== 200) {
+            log.error(err || res.body);
+            return;
+        }
+        dispatch(setCommentRestored(commentId, topLevelCommentId));
+        if (!topLevelCommentId) {
+            dispatch(setRepliesRestored(commentId));
+        }
+    });
+});
+
+module.exports = {
+    getTopLevelComments,
+    getCommentById,
+    getReplies,
+    deleteComment,
+    reportComment,
+    restoreComment,
+
+    // Re-export these specific action creators directly so the implementer
+    // does not need to go to two places for comment actions
+    addNewComment,
+    resetComments
+};

--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -110,7 +110,7 @@ class Comment extends React.Component {
             highlighted,
             id,
             parentId,
-            projectId,
+            postURI,
             replyUsername,
             visibility
         } = this.props;
@@ -234,7 +234,7 @@ class Comment extends React.Component {
                                 isReply
                                 commenteeId={author.id}
                                 parentId={parentId || id}
-                                projectId={projectId}
+                                postURI={postURI}
                                 onAddComment={this.handlePostReply}
                                 onCancel={this.handleToggleReplying}
                             />
@@ -285,7 +285,7 @@ Comment.propTypes = {
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
     parentId: PropTypes.number,
-    projectId: PropTypes.string,
+    postURI: PropTypes.string,
     replyUsername: PropTypes.string,
     visibility: PropTypes.string
 };

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -444,7 +444,7 @@ ComposeComment.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    muteStatus: state.session.session.permissions && state.session.session.permissions.mute_status ?
+    muteStatus: state.session.session.permissions.mute_status ?
         state.session.session.permissions.mute_status :
         {muteExpiresAt: 0, offenses: [], showWarning: false},
     user: state.session.session.user

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -79,7 +79,7 @@ class ComposeComment extends React.Component {
     handlePost () {
         this.setState({status: ComposeStatus.SUBMITTING});
         api({
-            uri: `/proxy/comments/project/${this.props.projectId}`,
+            uri: this.props.postURI,
             authentication: this.props.user.token,
             withCredentials: true,
             method: 'POST',
@@ -434,7 +434,7 @@ ComposeComment.propTypes = {
     onAddComment: PropTypes.func,
     onCancel: PropTypes.func,
     parentId: PropTypes.number,
-    projectId: PropTypes.string,
+    postURI: PropTypes.string,
     user: PropTypes.shape({
         id: PropTypes.number,
         username: PropTypes.string,
@@ -444,7 +444,7 @@ ComposeComment.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    muteStatus: state.session.session.permissions.mute_status ?
+    muteStatus: state.session.session.permissions && state.session.session.permissions.mute_status ?
         state.session.session.permissions.mute_status :
         {muteExpiresAt: 0, offenses: [], showWarning: false},
     user: state.session.session.user

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -87,7 +87,7 @@ class TopLevelComment extends React.Component {
             onReport,
             onRestore,
             replies,
-            projectId,
+            postURI,
             visibility
         } = this.props;
 
@@ -97,7 +97,7 @@ class TopLevelComment extends React.Component {
             <FlexRow className="comment-container">
                 <Comment
                     highlighted={highlightedCommentId === id}
-                    projectId={projectId}
+                    postURI={postURI}
                     onAddComment={this.handleAddComment}
                     {...{
                         author,
@@ -138,7 +138,7 @@ class TopLevelComment extends React.Component {
                                 id={reply.id}
                                 key={reply.id}
                                 parentId={id}
-                                projectId={projectId}
+                                postURI={postURI}
                                 replyUsername={this.authorUsername(reply.commentee_id)}
                                 visibility={reply.visibility}
                                 onAddComment={this.handleAddComment}
@@ -188,7 +188,7 @@ TopLevelComment.propTypes = {
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
     parentId: PropTypes.number,
-    projectId: PropTypes.string,
+    postURI: PropTypes.string,
     replies: PropTypes.arrayOf(PropTypes.object),
     visibility: PropTypes.string
 };

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -581,7 +581,7 @@ const PreviewPresentation = ({
                                             {projectInfo.comments_allowed ? (
                                                 isLoggedIn ? (
                                                     isShared && <ComposeComment
-                                                        projectId={projectId}
+                                                        postURI={`/proxy/comments/project/${projectId}`}
                                                         onAddComment={onAddComment}
                                                     />
                                                 ) : (
@@ -613,7 +613,7 @@ const PreviewPresentation = ({
                                                 key={comment.id}
                                                 moreRepliesToLoad={comment.moreRepliesToLoad}
                                                 parentId={comment.parent_id}
-                                                projectId={projectId}
+                                                postURI={`/proxy/comments/project/${projectId}`}
                                                 replies={replies && replies[comment.id] ? replies[comment.id] : []}
                                                 visibility={comment.visibility}
                                                 onAddComment={onAddComment}

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -47,6 +47,7 @@ const StudioComments = ({
                         key={comment.id}
                         moreRepliesToLoad={comment.moreRepliesToLoad}
                         parentId={comment.parent_id}
+                        postURI={`/proxy/comments/studio/${studioId}`}
                         replies={replies && replies[comment.id] ? replies[comment.id] : []}
                         visibility={comment.visibility}
                     />

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -1,15 +1,37 @@
-import React from 'react';
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
+import {connect} from 'react-redux';
+import Debug from './debug.jsx';
 
-const StudioComments = () => {
+import studioCommentActions from '../../redux/studio-comment-actions.js';
+
+const StudioComments = props => {
     const {studioId} = useParams();
-
+    useEffect(() => {
+        if (props.comments.length === 0) props.getTopLevelComments(studioId, 0)
+    }, [studioId]);
     return (
         <div>
             <h2>Comments</h2>
+            <Debug
+                label="Comments"
+                data={props}
+            />
             <p>Studio {studioId}</p>
         </div>
     );
 };
 
-export default StudioComments;
+StudioComments.propTypes = {
+    comments: PropTypes.arrayOf(PropTypes.shape({})),
+    getTopLevelComments: PropTypes.func
+};
+
+
+export default connect(
+    state => state.comments,
+    {
+        getTopLevelComments: studioCommentActions.getTopLevelComments
+    }
+)(StudioComments);

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -61,7 +61,6 @@ const StudioComments = ({
                     </Button>
                 }
             </div>
-            <p>Studio {studioId}</p>
         </div>
     );
 };

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -13,9 +13,9 @@ const StudioComments = ({
     comments,
     getTopLevelComments,
     handleNewComment,
-    isLoggedIn,
     moreCommentsToLoad,
-    replies
+    replies,
+    shouldShowCommentComposer
 }) => {
     const {studioId} = useParams();
 
@@ -31,7 +31,7 @@ const StudioComments = ({
         <div>
             <h2>Comments</h2>
             <div>
-                {isLoggedIn &&
+                {shouldShowCommentComposer &&
                     <ComposeComment
                         postURI={`/proxy/comments/studio/${studioId}`}
                         onAddComment={handleNewComment}
@@ -40,7 +40,7 @@ const StudioComments = ({
                 {comments.map(comment => (
                     <TopLevelComment
                         author={comment.author}
-                        canReply={isLoggedIn}
+                        canReply={shouldShowCommentComposer}
                         content={comment.content}
                         datetimeCreated={comment.datetime_created}
                         id={comment.id}
@@ -69,18 +69,20 @@ StudioComments.propTypes = {
     comments: PropTypes.arrayOf(PropTypes.shape({})),
     getTopLevelComments: PropTypes.func,
     handleNewComment: PropTypes.func,
-    isLoggedIn: PropTypes.bool,
     moreCommentsToLoad: PropTypes.bool,
-    replies: PropTypes.shape({})
+    replies: PropTypes.shape({}),
+    shouldShowCommentComposer: PropTypes.bool
 };
 
 
 export default connect(
     state => ({
         comments: state.comments.comments,
-        isLoggedIn: !!state.session.session.user,
         moreCommentsToLoad: state.comments.moreCommentsToLoad,
-        replies: state.comments.replies
+        replies: state.comments.replies,
+
+        // TODO permissions like this to a selector for testing
+        shouldShowCommentComposer: !!state.session.session.user // is logged in
     }),
     {
         getTopLevelComments: studioCommentActions.getTopLevelComments,

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -2,36 +2,73 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
 import {connect} from 'react-redux';
-import Debug from './debug.jsx';
+import {FormattedMessage} from 'react-intl';
 
+import Button from '../../components/forms/button.jsx';
+import ComposeComment from '../preview/comment/compose-comment.jsx';
+import TopLevelComment from '../preview/comment/top-level-comment.jsx';
 import studioCommentActions from '../../redux/studio-comment-actions.js';
 
 const StudioComments = props => {
     const {studioId} = useParams();
     useEffect(() => {
-        if (props.comments.length === 0) props.getTopLevelComments(studioId, 0)
+        if (props.comments.length === 0) props.getTopLevelComments(studioId, 0);
     }, [studioId]);
     return (
         <div>
             <h2>Comments</h2>
-            <Debug
-                label="Comments"
-                data={props}
-            />
+            <div>
+                {props.isLoggedIn ? <ComposeComment
+                    postURI={`/proxy/comments/studio/${studioId}`}
+                    // eslint-disable-next-line react/jsx-handler-names
+                    onAddComment={props.addNewComment}
+                /> : null}
+                {props.comments.map(comment => (
+                    <TopLevelComment
+                        author={comment.author}
+                        canReply={props.isLoggedIn}
+                        content={comment.content}
+                        datetimeCreated={comment.datetime_created}
+                        id={comment.id}
+                        key={comment.id}
+                        moreRepliesToLoad={comment.moreRepliesToLoad}
+                        parentId={comment.parent_id}
+                        replies={props.replies && props.replies[comment.id] ? props.replies[comment.id] : []}
+                        visibility={comment.visibility}
+                    />
+                ))}
+                {props.moreCommentsToLoad &&
+                <Button
+                    className="button load-more-button"
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onClick={() => props.getTopLevelComments(studioId, props.comments.length)}
+                >
+                    <FormattedMessage id="general.loadMore" />
+                </Button>
+                }
+            </div>
             <p>Studio {studioId}</p>
         </div>
     );
 };
 
 StudioComments.propTypes = {
+    addNewComment: PropTypes.func,
     comments: PropTypes.arrayOf(PropTypes.shape({})),
-    getTopLevelComments: PropTypes.func
+    getTopLevelComments: PropTypes.func,
+    isLoggedIn: PropTypes.bool,
+    moreCommentsToLoad: PropTypes.bool,
+    replies: PropTypes.shape({})
 };
 
 
 export default connect(
-    state => state.comments,
+    state => ({
+        isLoggedIn: !!state.session.session.user,
+        ...state.comments
+    }),
     {
+        addNewComment: studioCommentActions.addNewComment,
         getTopLevelComments: studioCommentActions.getTopLevelComments
     }
 )(StudioComments);

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
 import {connect} from 'react-redux';
@@ -18,6 +18,11 @@ const StudioComments = ({
     replies
 }) => {
     const {studioId} = useParams();
+
+    const handleLoadComments = useCallback(() => {
+        getTopLevelComments(studioId, comments.length);
+    }, [studioId, comments.length]);
+
     useEffect(() => {
         if (comments.length === 0) getTopLevelComments(studioId, 0);
     }, [studioId]);
@@ -49,8 +54,7 @@ const StudioComments = ({
                 {moreCommentsToLoad &&
                     <Button
                         className="button load-more-button"
-                        // eslint-disable-next-line react/jsx-no-bind
-                        onClick={() => getTopLevelComments(studioId, comments.length)}
+                        onClick={handleLoadComments}
                     >
                         <FormattedMessage id="general.loadMore" />
                     </Button>

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -9,42 +9,51 @@ import ComposeComment from '../preview/comment/compose-comment.jsx';
 import TopLevelComment from '../preview/comment/top-level-comment.jsx';
 import studioCommentActions from '../../redux/studio-comment-actions.js';
 
-const StudioComments = props => {
+const StudioComments = ({
+    comments,
+    getTopLevelComments,
+    handleNewComment,
+    isLoggedIn,
+    moreCommentsToLoad,
+    replies
+}) => {
     const {studioId} = useParams();
     useEffect(() => {
-        if (props.comments.length === 0) props.getTopLevelComments(studioId, 0);
+        if (comments.length === 0) getTopLevelComments(studioId, 0);
     }, [studioId]);
+
     return (
         <div>
             <h2>Comments</h2>
             <div>
-                {props.isLoggedIn ? <ComposeComment
-                    postURI={`/proxy/comments/studio/${studioId}`}
-                    // eslint-disable-next-line react/jsx-handler-names
-                    onAddComment={props.addNewComment}
-                /> : null}
-                {props.comments.map(comment => (
+                {isLoggedIn &&
+                    <ComposeComment
+                        postURI={`/proxy/comments/studio/${studioId}`}
+                        onAddComment={handleNewComment}
+                    />
+                }
+                {comments.map(comment => (
                     <TopLevelComment
                         author={comment.author}
-                        canReply={props.isLoggedIn}
+                        canReply={isLoggedIn}
                         content={comment.content}
                         datetimeCreated={comment.datetime_created}
                         id={comment.id}
                         key={comment.id}
                         moreRepliesToLoad={comment.moreRepliesToLoad}
                         parentId={comment.parent_id}
-                        replies={props.replies && props.replies[comment.id] ? props.replies[comment.id] : []}
+                        replies={replies && replies[comment.id] ? replies[comment.id] : []}
                         visibility={comment.visibility}
                     />
                 ))}
-                {props.moreCommentsToLoad &&
-                <Button
-                    className="button load-more-button"
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onClick={() => props.getTopLevelComments(studioId, props.comments.length)}
-                >
-                    <FormattedMessage id="general.loadMore" />
-                </Button>
+                {moreCommentsToLoad &&
+                    <Button
+                        className="button load-more-button"
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onClick={() => getTopLevelComments(studioId, comments.length)}
+                    >
+                        <FormattedMessage id="general.loadMore" />
+                    </Button>
                 }
             </div>
             <p>Studio {studioId}</p>
@@ -53,9 +62,9 @@ const StudioComments = props => {
 };
 
 StudioComments.propTypes = {
-    addNewComment: PropTypes.func,
     comments: PropTypes.arrayOf(PropTypes.shape({})),
     getTopLevelComments: PropTypes.func,
+    handleNewComment: PropTypes.func,
     isLoggedIn: PropTypes.bool,
     moreCommentsToLoad: PropTypes.bool,
     replies: PropTypes.shape({})
@@ -64,11 +73,13 @@ StudioComments.propTypes = {
 
 export default connect(
     state => ({
+        comments: state.comments.comments,
         isLoggedIn: !!state.session.session.user,
-        ...state.comments
+        moreCommentsToLoad: state.comments.moreCommentsToLoad,
+        replies: state.comments.replies
     }),
     {
-        addNewComment: studioCommentActions.addNewComment,
-        getTopLevelComments: studioCommentActions.getTopLevelComments
+        getTopLevelComments: studioCommentActions.getTopLevelComments,
+        handleNewComment: studioCommentActions.addNewComment
     }
 )(StudioComments);

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -25,6 +25,7 @@ import {
 } from './lib/redux-modules';
 
 const {studioReducer} = require('../../redux/studio');
+const {commentsReducer} = require('../../redux/comments');
 
 const StudioShell = () => {
     const match = useRouteMatch();
@@ -75,6 +76,7 @@ render(
         [curators.key]: curators.reducer,
         [managers.key]: managers.reducer,
         [activity.key]: activity.reducer,
-        studio: studioReducer
+        studio: studioReducer,
+        comments: commentsReducer
     }
 );


### PR DESCRIPTION
### Changes:

This PR starts some of the studio comments work, fetching the top level comments and displaying them on the comments tab of the studios playground.
- Create a studio comment actions creator using the one from project comment actions as a model.
- Hook up the comments reducer and actions to the studio comments tab
- Generalize the comment components (still currently located with the Project page code) so that they can also be used with studios. The main piece of work here was just to pull out the comment POST URI out as a component prop.
- Update project page to pass in the `postURI` prop instead of the `projectId` prop
- Add the UI for composing a comment and the list of comments to the studio comments tab
- Start to hook up some initial state controlled rendering (only displaying the comment compose UI and 'reply comment' links if a user is logged in)
- Fix a minor bug in the ComposeComment code where we were referencing an object property before it was defined

### Test Coverage:

Tested locally in the studios playground:
- Adding new comments and comment replies on the scratchr2 studios page, seeing them in the studios playground
- Adding new comments on the project page
- Adding new comments and replies in the studios playground
