### PR TITLE
Include onAddComment for studio comments

### DIFF
--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -50,6 +50,7 @@ const StudioComments = ({
                         postURI={`/proxy/comments/studio/${studioId}`}
                         replies={replies && replies[comment.id] ? replies[comment.id] : []}
                         visibility={comment.visibility}
+                        onAddComment={handleNewComment}
                     />
                 ))}
                 {moreCommentsToLoad &&


### PR DESCRIPTION
@kchadha looks like we forgot to include the `onAddComment` prop for the studio comments (I think we must have missed a last commit, postURI was also missing but I caught that before the previous PR)