### PR TITLE
Revert "Add privacy policy and terms of use to allowlist"

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -13,10 +13,9 @@ const Types = keyMirror({
 });
 
 const banWhitelistPaths = [
-    '/accounts/banned-response',
-    '/community_guidelines',
-    '/privacy_policy',
-    '/terms_of_use'
+    '/accounts/banned-response/',
+    '/community_guidelines/',
+    '/community_guidelines'
 ];
 
 module.exports.Status = keyMirror({


### PR DESCRIPTION
Reverts LLK/scratch-www#5220

Turns out we did need those redundant entries with the slashes after all!

Fix seems to be to either strip the trailing slash from the pathname, or reverse the order of the indexOf and use some kind of reducer to check if the pathname contains any of the goodlist entries.