### PR TITLE
Run npm ci in update-translations cron on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,9 @@ aliases:
     steps:
       - checkout
       - run:
+          name: "setup"
+          command: npm --production=false ci
+      - run:
           name: "run i18n script"
           command: npm run i18n:push
 


### PR DESCRIPTION
### Resolves:

The cron job that pushes translations to transifex failed with the error: 

Error: Cannot find module 'glob'

We weren't running install (or CI in this case) in the job so it did not have access to the glob package.

### Changes:

Adds a run step that runs npm ci to the update-translations job

