### PR TITLE
Move the studio route from routes-dev.json to routes.json

### DIFF
--- a/src/routes-dev.json
+++ b/src/routes-dev.json
@@ -4,12 +4,5 @@
         "pattern": "^/components/?$",
         "view": "components/components",
         "title": "Components"
-    },
-    {
-        "name": "studio",
-        "pattern": "^/studios-playground/\\d+(/projects|/curators|/activity|/comments)?/?(\\?.*)?$",
-        "routeAlias": "/studios-playground/?$",
-        "view": "studio/studio",
-        "title": "Studio Playground"
     }
 ]

--- a/src/routes.json
+++ b/src/routes.json
@@ -297,6 +297,13 @@
         "title": "Class Registration"
     },
     {
+        "name": "studio",
+        "pattern": "^/studios-playground/\\d+(/projects|/curators|/activity|/comments)?/?(\\?.*)?$",
+        "routeAlias": "/studios-playground/?$",
+        "view": "studio/studio",
+        "title": "Studio Playground"
+    },
+    {
         "name": "teacher-faq",
         "pattern": "^/educators/faq/?$",
         "routeAlias": "/educators(?:/(faq|register|waiting))?/?$",


### PR DESCRIPTION
### Resolves:

Allows the in progress www studios page to be viewable on staging and production.

### Changes:

Moves the studios route from routes-dev.json to routes.json

These routes are being blocked by fastly if you are not coming from certain specific ip addresses.
