### PR TITLE
Reset studio comments when admin logs in

### DIFF
--- a/test/unit/components/studio-comments.test.jsx
+++ b/test/unit/components/studio-comments.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+import {StudioComments} from '../../../src/views/studio/studio-comments.jsx';
+
+describe('Studio comments', () => {
+    test('if there are no comments, they get loaded', () => {
+        const loadComments = jest.fn();
+        const component = mountWithIntl(
+            <StudioComments
+                comments={[]}
+                handleLoadMoreComments={loadComments}
+            />
+        );
+        expect(loadComments).toHaveBeenCalled();
+
+        // When updated to have comments, load is not called again
+        loadComments.mockClear();
+        component.setProps({comments: [{id: 123, author: {}}]});
+        component.update();
+        expect(loadComments).not.toHaveBeenCalled();
+
+        // When reset to have no comments again, load is called again
+        loadComments.mockClear();
+        component.setProps({comments: []});
+        component.update();
+        expect(loadComments).toHaveBeenCalled();
+    });
+    
+    test('becoming an admin resets the comments', () => {
+        const resetComments = jest.fn();
+        const component = mountWithIntl(
+            <StudioComments
+                isAdmin={false}
+                comments={[{id: 123, author: {}}]}
+                handleResetComments={resetComments}
+            />
+        );
+        expect(resetComments).not.toHaveBeenCalled();
+
+        // When updated to isAdmin=true, reset is called
+        resetComments.mockClear();
+        component.setProps({isAdmin: true});
+        component.update();
+        expect(resetComments).toHaveBeenCalled();
+
+        // If updated back to isAdmin=false, reset is also called
+        // not currently possible in the UI, but if it was, we'd want to clear comments
+        resetComments.mockClear();
+        component.setProps({isAdmin: false});
+        component.update();
+        expect(resetComments).toHaveBeenCalled();
+    });
+    
+    test('being an admin on initial render doesnt reset comments', () => {
+        // This ensures that comments don't get reloaded when changing tabs
+        const resetComments = jest.fn();
+        mountWithIntl(
+            <StudioComments
+                isAdmin
+                comments={[{id: 123, author: {}}]}
+                handleResetComments={resetComments}
+            />
+        );
+        expect(resetComments).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Resolves:

Resolves an issue we found in testing where an admin user might navigate directly to /studios-playground/123/comments and would see the comments as if they weren't an admin. The reason is that comments do not wait to load for the user session to return, because for almost all users it doesn't matter. But admins see reported comments, so the comment list either has to wait for the user session to return (slowing down the experience for all users) or reset the comment list when the session returns as an admin (possibly causing a layout shift only for admins as their logged out comment list gets replaced by the admin one). I chose the second option, since it will provide the fastest experience for far more people.


### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._

Instead of only loading the initial comment list on first render, I added `comments.length === 0` to the effect hook dependency list, so it will re-load comments any time that number changes to 0 (or initially). 

Then I added another effect hook that uses `useRef` to track the previous value of `isAdmin`, and compares it against the new value (this is like `prevProps.X !== props.X` in componentDidUpdate). If the user "becomes" an admin, the comments are reset, which then gets the comments reloaded. 


### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._

Added a unit test for the `studio-comment` component (and exported the unconnected version for simpler testing). It tests the situations when the initial comment load is called, and when the admin reset is called.

For manual testing, the repro is:
- Log in as an admin
- Go to a studio with studios-playground that has reported comments
- Click the "comments" tab -> see the reported comments in red.
- Reload the page, which will load the comment tab directly with url `/comments`
- You don't see the reported comments. (this is fixed with this PR).