### PR TITLE
Move deploy and integration tests to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,15 +123,15 @@ jobs:
   deploy-staging:
     <<: *deploy
   deploy-production:
-    # <<: *deploy
+    <<: *deploy
   integration-staging-jest:
     <<: *integration_jest
   integration-staging-tap:
     <<: *integration_tap
   integration-production-jest:
-    # <<: *integration_jest
+    <<: *integration_jest
   integration-production-tap:
-    # <<: *integration_tap
+    <<: *integration_tap
 
 workflows:
   build-test-deploy:
@@ -166,6 +166,16 @@ workflows:
                 - develop
                 - /^hotfix\/.*/
                 - /^release\/.*/
+      - deploy-production:
+          context:
+            - scratch-www-all
+            - scratch-www-production
+          requires:
+            - build-production
+          filters:
+            branches:
+              only:
+                - master
       - integration-staging-jest:
           context:
             - scratch-www-all
@@ -190,3 +200,23 @@ workflows:
                 - develop
                 - /^hotfix\/.*/
                 - /^release\/.*/
+      - integration-production-jest:
+          context:
+            - scratch-www-all
+            - scratch-www-production
+          requires:
+            - deploy-production
+          filters:
+            branches:
+              only:
+                - master
+      - integration-production-tap:
+          context:
+            - scratch-www-all
+            - scratch-www-production
+          requires:
+            - deploy-production
+          filters:
+            branches:
+              only:
+                - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,22 +113,10 @@ install:
 jobs:
   include:
   - stage: test
-    deploy:
-    - provider: script
-      skip_cleanup: $SKIP_CLEANUP
-      script: npm run deploy
-      on:
-        repo: LLK/scratch-www
-        branch:
-        - master
-  - stage: smoke
-    script: npm run test:integration:remote
   - stage: update translations
     script: npm run i18n:push
 stages:
 - name: test
   if: type != cron
-- name: smoke
-  if: type NOT IN (cron, pull_request) AND (branch =~ /^(master)/)
 - name: update translations
   if: branch == develop AND type == cron


### PR DESCRIPTION
### Changes:

Adds the deploy-production and integration jobs to the circleci config.
Removes the deploy step from travis entirely.
Removes the smoke job from travis entirely.

### Test Coverage:

Includes running integration tests against production after the deploy
