### PR TITLE
Add client-side editing of studio info

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -121,7 +121,7 @@ module.exports.refreshSessionWithRetry = () => (dispatch => {
 });
 
 // Selectors
-module.exports.selectIsLoggedIn = state => get(state, ['session', 'session', 'user'], false);
+module.exports.selectIsLoggedIn = state => !!get(state, ['session', 'session', 'user'], false);
 module.exports.selectUsername = state => get(state, ['session', 'session', 'user', 'username'], null);
 module.exports.selectToken = state => get(state, ['session', 'session', 'user', 'token'], null);
 module.exports.selectIsAdmin = state => get(state, ['session', 'session', 'permissions', 'admin'], false);

--- a/src/redux/studio-mutations.js
+++ b/src/redux/studio-mutations.js
@@ -191,7 +191,7 @@ const mutateStudioCommentsAllowed = shouldAllow => ((dispatch, getState) => {
     api({
         host: '',
         uri: `/site-api/comments/gallery/${studioId}/toggle-comments/`,
-        method: 'PUT',
+        method: 'POST',
         useCsrf: true
     }, (err, body, res) => {
         const error = normalizeError(err, body, res);

--- a/src/redux/studio-mutations.js
+++ b/src/redux/studio-mutations.js
@@ -1,0 +1,174 @@
+/**
+ * Studio Mutation Reducer - Responsible for client-side modifications
+ * to studio info / roles. Stores in-progress and error states for updates,
+ * and handles the network requests.
+ *
+ * This reducer DOES NOT store the value of the field being mutated,
+ * or deal with loading that value initially from the server. That is
+ * handled by the studio info and roles reducer.
+ */
+const keyMirror = require('keymirror');
+const api = require('../lib/api');
+const {selectUsername} = require('./session');
+const {selectStudioId} = require('./studio');
+
+const Errors = keyMirror({
+    NETWORK: null,
+    SERVER: null,
+    INAPPROPRIATE: null,
+    PERMISSION: null,
+    UNHANDLED: null
+});
+
+const getInitialState = () => ({
+    mutationErrors: {}, // { [field]: <error>, ... }
+    isMutating: {} // { [field]: <boolean>, ... }
+});
+
+const studioMutationsReducer = (state, action) => {
+    if (typeof state === 'undefined') {
+        state = getInitialState();
+    }
+
+    switch (action.type) {
+    case 'START_STUDIO_MUTATION':
+        return {
+            ...state,
+            isMutating: {
+                ...state.isMutating,
+                [action.field]: true
+            },
+            mutationErrors: {
+                ...state.mutationErrors,
+                [action.field]: null
+            }
+        };
+    case 'COMPLETE_STUDIO_MUTATION':
+        return {
+            ...state,
+            isMutating: {
+                ...state.isMutating,
+                [action.field]: false
+            },
+            mutationErrors: {
+                ...state.mutationErrors,
+                [action.field]: action.error
+            }
+        };
+    default:
+        return state;
+    }
+};
+
+// Action Creators
+const startMutation = field => ({
+    type: 'START_STUDIO_MUTATION',
+    field
+});
+
+const completeMutation = (field, value, error = null) => ({
+    type: 'COMPLETE_STUDIO_MUTATION',
+    field,
+    value, // Value is used by other reducers listening for this action
+    error
+});
+
+// Selectors
+const selectIsMutatingTitle = state => state.studioMutations.isMutating.title;
+const selectIsMutatingDescription = state => state.studioMutations.isMutating.description;
+const selectIsMutatingFollowing = state => state.studioMutations.isMutating.following;
+const selectTitleMutationError = state => state.studioMutations.mutationErrors.title;
+const selectDescriptionMutationError = state => state.studioMutations.mutationErrors.description;
+const selectFollowingMutationError = state => state.studioMutations.mutationErrors.following;
+
+// Thunks
+/**
+ * Given a response from `api.js`, normalize the possible
+ * error conditions using the `Errors` object.
+ * @param {object} err - error from api.js
+ * @param {object} body - parsed body
+ * @param {object} res - raw response from api.js
+ * @returns {string} one of Errors.<TYPE> or null
+ */
+const normalizeError = (err, body, res) => {
+    if (err) return Errors.NETWORK;
+    if (res.statusCode === 401 || res.statusCode === 403) return Errors.PERMISSION;
+    if (res.statusCode !== 200) return Errors.SERVER;
+    try {
+        if (body.errors.length > 0) {
+            if (body.errors[0] === 'inappropriate-generic') return Errors.INAPPROPRIATE;
+            return Errors.UNHANDLED;
+        }
+    } catch (_) { /* No body.errors[], continue */ }
+    return null;
+};
+
+const mutateStudioTitle = value => ((dispatch, getState) => {
+    dispatch(startMutation('title'));
+    api({
+        host: '',
+        uri: `/site-api/galleries/all/${selectStudioId(getState())}/`,
+        method: 'PUT',
+        useCsrf: true,
+        json: {
+            title: value
+        }
+    }, (err, body, res) => {
+        const error = normalizeError(err, body, res);
+        dispatch(completeMutation('title', value, error));
+    });
+});
+
+const mutateStudioDescription = value => ((dispatch, getState) => {
+    dispatch(startMutation('description'));
+    api({
+        host: '',
+        uri: `/site-api/galleries/all/${selectStudioId(getState())}/`,
+        method: 'PUT',
+        useCsrf: true,
+        json: {
+            description: value
+        }
+    }, (err, body, res) => {
+        const error = normalizeError(err, body, res);
+        dispatch(completeMutation('description', value, error));
+    });
+});
+
+const mutateFollowingStudio = shouldFollow => ((dispatch, getState) => {
+    dispatch(startMutation('following'));
+    const state = getState();
+    const studioId = selectStudioId(state);
+    const username = selectUsername(state);
+    let uri = `/site-api/users/bookmarkers/${studioId}/`;
+    uri += shouldFollow ? 'add/' : 'remove/';
+    uri += `?usernames=${username}`;
+    api({
+        host: '',
+        uri: uri,
+        method: 'PUT',
+        useCsrf: true
+    }, (err, body, res) => {
+        const error = normalizeError(err, body, res);
+        dispatch(completeMutation('following', error ? !shouldFollow : shouldFollow, error));
+    });
+});
+
+module.exports = {
+    getInitialState,
+    studioMutationsReducer,
+    Errors,
+
+    // Thunks
+    mutateStudioTitle,
+    mutateStudioDescription,
+    mutateFollowingStudio,
+
+    // Selectors
+    selectIsMutatingTitle,
+    selectIsMutatingDescription,
+    selectIsMutatingFollowing,
+    selectTitleMutationError,
+    selectDescriptionMutationError,
+    selectFollowingMutationError
+};

--- a/src/redux/studio-mutations.js
+++ b/src/redux/studio-mutations.js
@@ -19,6 +19,8 @@ const Errors = keyMirror({
     PERMISSION: null,
     THUMBNAIL_TOO_LARGE: null,
     THUMBNAIL_MISSING: null,
+    TEXT_TOO_LONG: null,
+    REQUIRED_FIELD: null,
     UNHANDLED: null
 });
 
@@ -104,10 +106,14 @@ const normalizeError = (err, body, res) => {
     if (res.statusCode !== 200) return Errors.SERVER;
     try {
         if (body.errors.length > 0) {
-            if (body.errors[0] === 'inappropriate-generic') return Errors.INAPPROPRIATE;
-            if (body.errors[0] === 'thumbnail-too-large') return Errors.THUMBNAIL_TOO_LARGE;
-            if (body.errors[0] === 'thumbnail-missing') return Errors.THUMBNAIL_MISSING;
-            return Errors.UNHANDLED;
+            switch (body.errors[0]) {
+            case 'inappropriate-generic': return Errors.INAPPROPRIATE;
+            case 'thumbnail-too-large': return Errors.THUMBNAIL_TOO_LARGE;
+            case 'thumbnail-missing': return Errors.THUMBNAIL_MISSING;
+            case 'editable-text-too-long': return Errors.TEXT_TOO_LONG;
+            case 'This field is required.': return Errors.REQUIRED_FIELD;
+            default: return Errors.UNHANDLED;
+            }
         }
     } catch (_) { /* No body.errors[], continue */ }
     return null;

--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -1,0 +1,37 @@
+const {selectUserId, selectIsAdmin, selectIsSocial, selectIsLoggedIn} = require('./session');
+
+// Fine-grain selector helpers - not exported, use the higher level selectors below
+const isCreator = state => selectUserId(state) === state.studio.owner;
+const isCurator = state => state.studio.curator;
+const isManager = state => state.studio.manager || isCreator(state);
+
+// Action-based permissions selectors
+const selectCanEditInfo = state => selectIsAdmin(state) || isManager(state);
+const selectCanAddProjects = state =>
+    isManager(state) ||
+    isCurator(state) ||
+    (selectIsSocial(state) && state.studio.openToAll);
+
+// This isn't "canComment" since they could be muted, but comment composer handles that
+const selectShowCommentComposer = state => selectIsSocial(state);
+
+const selectCanReportComment = state => selectIsSocial(state);
+const selectCanRestoreComment = state => selectIsAdmin(state);
+// On the project page, project owners can delete comments with a confirmation,
+// and admins can delete comments without a confirmation. For now, only admins
+// can delete studio comments, so the following two are the same.
+const selectCanDeleteComment = state => selectIsAdmin(state);
+const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
+
+const selectCanFollowStudio = state => selectIsLoggedIn(state);
+
+export {
+    selectCanEditInfo,
+    selectCanAddProjects,
+    selectCanFollowStudio,
+    selectShowCommentComposer,
+    selectCanDeleteComment,
+    selectCanDeleteCommentWithoutConfirm,
+    selectCanReportComment,
+    selectCanRestoreComment
+};

--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -25,9 +25,9 @@ const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
 
 const selectCanFollowStudio = state => selectIsLoggedIn(state);
 
-// Matching existing behavior, only the creator is allowed to toggle comments.
+// Matching existing behavior, only admin/creator is allowed to toggle comments.
 const selectCanEditCommentsAllowed = state => selectIsAdmin(state) || isCreator(state);
-const selectCanEditOpenToAll = state => selectIsAdmin(state) || isManager(state);
+const selectCanEditOpenToAll = state => isManager(state);
 
 export {
     selectCanEditInfo,

--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -25,6 +25,10 @@ const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
 
 const selectCanFollowStudio = state => selectIsLoggedIn(state);
 
+// Matching existing behavior, only the creator is allowed to toggle comments.
+const selectCanEditCommentsAllowed = state => selectIsAdmin(state) || isCreator(state);
+const selectCanEditOpenToAll = state => selectIsAdmin(state) || isManager(state);
+
 export {
     selectCanEditInfo,
     selectCanAddProjects,
@@ -33,5 +37,7 @@ export {
     selectCanDeleteComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
-    selectCanRestoreComment
+    selectCanRestoreComment,
+    selectCanEditCommentsAllowed,
+    selectCanEditOpenToAll
 };

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -89,9 +89,9 @@ const selectStudioDescription = state => state.studio.description;
 const selectStudioImage = state => state.studio.image;
 const selectStudioOpenToAll = state => state.studio.openToAll;
 const selectStudioCommentsAllowed = state => state.studio.commentsAllowed;
-const selectIsLoadingInfo = state => state.studio.infoStatus === Status.FETCHING;
+const selectIsFetchingInfo = state => state.studio.infoStatus === Status.FETCHING;
 const selectIsFollowing = state => state.studio.following;
-const selectIsLoadingRoles = state => state.studio.rolesStatus === Status.FETCHING;
+const selectIsFetchingRoles = state => state.studio.rolesStatus === Status.FETCHING;
 
 // Thunks
 const getInfo = () => ((dispatch, getState) => {
@@ -157,7 +157,7 @@ module.exports = {
     selectStudioImage,
     selectStudioOpenToAll,
     selectStudioCommentsAllowed,
-    selectIsLoadingInfo,
-    selectIsLoadingRoles,
+    selectIsFetchingInfo,
+    selectIsFetchingRoles,
     selectIsFollowing
 };

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -3,10 +3,7 @@ const keyMirror = require('keymirror');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const {
-    selectUserId, selectIsAdmin, selectIsSocial, selectUsername, selectToken,
-    selectIsLoggedIn
-} = require('./session');
+const {selectUsername, selectToken} = require('./session');
 
 const Status = keyMirror({
     FETCHED: null,
@@ -68,7 +65,6 @@ const studioReducer = (state, action) => {
 };
 
 // Action Creators
-
 const setFetchStatus = (fetchType, fetchStatus, error) => ({
     type: 'SET_FETCH_STATUS',
     fetchType,
@@ -86,36 +82,12 @@ const setRoles = roles => ({
     roles: roles
 });
 
-// Selectors
-
-// Fine-grain selector helpers - not exported, use the higher level selectors below
-const isCreator = state => selectUserId(state) === state.studio.owner;
-const isCurator = state => state.studio.curator;
-const isManager = state => state.studio.manager || isCreator(state);
-
-// Action-based permissions selectors
-const selectCanEditInfo = state => selectIsAdmin(state) || isManager(state);
-const selectCanAddProjects = state =>
-    isManager(state) ||
-    isCurator(state) ||
-    (selectIsSocial(state) && state.studio.openToAll);
-
-const selectShowCommentComposer = state => selectIsSocial(state);
-const selectCanReportComment = state => selectIsSocial(state);
-const selectCanRestoreComment = state => selectIsAdmin(state);
-// On the project page, project owners can delete comments with a confirmation,
-// and admins can delete comments without a confirmation. For now, only admins
-// can delete studio comments, so the following two are the same.
-const selectCanDeleteComment = state => selectIsAdmin(state);
-const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
-
 // Data selectors
 const selectStudioId = state => state.studio.id;
 const selectStudioTitle = state => state.studio.title;
 const selectStudioDescription = state => state.studio.description;
 const selectIsLoadingInfo = state => state.studio.infoStatus === Status.FETCHING;
 const selectIsFollowing = state => state.studio.following;
-const selectCanFollowStudio = state => selectIsLoggedIn(state);
 const selectIsLoadingRoles = state => state.studio.rolesStatus === Status.FETCHING;
 
 // Thunks
@@ -180,13 +152,5 @@ module.exports = {
     selectStudioDescription,
     selectIsLoadingInfo,
     selectIsLoadingRoles,
-    selectIsFollowing,
-    selectCanEditInfo,
-    selectCanAddProjects,
-    selectShowCommentComposer,
-    selectCanDeleteComment,
-    selectCanDeleteCommentWithoutConfirm,
-    selectCanReportComment,
-    selectCanRestoreComment,
-    selectCanFollowStudio
+    selectIsFollowing
 };

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -3,7 +3,10 @@ const keyMirror = require('keymirror');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const {selectUserId, selectIsAdmin, selectIsSocial, selectUsername, selectToken} = require('./session');
+const {
+    selectUserId, selectIsAdmin, selectIsSocial, selectUsername, selectToken,
+    selectIsLoggedIn
+} = require('./session');
 
 const Status = keyMirror({
     FETCHED: null,
@@ -25,7 +28,7 @@ const getInitialState = () => ({
     rolesStatus: Status.NOT_FETCHED,
     manager: false,
     curator: false,
-    follower: false,
+    following: false,
     invited: false
 });
 
@@ -52,6 +55,12 @@ const studioReducer = (state, action) => {
         return {
             ...state,
             [action.fetchType]: action.fetchStatus
+        };
+    case 'COMPLETE_STUDIO_MUTATION':
+        if (typeof state[action.field] === 'undefined') return state;
+        return {
+            ...state,
+            [action.field]: action.value
         };
     default:
         return state;
@@ -102,7 +111,12 @@ const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
 
 // Data selectors
 const selectStudioId = state => state.studio.id;
-
+const selectStudioTitle = state => state.studio.title;
+const selectStudioDescription = state => state.studio.description;
+const selectIsLoadingInfo = state => state.studio.infoStatus === Status.FETCHING;
+const selectIsFollowing = state => state.studio.following;
+const selectCanFollowStudio = state => selectIsLoggedIn(state);
+const selectIsLoadingRoles = state => state.studio.rolesStatus === Status.FETCHING;
 
 // Thunks
 const getInfo = () => ((dispatch, getState) => {
@@ -158,14 +172,21 @@ module.exports = {
     // Thunks
     getInfo,
     getRoles,
+    setInfo,
 
     // Selectors
     selectStudioId,
+    selectStudioTitle,
+    selectStudioDescription,
+    selectIsLoadingInfo,
+    selectIsLoadingRoles,
+    selectIsFollowing,
     selectCanEditInfo,
     selectCanAddProjects,
     selectShowCommentComposer,
     selectCanDeleteComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
-    selectCanRestoreComment
+    selectCanRestoreComment,
+    selectCanFollowStudio
 };

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -18,7 +18,7 @@ const getInitialState = () => ({
     description: '',
     openToAll: false,
     commentingAllowed: false,
-    thumbnail: '',
+    image: '',
     followers: 0,
     owner: null,
 
@@ -86,6 +86,7 @@ const setRoles = roles => ({
 const selectStudioId = state => state.studio.id;
 const selectStudioTitle = state => state.studio.title;
 const selectStudioDescription = state => state.studio.description;
+const selectStudioImage = state => state.studio.image;
 const selectIsLoadingInfo = state => state.studio.infoStatus === Status.FETCHING;
 const selectIsFollowing = state => state.studio.following;
 const selectIsLoadingRoles = state => state.studio.rolesStatus === Status.FETCHING;
@@ -103,6 +104,7 @@ const getInfo = () => ((dispatch, getState) => {
         dispatch(setInfo({
             title: body.title,
             description: body.description,
+            image: body.image,
             openToAll: body.open_to_all,
             commentingAllowed: body.commenting_allowed,
             updated: new Date(body.history.modified),
@@ -150,6 +152,7 @@ module.exports = {
     selectStudioId,
     selectStudioTitle,
     selectStudioDescription,
+    selectStudioImage,
     selectIsLoadingInfo,
     selectIsLoadingRoles,
     selectIsFollowing

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -17,7 +17,7 @@ const getInitialState = () => ({
     title: '',
     description: '',
     openToAll: false,
-    commentingAllowed: false,
+    commentsAllowed: false,
     image: '',
     followers: 0,
     owner: null,
@@ -87,6 +87,8 @@ const selectStudioId = state => state.studio.id;
 const selectStudioTitle = state => state.studio.title;
 const selectStudioDescription = state => state.studio.description;
 const selectStudioImage = state => state.studio.image;
+const selectStudioOpenToAll = state => state.studio.openToAll;
+const selectStudioCommentsAllowed = state => state.studio.commentsAllowed;
 const selectIsLoadingInfo = state => state.studio.infoStatus === Status.FETCHING;
 const selectIsFollowing = state => state.studio.following;
 const selectIsLoadingRoles = state => state.studio.rolesStatus === Status.FETCHING;
@@ -106,7 +108,7 @@ const getInfo = () => ((dispatch, getState) => {
             description: body.description,
             image: body.image,
             openToAll: body.open_to_all,
-            commentingAllowed: body.commenting_allowed,
+            commentsAllowed: body.comments_allowed,
             updated: new Date(body.history.modified),
             followers: body.stats.followers,
             owner: body.owner
@@ -153,6 +155,8 @@ module.exports = {
     selectStudioTitle,
     selectStudioDescription,
     selectStudioImage,
+    selectStudioOpenToAll,
+    selectStudioCommentsAllowed,
     selectIsLoadingInfo,
     selectIsLoadingRoles,
     selectIsFollowing

--- a/src/views/studio/studio-comments-allowed.jsx
+++ b/src/views/studio/studio-comments-allowed.jsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {selectStudioCommentsAllowed, selectIsLoadingInfo} from '../../redux/studio';
-import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {
     mutateStudioCommentsAllowed, selectIsMutatingCommentsAllowed, selectCommentsAllowedMutationError
 } from '../../redux/studio-mutations';
 
 const StudioCommentsAllowed = ({
-    commentsAllowedError, isLoading, isMutating, commentsAllowed, canEditInfo, handleUpdate
+    commentsAllowedError, isLoading, isMutating, commentsAllowed, handleUpdate
 }) => (
     <div>
         {isLoading ? (
@@ -19,12 +18,12 @@ const StudioCommentsAllowed = ({
             <div>
                 <label>
                     <input
-                        disabled={isMutating || !canEditInfo}
+                        disabled={isMutating}
                         type="checkbox"
                         checked={commentsAllowed}
                         onChange={e => handleUpdate(e.target.checked)}
                     />
-                    <h4>{commentsAllowed ? 'Comments allowed' : 'Comments not allowed'}</h4>
+                    <span>{commentsAllowed ? 'Comments allowed' : 'Comments not allowed'}</span>
                     {commentsAllowedError && <div>Error mutating commentsAllowed: {commentsAllowedError}</div>}
                 </label>
             </div>
@@ -34,7 +33,6 @@ const StudioCommentsAllowed = ({
 
 StudioCommentsAllowed.propTypes = {
     commentsAllowedError: PropTypes.string,
-    canEditInfo: PropTypes.bool,
     isLoading: PropTypes.bool,
     isMutating: PropTypes.bool,
     commentsAllowed: PropTypes.bool,
@@ -44,7 +42,6 @@ StudioCommentsAllowed.propTypes = {
 export default connect(
     state => ({
         commentsAllowed: selectStudioCommentsAllowed(state),
-        canEditInfo: selectCanEditInfo(state),
         isLoading: selectIsLoadingInfo(state),
         isMutating: selectIsMutatingCommentsAllowed(state),
         commentsAllowedError: selectCommentsAllowedMutationError(state)

--- a/src/views/studio/studio-comments-allowed.jsx
+++ b/src/views/studio/studio-comments-allowed.jsx
@@ -37,7 +37,7 @@ StudioCommentsAllowed.propTypes = {
     canEditInfo: PropTypes.bool,
     isLoading: PropTypes.bool,
     isMutating: PropTypes.bool,
-    commentsAllowed: PropTypes.string,
+    commentsAllowed: PropTypes.bool,
     handleUpdate: PropTypes.func
 };
 

--- a/src/views/studio/studio-comments-allowed.jsx
+++ b/src/views/studio/studio-comments-allowed.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectStudioCommentsAllowed, selectIsLoadingInfo} from '../../redux/studio';
+import {selectCanEditInfo} from '../../redux/studio-permissions';
+import {
+    mutateStudioCommentsAllowed, selectIsMutatingCommentsAllowed, selectCommentsAllowedMutationError
+} from '../../redux/studio-mutations';
+
+const StudioCommentsAllowed = ({
+    commentsAllowedError, isLoading, isMutating, commentsAllowed, canEditInfo, handleUpdate
+}) => (
+    <div>
+        {isLoading ? (
+            <h4>Loading...</h4>
+        ) : (
+            <div>
+                <label>
+                    <input
+                        disabled={isMutating || !canEditInfo}
+                        type="checkbox"
+                        checked={commentsAllowed}
+                        onChange={e => handleUpdate(e.target.checked)}
+                    />
+                    <h4>{commentsAllowed ? 'Comments allowed' : 'Comments not allowed'}</h4>
+                    {commentsAllowedError && <div>Error mutating commentsAllowed: {commentsAllowedError}</div>}
+                </label>
+            </div>
+        )}
+    </div>
+);
+
+StudioCommentsAllowed.propTypes = {
+    commentsAllowedError: PropTypes.string,
+    canEditInfo: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    commentsAllowed: PropTypes.string,
+    handleUpdate: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        commentsAllowed: selectStudioCommentsAllowed(state),
+        canEditInfo: selectCanEditInfo(state),
+        isLoading: selectIsLoadingInfo(state),
+        isMutating: selectIsMutatingCommentsAllowed(state),
+        commentsAllowedError: selectCommentsAllowedMutationError(state)
+    }),
+    {
+        handleUpdate: mutateStudioCommentsAllowed
+    }
+)(StudioCommentsAllowed);

--- a/src/views/studio/studio-comments-allowed.jsx
+++ b/src/views/studio/studio-comments-allowed.jsx
@@ -3,17 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioCommentsAllowed, selectIsLoadingInfo} from '../../redux/studio';
+import {selectStudioCommentsAllowed, selectIsFetchingInfo} from '../../redux/studio';
 import {
     mutateStudioCommentsAllowed, selectIsMutatingCommentsAllowed, selectCommentsAllowedMutationError
 } from '../../redux/studio-mutations';
 
 const StudioCommentsAllowed = ({
-    commentsAllowedError, isLoading, isMutating, commentsAllowed, handleUpdate
+    commentsAllowedError, isFetching, isMutating, commentsAllowed, handleUpdate
 }) => (
     <div>
-        {isLoading ? (
-            <h4>Loading...</h4>
+        {isFetching ? (
+            <h4>Fetching...</h4>
         ) : (
             <div>
                 <label>
@@ -33,7 +33,7 @@ const StudioCommentsAllowed = ({
 
 StudioCommentsAllowed.propTypes = {
     commentsAllowedError: PropTypes.string,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isMutating: PropTypes.bool,
     commentsAllowed: PropTypes.bool,
     handleUpdate: PropTypes.func
@@ -42,7 +42,7 @@ StudioCommentsAllowed.propTypes = {
 export default connect(
     state => ({
         commentsAllowed: selectStudioCommentsAllowed(state),
-        isLoading: selectIsLoadingInfo(state),
+        isFetching: selectIsFetchingInfo(state),
         isMutating: selectIsMutatingCommentsAllowed(state),
         commentsAllowedError: selectCommentsAllowedMutationError(state)
     }),

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -7,6 +7,7 @@ import Button from '../../components/forms/button.jsx';
 import ComposeComment from '../preview/comment/compose-comment.jsx';
 import TopLevelComment from '../preview/comment/top-level-comment.jsx';
 import studioCommentActions from '../../redux/studio-comment-actions.js';
+import StudioCommentsAllowed from './studio-comments-allowed.jsx';
 
 import {
     selectShowCommentComposer,
@@ -40,6 +41,7 @@ const StudioComments = ({
     return (
         <div>
             <h2>Comments</h2>
+            <StudioCommentsAllowed />
             <div>
                 {shouldShowCommentComposer &&
                     <ComposeComment

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -14,7 +14,7 @@ import {
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
     selectCanRestoreComment
-} from '../../redux/studio.js';
+} from '../../redux/studio-permissions';
 
 const StudioComments = ({
     comments,

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -14,11 +14,14 @@ import {
     selectCanDeleteComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
-    selectCanRestoreComment
+    selectCanRestoreComment,
+    selectCanEditCommentsAllowed
 } from '../../redux/studio-permissions';
+import {selectStudioCommentsAllowed} from '../../redux/studio.js';
 
 const StudioComments = ({
     comments,
+    commentsAllowed,
     handleLoadMoreComments,
     handleNewComment,
     moreCommentsToLoad,
@@ -27,6 +30,7 @@ const StudioComments = ({
     shouldShowCommentComposer,
     canDeleteComment,
     canDeleteCommentWithoutConfirm,
+    canEditCommentsAllowed,
     canReportComment,
     canRestoreComment,
     handleDeleteComment,
@@ -41,9 +45,9 @@ const StudioComments = ({
     return (
         <div>
             <h2>Comments</h2>
-            <StudioCommentsAllowed />
+            {canEditCommentsAllowed && <StudioCommentsAllowed />}
             <div>
-                {shouldShowCommentComposer &&
+                {shouldShowCommentComposer && commentsAllowed &&
                     <ComposeComment
                         postURI={postURI}
                         onAddComment={handleNewComment}
@@ -88,6 +92,7 @@ const StudioComments = ({
 
 StudioComments.propTypes = {
     comments: PropTypes.arrayOf(PropTypes.shape({})),
+    commentsAllowed: PropTypes.bool,
     handleLoadMoreComments: PropTypes.func,
     handleNewComment: PropTypes.func,
     moreCommentsToLoad: PropTypes.bool,
@@ -95,6 +100,7 @@ StudioComments.propTypes = {
     shouldShowCommentComposer: PropTypes.bool,
     canDeleteComment: PropTypes.bool,
     canDeleteCommentWithoutConfirm: PropTypes.bool,
+    canEditCommentsAllowed: PropTypes.bool,
     canReportComment: PropTypes.bool,
     canRestoreComment: PropTypes.bool,
     handleDeleteComment: PropTypes.func,
@@ -109,9 +115,11 @@ export default connect(
         comments: state.comments.comments,
         moreCommentsToLoad: state.comments.moreCommentsToLoad,
         replies: state.comments.replies,
+        commentsAllowed: selectStudioCommentsAllowed(state),
         shouldShowCommentComposer: selectShowCommentComposer(state),
         canDeleteComment: selectCanDeleteComment(state),
         canDeleteCommentWithoutConfirm: selectCanDeleteCommentWithoutConfirm(state),
+        canEditCommentsAllowed: selectCanEditCommentsAllowed(state),
         canReportComment: selectCanReportComment(state),
         canRestoreComment: selectCanRestoreComment(state),
         postURI: `/proxy/comments/studio/${state.studio.id}`

--- a/src/views/studio/studio-description.jsx
+++ b/src/views/studio/studio-description.jsx
@@ -1,0 +1,56 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectStudioDescription, selectIsLoadingInfo, selectCanEditInfo} from '../../redux/studio';
+import {
+    mutateStudioDescription, selectIsMutatingDescription, selectDescriptionMutationError
+} from '../../redux/studio-mutations';
+
+const StudioDescription = ({
+    descriptionError, isLoading, isMutating, description, canEditInfo, handleUpdate
+}) => (
+    <div>
+        <h3>Description</h3>
+        {isLoading ? (
+            <h4>Loading...</h4>
+        ) : (canEditInfo ? (
+            <label>
+                <textarea
+                    rows="5"
+                    cols="100"
+                    disabled={isMutating}
+                    defaultValue={description}
+                    onBlur={e => e.target.value !== description &&
+                        handleUpdate(e.target.value)}
+                />
+                {descriptionError && <div>Error mutating description: {descriptionError}</div>}
+            </label>
+        ) : (
+            <div>{description}</div>
+        ))}
+    </div>
+);
+
+StudioDescription.propTypes = {
+    descriptionError: PropTypes.string,
+    canEditInfo: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    description: PropTypes.string,
+    handleUpdate: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        description: selectStudioDescription(state),
+        canEditInfo: selectCanEditInfo(state),
+        isLoading: selectIsLoadingInfo(state),
+        isMutating: selectIsMutatingDescription(state),
+        descriptionError: selectDescriptionMutationError(state)
+    }),
+    {
+        handleUpdate: mutateStudioDescription
+    }
+)(StudioDescription);

--- a/src/views/studio/studio-description.jsx
+++ b/src/views/studio/studio-description.jsx
@@ -3,19 +3,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioDescription, selectIsLoadingInfo} from '../../redux/studio';
+import {selectStudioDescription, selectIsFetchingInfo} from '../../redux/studio';
 import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {
     mutateStudioDescription, selectIsMutatingDescription, selectDescriptionMutationError
 } from '../../redux/studio-mutations';
 
 const StudioDescription = ({
-    descriptionError, isLoading, isMutating, description, canEditInfo, handleUpdate
+    descriptionError, isFetching, isMutating, description, canEditInfo, handleUpdate
 }) => (
     <div>
         <h3>Description</h3>
-        {isLoading ? (
-            <h4>Loading...</h4>
+        {isFetching ? (
+            <h4>Fetching...</h4>
         ) : (canEditInfo ? (
             <label>
                 <textarea
@@ -37,7 +37,7 @@ const StudioDescription = ({
 StudioDescription.propTypes = {
     descriptionError: PropTypes.string,
     canEditInfo: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isMutating: PropTypes.bool,
     description: PropTypes.string,
     handleUpdate: PropTypes.func
@@ -47,7 +47,7 @@ export default connect(
     state => ({
         description: selectStudioDescription(state),
         canEditInfo: selectCanEditInfo(state),
-        isLoading: selectIsLoadingInfo(state),
+        isFetching: selectIsFetchingInfo(state),
         isMutating: selectIsMutatingDescription(state),
         descriptionError: selectDescriptionMutationError(state)
     }),

--- a/src/views/studio/studio-description.jsx
+++ b/src/views/studio/studio-description.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioDescription, selectIsLoadingInfo, selectCanEditInfo} from '../../redux/studio';
+import {selectStudioDescription, selectIsLoadingInfo} from '../../redux/studio';
+import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {
     mutateStudioDescription, selectIsMutatingDescription, selectDescriptionMutationError
 } from '../../redux/studio-mutations';

--- a/src/views/studio/studio-follow.jsx
+++ b/src/views/studio/studio-follow.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {selectIsFollowing, selectIsLoadingRoles} from '../../redux/studio';
+import {selectIsFollowing, selectIsFetchingRoles} from '../../redux/studio';
 import {selectCanFollowStudio} from '../../redux/studio-permissions';
 import {
     mutateFollowingStudio, selectIsMutatingFollowing, selectFollowingMutationError
@@ -11,7 +11,7 @@ import {
 
 const StudioFollow = ({
     canFollow,
-    isLoading,
+    isFetching,
     isFollowing,
     isMutating,
     followingError,
@@ -21,11 +21,11 @@ const StudioFollow = ({
         <h3>Following</h3>
         <div>
             <button
-                disabled={isLoading || isMutating || !canFollow}
+                disabled={isFetching || isMutating || !canFollow}
                 onClick={() => handleFollow(!isFollowing)}
             >
-                {isLoading ? (
-                    'Loading...'
+                {isFetching ? (
+                    'Fetching...'
                 ) : (
                     isFollowing ? 'Unfollow' : 'Follow'
                 )}
@@ -38,7 +38,7 @@ const StudioFollow = ({
 
 StudioFollow.propTypes = {
     canFollow: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isFollowing: PropTypes.bool,
     isMutating: PropTypes.bool,
     followingError: PropTypes.string,
@@ -48,7 +48,7 @@ StudioFollow.propTypes = {
 export default connect(
     state => ({
         canFollow: selectCanFollowStudio(state),
-        isLoading: selectIsLoadingRoles(state),
+        isFetching: selectIsFetchingRoles(state),
         isMutating: selectIsMutatingFollowing(state),
         isFollowing: selectIsFollowing(state),
         followingError: selectFollowingMutationError(state)

--- a/src/views/studio/studio-follow.jsx
+++ b/src/views/studio/studio-follow.jsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-
-import {selectIsFollowing, selectCanFollowStudio, selectIsLoadingRoles} from '../../redux/studio';
+import {selectIsFollowing, selectIsLoadingRoles} from '../../redux/studio';
+import {selectCanFollowStudio} from '../../redux/studio-permissions';
 import {
     mutateFollowingStudio, selectIsMutatingFollowing, selectFollowingMutationError
 } from '../../redux/studio-mutations';

--- a/src/views/studio/studio-follow.jsx
+++ b/src/views/studio/studio-follow.jsx
@@ -1,0 +1,59 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectIsFollowing, selectCanFollowStudio, selectIsLoadingRoles} from '../../redux/studio';
+import {
+    mutateFollowingStudio, selectIsMutatingFollowing, selectFollowingMutationError
+} from '../../redux/studio-mutations';
+
+
+const StudioFollow = ({
+    canFollow,
+    isLoading,
+    isFollowing,
+    isMutating,
+    followingError,
+    handleFollow
+}) => (
+    <div>
+        <h3>Following</h3>
+        <div>
+            <button
+                disabled={isLoading || isMutating || !canFollow}
+                onClick={() => handleFollow(!isFollowing)}
+            >
+                {isLoading ? (
+                    'Loading...'
+                ) : (
+                    isFollowing ? 'Unfollow' : 'Follow'
+                )}
+            </button>
+            {followingError && <div>Error mutating following: {followingError}</div>}
+            {!canFollow && <div>Must be logged in to follow</div>}
+        </div>
+    </div>
+);
+
+StudioFollow.propTypes = {
+    canFollow: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isFollowing: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    followingError: PropTypes.string,
+    handleFollow: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        canFollow: selectCanFollowStudio(state),
+        isLoading: selectIsLoadingRoles(state),
+        isMutating: selectIsMutatingFollowing(state),
+        isFollowing: selectIsFollowing(state),
+        followingError: selectFollowingMutationError(state)
+    }),
+    {
+        handleFollow: mutateFollowingStudio
+    }
+)(StudioFollow);

--- a/src/views/studio/studio-image.jsx
+++ b/src/views/studio/studio-image.jsx
@@ -1,0 +1,69 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectStudioImage, selectIsLoadingInfo} from '../../redux/studio';
+import {selectCanEditInfo} from '../../redux/studio-permissions';
+import {
+    mutateStudioImage, selectIsMutatingImage, selectImageMutationError
+} from '../../redux/studio-mutations';
+import Spinner from '../../components/spinner/spinner.jsx';
+
+const StudioImage = ({
+    imageError, isLoading, isMutating, image, canEditInfo, handleUpdate
+}) => (
+    <div>
+        <h3>Image</h3>
+        {isLoading ? (
+            <h4>Loading...</h4>
+        ) : (
+            <div>
+                <div style={{width: '200px', height: '150px', border: '1px solid green'}}>
+                    {isMutating ?
+                        <Spinner color="blue" /> :
+                        <img
+                            style={{objectFit: 'contain'}}
+                            src={image}
+                        />}
+                </div>
+                {canEditInfo &&
+                    <label>
+                        <input
+                            disabled={isMutating}
+                            type="file"
+                            accept="image/*"
+                            onChange={e => {
+                                handleUpdate(e.target);
+                                e.target.value = '';
+                            }}
+                        />
+                        {imageError && <div>Error mutating image: {imageError}</div>}
+                    </label>
+                }
+            </div>
+        )}
+    </div>
+);
+
+StudioImage.propTypes = {
+    imageError: PropTypes.string,
+    canEditInfo: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    image: PropTypes.string,
+    handleUpdate: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        image: selectStudioImage(state),
+        canEditInfo: selectCanEditInfo(state),
+        isLoading: selectIsLoadingInfo(state),
+        isMutating: selectIsMutatingImage(state),
+        imageError: selectImageMutationError(state)
+    }),
+    {
+        handleUpdate: mutateStudioImage
+    }
+)(StudioImage);

--- a/src/views/studio/studio-image.jsx
+++ b/src/views/studio/studio-image.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioImage, selectIsLoadingInfo} from '../../redux/studio';
+import {selectStudioImage, selectIsFetchingInfo} from '../../redux/studio';
 import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {
     mutateStudioImage, selectIsMutatingImage, selectImageMutationError
@@ -11,12 +11,12 @@ import {
 import Spinner from '../../components/spinner/spinner.jsx';
 
 const StudioImage = ({
-    imageError, isLoading, isMutating, image, canEditInfo, handleUpdate
+    imageError, isFetching, isMutating, image, canEditInfo, handleUpdate
 }) => (
     <div>
         <h3>Image</h3>
-        {isLoading ? (
-            <h4>Loading...</h4>
+        {isFetching ? (
+            <h4>Fetching...</h4>
         ) : (
             <div>
                 <div style={{width: '200px', height: '150px', border: '1px solid green'}}>
@@ -49,7 +49,7 @@ const StudioImage = ({
 StudioImage.propTypes = {
     imageError: PropTypes.string,
     canEditInfo: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isMutating: PropTypes.bool,
     image: PropTypes.string,
     handleUpdate: PropTypes.func
@@ -59,7 +59,7 @@ export default connect(
     state => ({
         image: selectStudioImage(state),
         canEditInfo: selectCanEditInfo(state),
-        isLoading: selectIsLoadingInfo(state),
+        isFetching: selectIsFetchingInfo(state),
         isMutating: selectIsMutatingImage(state),
         imageError: selectImageMutationError(state)
     }),

--- a/src/views/studio/studio-info.jsx
+++ b/src/views/studio/studio-info.jsx
@@ -2,11 +2,16 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import Debug from './debug.jsx';
+import StudioDescription from './studio-description.jsx';
+import StudioFollow from './studio-follow.jsx';
+import StudioTitle from './studio-title.jsx';
 
 import {selectIsLoggedIn} from '../../redux/session';
-import {getInfo, getRoles, selectCanEditInfo} from '../../redux/studio';
+import {getInfo, getRoles} from '../../redux/studio';
 
-const StudioInfo = ({isLoggedIn, studio, canEditInfo, onLoadInfo, onLoadRoles}) => {
+const StudioInfo = ({
+    isLoggedIn, studio, onLoadInfo, onLoadRoles
+}) => {
     useEffect(() => { // Load studio info after first render
         onLoadInfo();
     }, []);
@@ -18,23 +23,22 @@ const StudioInfo = ({isLoggedIn, studio, canEditInfo, onLoadInfo, onLoadRoles}) 
     return (
         <div>
             <h2>Studio Info</h2>
+            <StudioTitle />
+            <StudioDescription />
+            <StudioFollow />
             <Debug
                 label="Studio Info"
                 data={studio}
-            />
-            <Debug
-                label="Studio Info Permissions"
-                data={{canEditInfo}}
             />
         </div>
     );
 };
 
 StudioInfo.propTypes = {
-    canEditInfo: PropTypes.bool,
     isLoggedIn: PropTypes.bool,
     studio: PropTypes.shape({
-        // Fill this in as the data is used, just for demo now
+        title: PropTypes.string,
+        description: PropTypes.description
     }),
     onLoadInfo: PropTypes.func,
     onLoadRoles: PropTypes.func
@@ -43,8 +47,7 @@ StudioInfo.propTypes = {
 export default connect(
     state => ({
         studio: state.studio,
-        isLoggedIn: selectIsLoggedIn(state),
-        canEditInfo: selectCanEditInfo(state)
+        isLoggedIn: selectIsLoggedIn(state)
     }),
     {
         onLoadInfo: getInfo,

--- a/src/views/studio/studio-info.jsx
+++ b/src/views/studio/studio-info.jsx
@@ -5,6 +5,7 @@ import Debug from './debug.jsx';
 import StudioDescription from './studio-description.jsx';
 import StudioFollow from './studio-follow.jsx';
 import StudioTitle from './studio-title.jsx';
+import StudioImage from './studio-image.jsx';
 
 import {selectIsLoggedIn} from '../../redux/session';
 import {getInfo, getRoles} from '../../redux/studio';
@@ -26,6 +27,7 @@ const StudioInfo = ({
             <StudioTitle />
             <StudioDescription />
             <StudioFollow />
+            <StudioImage />
             <Debug
                 label="Studio Info"
                 data={studio}

--- a/src/views/studio/studio-info.jsx
+++ b/src/views/studio/studio-info.jsx
@@ -36,10 +36,7 @@ const StudioInfo = ({
 
 StudioInfo.propTypes = {
     isLoggedIn: PropTypes.bool,
-    studio: PropTypes.shape({
-        title: PropTypes.string,
-        description: PropTypes.description
-    }),
+    studio: PropTypes.shape({}), // TODO remove, just for <Debug />
     onLoadInfo: PropTypes.func,
     onLoadRoles: PropTypes.func
 };

--- a/src/views/studio/studio-open-to-all.jsx
+++ b/src/views/studio/studio-open-to-all.jsx
@@ -37,7 +37,7 @@ StudioOpenToAll.propTypes = {
     canEditInfo: PropTypes.bool,
     isLoading: PropTypes.bool,
     isMutating: PropTypes.bool,
-    openToAll: PropTypes.string,
+    openToAll: PropTypes.bool,
     handleUpdate: PropTypes.func
 };
 

--- a/src/views/studio/studio-open-to-all.jsx
+++ b/src/views/studio/studio-open-to-all.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectStudioOpenToAll, selectIsLoadingInfo} from '../../redux/studio';
+import {selectCanEditInfo} from '../../redux/studio-permissions';
+import {
+    mutateStudioOpenToAll, selectIsMutatingOpenToAll, selectOpenToAllMutationError
+} from '../../redux/studio-mutations';
+
+const StudioOpenToAll = ({
+    openToAllError, isLoading, isMutating, openToAll, canEditInfo, handleUpdate
+}) => (
+    <div>
+        {isLoading ? (
+            <h4>Loading...</h4>
+        ) : (
+            <div>
+                <label>
+                    <input
+                        disabled={isMutating || !canEditInfo}
+                        type="checkbox"
+                        checked={openToAll}
+                        onChange={e => handleUpdate(e.target.checked)}
+                    />
+                    <h4>{openToAll ? 'Open to all' : 'Not open to all'}</h4>
+                    {openToAllError && <div>Error mutating openToAll: {openToAllError}</div>}
+                </label>
+            </div>
+        )}
+    </div>
+);
+
+StudioOpenToAll.propTypes = {
+    openToAllError: PropTypes.string,
+    canEditInfo: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    openToAll: PropTypes.string,
+    handleUpdate: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        openToAll: selectStudioOpenToAll(state),
+        canEditInfo: selectCanEditInfo(state),
+        isLoading: selectIsLoadingInfo(state),
+        isMutating: selectIsMutatingOpenToAll(state),
+        openToAllError: selectOpenToAllMutationError(state)
+    }),
+    {
+        handleUpdate: mutateStudioOpenToAll
+    }
+)(StudioOpenToAll);

--- a/src/views/studio/studio-open-to-all.jsx
+++ b/src/views/studio/studio-open-to-all.jsx
@@ -3,17 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioOpenToAll, selectIsLoadingInfo} from '../../redux/studio';
+import {selectStudioOpenToAll, selectIsFetchingInfo} from '../../redux/studio';
 import {
     mutateStudioOpenToAll, selectIsMutatingOpenToAll, selectOpenToAllMutationError
 } from '../../redux/studio-mutations';
 
 const StudioOpenToAll = ({
-    openToAllError, isLoading, isMutating, openToAll, handleUpdate
+    openToAllError, isFetching, isMutating, openToAll, handleUpdate
 }) => (
     <div>
-        {isLoading ? (
-            <h4>Loading...</h4>
+        {isFetching ? (
+            <h4>Fetching...</h4>
         ) : (
             <div>
                 <label>
@@ -33,7 +33,7 @@ const StudioOpenToAll = ({
 
 StudioOpenToAll.propTypes = {
     openToAllError: PropTypes.string,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isMutating: PropTypes.bool,
     openToAll: PropTypes.bool,
     handleUpdate: PropTypes.func
@@ -42,7 +42,7 @@ StudioOpenToAll.propTypes = {
 export default connect(
     state => ({
         openToAll: selectStudioOpenToAll(state),
-        isLoading: selectIsLoadingInfo(state),
+        isFetching: selectIsFetchingInfo(state),
         isMutating: selectIsMutatingOpenToAll(state),
         openToAllError: selectOpenToAllMutationError(state)
     }),

--- a/src/views/studio/studio-open-to-all.jsx
+++ b/src/views/studio/studio-open-to-all.jsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
 import {selectStudioOpenToAll, selectIsLoadingInfo} from '../../redux/studio';
-import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {
     mutateStudioOpenToAll, selectIsMutatingOpenToAll, selectOpenToAllMutationError
 } from '../../redux/studio-mutations';
 
 const StudioOpenToAll = ({
-    openToAllError, isLoading, isMutating, openToAll, canEditInfo, handleUpdate
+    openToAllError, isLoading, isMutating, openToAll, handleUpdate
 }) => (
     <div>
         {isLoading ? (
@@ -19,12 +18,12 @@ const StudioOpenToAll = ({
             <div>
                 <label>
                     <input
-                        disabled={isMutating || !canEditInfo}
+                        disabled={isMutating}
                         type="checkbox"
                         checked={openToAll}
                         onChange={e => handleUpdate(e.target.checked)}
                     />
-                    <h4>{openToAll ? 'Open to all' : 'Not open to all'}</h4>
+                    <span>{openToAll ? 'Open to all' : 'Not open to all'}</span>
                     {openToAllError && <div>Error mutating openToAll: {openToAllError}</div>}
                 </label>
             </div>
@@ -34,7 +33,6 @@ const StudioOpenToAll = ({
 
 StudioOpenToAll.propTypes = {
     openToAllError: PropTypes.string,
-    canEditInfo: PropTypes.bool,
     isLoading: PropTypes.bool,
     isMutating: PropTypes.bool,
     openToAll: PropTypes.bool,
@@ -44,7 +42,6 @@ StudioOpenToAll.propTypes = {
 export default connect(
     state => ({
         openToAll: selectStudioOpenToAll(state),
-        canEditInfo: selectCanEditInfo(state),
         isLoading: selectIsLoadingInfo(state),
         isMutating: selectIsMutatingOpenToAll(state),
         openToAllError: selectOpenToAllMutationError(state)

--- a/src/views/studio/studio-projects.jsx
+++ b/src/views/studio/studio-projects.jsx
@@ -2,6 +2,7 @@ import React, {useEffect, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import {useParams} from 'react-router-dom';
 import {connect} from 'react-redux';
+import StudioOpenToAll from './studio-open-to-all.jsx';
 
 import {projectFetcher} from './lib/fetchers';
 import {projects} from './lib/redux-modules';
@@ -24,6 +25,7 @@ const StudioProjects = ({
     return (
         <div>
             <h2>Projects</h2>
+            <StudioOpenToAll />
             {error && <Debug
                 label="Error"
                 data={error}

--- a/src/views/studio/studio-projects.jsx
+++ b/src/views/studio/studio-projects.jsx
@@ -5,10 +5,10 @@ import {connect} from 'react-redux';
 
 import {projectFetcher} from './lib/fetchers';
 import {projects} from './lib/redux-modules';
+import {selectCanAddProjects} from '../../redux/studio-permissions';
 import Debug from './debug.jsx';
 
 const {actions, selector: projectsSelector} = projects;
-import {selectCanAddProjects} from '../../redux/studio';
 
 const StudioProjects = ({
     canAddProjects, items, error, loading, moreToLoad, onLoadMore

--- a/src/views/studio/studio-projects.jsx
+++ b/src/views/studio/studio-projects.jsx
@@ -6,13 +6,13 @@ import StudioOpenToAll from './studio-open-to-all.jsx';
 
 import {projectFetcher} from './lib/fetchers';
 import {projects} from './lib/redux-modules';
-import {selectCanAddProjects} from '../../redux/studio-permissions';
+import {selectCanAddProjects, selectCanEditOpenToAll} from '../../redux/studio-permissions';
 import Debug from './debug.jsx';
 
 const {actions, selector: projectsSelector} = projects;
 
 const StudioProjects = ({
-    canAddProjects, items, error, loading, moreToLoad, onLoadMore
+    canAddProjects, canEditOpenToAll, items, error, loading, moreToLoad, onLoadMore
 }) => {
     const {studioId} = useParams();
 
@@ -25,7 +25,7 @@ const StudioProjects = ({
     return (
         <div>
             <h2>Projects</h2>
-            <StudioOpenToAll />
+            {canEditOpenToAll && <StudioOpenToAll />}
             {error && <Debug
                 label="Error"
                 data={error}
@@ -56,6 +56,7 @@ const StudioProjects = ({
 
 StudioProjects.propTypes = {
     canAddProjects: PropTypes.bool,
+    canEditOpenToAll: PropTypes.bool,
     items: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     loading: PropTypes.bool,
     error: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -65,7 +66,8 @@ StudioProjects.propTypes = {
 
 const mapStateToProps = state => ({
     ...projectsSelector(state),
-    canAddProjects: selectCanAddProjects(state)
+    canAddProjects: selectCanAddProjects(state),
+    canEditOpenToAll: selectCanEditOpenToAll(state)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/views/studio/studio-title.jsx
+++ b/src/views/studio/studio-title.jsx
@@ -1,0 +1,52 @@
+/* eslint-disable react/jsx-no-bind */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+import {selectStudioTitle, selectIsLoadingInfo, selectCanEditInfo} from '../../redux/studio';
+import {mutateStudioTitle, selectIsMutatingTitle, selectTitleMutationError} from '../../redux/studio-mutations';
+
+const StudioTitle = ({
+    titleError, isLoading, isMutating, title, canEditInfo, handleUpdate
+}) => (
+    <div>
+        <h3>Title</h3>
+        {isLoading ? (
+            <h4>Loading...</h4>
+        ) : (canEditInfo ? (
+            <label>
+                <input
+                    disabled={isMutating}
+                    defaultValue={title}
+                    onBlur={e => e.target.value !== title &&
+                        handleUpdate(e.target.value)}
+                />
+                {titleError && <div>Error mutating title: {titleError}</div>}
+            </label>
+        ) : (
+            <div>{title}</div>
+        ))}
+    </div>
+);
+
+StudioTitle.propTypes = {
+    titleError: PropTypes.string,
+    canEditInfo: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isMutating: PropTypes.bool,
+    title: PropTypes.string,
+    handleUpdate: PropTypes.func
+};
+
+export default connect(
+    state => ({
+        title: selectStudioTitle(state),
+        canEditInfo: selectCanEditInfo(state),
+        isLoading: selectIsLoadingInfo(state),
+        isMutating: selectIsMutatingTitle(state),
+        titleError: selectTitleMutationError(state)
+    }),
+    {
+        handleUpdate: mutateStudioTitle
+    }
+)(StudioTitle);

--- a/src/views/studio/studio-title.jsx
+++ b/src/views/studio/studio-title.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioTitle, selectIsLoadingInfo, selectCanEditInfo} from '../../redux/studio';
+import {selectStudioTitle, selectIsLoadingInfo} from '../../redux/studio';
+import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {mutateStudioTitle, selectIsMutatingTitle, selectTitleMutationError} from '../../redux/studio-mutations';
 
 const StudioTitle = ({

--- a/src/views/studio/studio-title.jsx
+++ b/src/views/studio/studio-title.jsx
@@ -3,17 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {selectStudioTitle, selectIsLoadingInfo} from '../../redux/studio';
+import {selectStudioTitle, selectIsFetchingInfo} from '../../redux/studio';
 import {selectCanEditInfo} from '../../redux/studio-permissions';
 import {mutateStudioTitle, selectIsMutatingTitle, selectTitleMutationError} from '../../redux/studio-mutations';
 
 const StudioTitle = ({
-    titleError, isLoading, isMutating, title, canEditInfo, handleUpdate
+    titleError, isFetching, isMutating, title, canEditInfo, handleUpdate
 }) => (
     <div>
         <h3>Title</h3>
-        {isLoading ? (
-            <h4>Loading...</h4>
+        {isFetching ? (
+            <h4>Fetching...</h4>
         ) : (canEditInfo ? (
             <label>
                 <input
@@ -33,7 +33,7 @@ const StudioTitle = ({
 StudioTitle.propTypes = {
     titleError: PropTypes.string,
     canEditInfo: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isFetching: PropTypes.bool,
     isMutating: PropTypes.bool,
     title: PropTypes.string,
     handleUpdate: PropTypes.func
@@ -43,7 +43,7 @@ export default connect(
     state => ({
         title: selectStudioTitle(state),
         canEditInfo: selectCanEditInfo(state),
-        isLoading: selectIsLoadingInfo(state),
+        isFetching: selectIsFetchingInfo(state),
         isMutating: selectIsMutatingTitle(state),
         titleError: selectTitleMutationError(state)
     }),

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -24,8 +24,9 @@ import {
     activity
 } from './lib/redux-modules';
 
-const {studioReducer} = require('../../redux/studio');
+const {getInitialState, studioReducer} = require('../../redux/studio');
 const {commentsReducer} = require('../../redux/comments');
+const {studioMutationsReducer} = require('../../redux/studio-mutations');
 
 const StudioShell = () => {
     const match = useRouteMatch();
@@ -77,10 +78,12 @@ render(
         [managers.key]: managers.reducer,
         [activity.key]: activity.reducer,
         studio: studioReducer,
+        studioMutations: studioMutationsReducer,
         comments: commentsReducer
     },
     {
         studio: {
+            ...getInitialState(),
             // Include the studio id in the initial state to allow us
             // to stop passing around the studio id in components
             // when it is only needed for data fetching, not for rendering.

--- a/test/unit/redux/session.test.js
+++ b/test/unit/redux/session.test.js
@@ -1,6 +1,6 @@
 import {
     getInitialState, selectIsAdmin, selectIsSocial, selectUserId,
-    selectUsername, selectToken, sessionReducer, setSession
+    selectIsLoggedIn, selectUsername, selectToken, sessionReducer, setSession
 } from '../../../src/redux/session';
 
 import {sessions} from '../../helpers/state-fixtures.json';
@@ -10,6 +10,7 @@ describe('session selectors', () => {
         const state = {session: getInitialState()};
         expect(selectIsAdmin(state)).toBe(false);
         expect(selectIsSocial(state)).toBe(false);
+        expect(selectIsLoggedIn(state)).toBe(false);
         expect(selectUserId(state)).toBeNaN();
         expect(selectToken(state)).toBeNull();
         expect(selectUsername(state)).toBeNull();
@@ -22,6 +23,7 @@ describe('session selectors', () => {
         expect(selectUserId(state)).toBe(1);
         expect(selectUsername(state)).toBe('user1-username');
         expect(selectToken(state)).toBe('user1-token');
+        expect(selectIsLoggedIn(state)).toBe(true);
     });
 
     describe('permissions', () => {

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -1,18 +1,16 @@
 import {
-    getInitialState as getInitialStudioState,
     selectCanEditInfo,
     selectCanAddProjects,
     selectShowCommentComposer,
     selectCanDeleteComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
-    selectCanRestoreComment
-} from '../../../src/redux/studio';
+    selectCanRestoreComment,
+    selectCanFollowStudio
+} from '../../../src/redux/studio-permissions';
 
-import {
-    getInitialState as getInitialSessionState
-} from '../../../src/redux/session';
-
+import {getInitialState as getInitialStudioState} from '../../../src/redux/studio';
+import {getInitialState as getInitialSessionState} from '../../../src/redux/session';
 import {sessions, studios} from '../../helpers/state-fixtures.json';
 
 let state;

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -6,7 +6,9 @@ import {
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
     selectCanRestoreComment,
-    selectCanFollowStudio
+    selectCanFollowStudio,
+    selectCanEditCommentsAllowed,
+    selectCanEditOpenToAll
 } from '../../../src/redux/studio-permissions';
 
 import {getInitialState as getInitialStudioState} from '../../../src/redux/studio';
@@ -174,6 +176,36 @@ describe('studio comments', () => {
         ])('%s: %s', (role, expected) => {
             setStateByRole(role);
             expect(selectCanFollowStudio(state)).toBe(expected);
+        });
+    });
+
+    describe('can set "comments allowed" on a studio', () => {
+        test.each([
+            ['admin', true],
+            ['curator', false],
+            ['manager', false],
+            ['creator', true],
+            ['logged in', false],
+            ['unconfirmed', false],
+            ['logged out', false]
+        ])('%s: %s', (role, expected) => {
+            setStateByRole(role);
+            expect(selectCanEditCommentsAllowed(state)).toBe(expected);
+        });
+    });
+
+    describe('can set "open to all" on a studio', () => {
+        test.each([
+            ['admin', true],
+            ['curator', false],
+            ['manager', true],
+            ['creator', true],
+            ['logged in', false],
+            ['unconfirmed', false],
+            ['logged out', false]
+        ])('%s: %s', (role, expected) => {
+            setStateByRole(role);
+            expect(selectCanEditOpenToAll(state)).toBe(expected);
         });
     });
 });

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -196,7 +196,7 @@ describe('studio comments', () => {
 
     describe('can set "open to all" on a studio', () => {
         test.each([
-            ['admin', true],
+            ['admin', false],
             ['curator', false],
             ['manager', true],
             ['creator', true],

--- a/test/unit/redux/studio.test.js
+++ b/test/unit/redux/studio.test.js
@@ -167,4 +167,15 @@ describe('studio comments', () => {
             expect(selectCanRestoreComment(state)).toBe(expected);
         });
     });
+
+    describe('can follow a studio', () => {
+        test.each([
+            ['logged in', true],
+            ['unconfirmed', true],
+            ['logged out', false]
+        ])('%s: %s', (role, expected) => {
+            setStateByRole(role);
+            expect(selectCanFollowStudio(state)).toBe(expected);
+        });
+    });
 });


### PR DESCRIPTION
This PR introduces a new reducer, studio-mutations, which includes data about client-side editing of studio information like following, title, description, etc. This PR also includes 3 new wireframed components for editing studio title, description and follow status. 
![image](https://user-images.githubusercontent.com/654102/115606504-c7cdda80-a2b1-11eb-8a17-77d63be0567d.png)

I found it made more sense to keep the loading/error states for mutating data in a separate place from where we are initially fetching and storing that data. The main studio reducer listens for `COMPLETE_STUDIO_MUTATION` to update the actual data in redux, and the studio-mutations reducer just tracks an in-progress flag (per field) and a mutation error property (per field). 

This PR also includes an additional permission selector (canFollowStudio) which right now is just "isLoggedIn", but can be modified as needed in the future. 

A note on terminology. I'm going to try to avoid ever using the word "loading" in this part of the code, since it just invites so much confusion. There are now at least 2 senses in which data can be "loading", it could be being fetched from the server, or it could be being modified by the user, waiting for server confirmation. So I'm using "fetching" and "mutating" explicitly from now on :) 

This PR is best reviewed commit-by-commit, since there is some refactoring.

/cc @rschamp leaning into redux, actually enjoying it :) 