### PR TITLE
Hook up remaining comment actions for studio comments

### DIFF
--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -91,8 +91,14 @@ const selectCanAddProjects = state =>
     isCurator(state) ||
     (selectIsSocial(state) && state.studio.openToAll);
 
-// This isn't "canComment" since they could be muted, but comment composer handles that
 const selectShowCommentComposer = state => selectIsSocial(state);
+const selectCanReportComment = state => selectIsSocial(state);
+const selectCanRestoreComment = state => selectIsAdmin(state);
+// On the project page, project owners can delete comments with a confirmation,
+// and admins can delete comments without a confirmation. For now, only admins
+// can delete studio comments, so the following two are the same.
+const selectCanDeleteComment = state => selectIsAdmin(state);
+const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
 
 // Data selectors
 const selectStudioId = state => state.studio.id;
@@ -157,5 +163,9 @@ module.exports = {
     selectStudioId,
     selectCanEditInfo,
     selectCanAddProjects,
-    selectShowCommentComposer
+    selectShowCommentComposer,
+    selectCanDeleteComment,
+    selectCanDeleteCommentWithoutConfirm,
+    selectCanReportComment,
+    selectCanRestoreComment
 };

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {useParams} from 'react-router-dom';
 import {connect} from 'react-redux';
 import {FormattedMessage} from 'react-intl';
 

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -9,7 +9,13 @@ import ComposeComment from '../preview/comment/compose-comment.jsx';
 import TopLevelComment from '../preview/comment/top-level-comment.jsx';
 import studioCommentActions from '../../redux/studio-comment-actions.js';
 
-import {selectShowCommentComposer} from '../../redux/studio.js';
+import {
+    selectShowCommentComposer,
+    selectCanDeleteComment,
+    selectCanDeleteCommentWithoutConfirm,
+    selectCanReportComment,
+    selectCanRestoreComment
+} from '../../redux/studio.js';
 
 const StudioComments = ({
     comments,
@@ -17,10 +23,17 @@ const StudioComments = ({
     handleNewComment,
     moreCommentsToLoad,
     replies,
-    shouldShowCommentComposer
+    postURI,
+    shouldShowCommentComposer,
+    canDeleteComment,
+    canDeleteCommentWithoutConfirm,
+    canReportComment,
+    canRestoreComment,
+    handleDeleteComment,
+    handleRestoreComment,
+    handleReportComment,
+    handleLoadMoreReplies
 }) => {
-    const {studioId} = useParams();
-
     useEffect(() => {
         if (comments.length === 0) handleLoadMoreComments();
     }, []); // Only runs once after the first render
@@ -31,24 +44,32 @@ const StudioComments = ({
             <div>
                 {shouldShowCommentComposer &&
                     <ComposeComment
-                        postURI={`/proxy/comments/studio/${studioId}`}
+                        postURI={postURI}
                         onAddComment={handleNewComment}
                     />
                 }
                 {comments.map(comment => (
                     <TopLevelComment
                         author={comment.author}
+                        canDelete={canDeleteComment}
+                        canDeleteWithoutConfirm={canDeleteCommentWithoutConfirm}
                         canReply={shouldShowCommentComposer}
+                        canReport={canReportComment}
+                        canRestore={canRestoreComment}
                         content={comment.content}
                         datetimeCreated={comment.datetime_created}
                         id={comment.id}
                         key={comment.id}
                         moreRepliesToLoad={comment.moreRepliesToLoad}
                         parentId={comment.parent_id}
-                        postURI={`/proxy/comments/studio/${studioId}`}
+                        postURI={postURI}
                         replies={replies && replies[comment.id] ? replies[comment.id] : []}
                         visibility={comment.visibility}
                         onAddComment={handleNewComment}
+                        onDelete={handleDeleteComment}
+                        onRestore={handleRestoreComment}
+                        onReport={handleReportComment}
+                        onLoadMoreReplies={handleLoadMoreReplies}
                     />
                 ))}
                 {moreCommentsToLoad &&
@@ -70,19 +91,37 @@ StudioComments.propTypes = {
     handleNewComment: PropTypes.func,
     moreCommentsToLoad: PropTypes.bool,
     replies: PropTypes.shape({}),
-    shouldShowCommentComposer: PropTypes.bool
+    shouldShowCommentComposer: PropTypes.bool,
+    canDeleteComment: PropTypes.bool,
+    canDeleteCommentWithoutConfirm: PropTypes.bool,
+    canReportComment: PropTypes.bool,
+    canRestoreComment: PropTypes.bool,
+    handleDeleteComment: PropTypes.func,
+    handleRestoreComment: PropTypes.func,
+    handleReportComment: PropTypes.func,
+    handleLoadMoreReplies: PropTypes.func,
+    postURI: PropTypes.string
 };
-
 
 export default connect(
     state => ({
         comments: state.comments.comments,
         moreCommentsToLoad: state.comments.moreCommentsToLoad,
         replies: state.comments.replies,
-        shouldShowCommentComposer: selectShowCommentComposer(state)
+        shouldShowCommentComposer: selectShowCommentComposer(state),
+        canDeleteComment: selectCanDeleteComment(state),
+        canDeleteCommentWithoutConfirm: selectCanDeleteCommentWithoutConfirm(state),
+        canReportComment: selectCanReportComment(state),
+        canRestoreComment: selectCanRestoreComment(state),
+        postURI: `/proxy/comments/studio/${state.studio.id}`
     }),
     {
         handleLoadMoreComments: studioCommentActions.getTopLevelComments,
-        handleNewComment: studioCommentActions.addNewComment
+        handleNewComment: studioCommentActions.addNewComment,
+        handleDeleteComment: studioCommentActions.deleteComment,
+        handleRestoreComment: studioCommentActions.restoreComment,
+        handleReportComment: studioCommentActions.reportComment,
+        handleLoadMoreReplies: studioCommentActions.getReplies
+
     }
 )(StudioComments);


### PR DESCRIPTION
This PR hooks up the remaining actions for studio comments:
- Loading more replies for a thread
- Deleting a comment
- Restoring a comment
- Reporting a comment

This PR also adds permissions selectors and extensive testing for them. The idea of the extensive testing is not that the selectors are particularly complex, but that they may change over time (they are not intended to be 100% accurate right now even), and we want to be very confident about both the current state of permissions and making changes to those permissions. The structure/format of these tests should be considered experimental, I don't think we've used [`test.each`](https://jestjs.io/docs/api#testeachtablename-fn-timeout) anywhere yet. The goal primarily is ease of answering the question: _can X do Y?_

This PR also follows on the previous one by removing more arguments to the studio-comment-actions. This helps remove the need for intermediate functions that bind data like username/token to callback functions, instead using `getState` inside the thunk to get that data directly.

/cc @kchadha I'd recommend reviewing this PR commit by commit, since there is a lot of related code in each commit that looks pretty confusing/unrelated when viewed all at once.