### PR TITLE
Bug fixes from studio playground test on May 5 2021

### DIFF
--- a/src/redux/infinite-list.js
+++ b/src/redux/infinite-list.js
@@ -76,10 +76,11 @@ const InfiniteList = key => {
                 ...state,
                 items: state.items.filter((_, i) => i !== action.index)
             };
-        case `${key}_PREPEND`:
+        case `${key}_CREATE`:
             return {
                 ...state,
-                items: [action.item].concat(state.items)
+                items: action.atEnd ? state.items.concat([action.item]) :
+                    [action.item].concat(state.items)
             };
         case `${key}_ERROR`:
             return {
@@ -94,7 +95,7 @@ const InfiniteList = key => {
     };
 
     const actions = {
-        create: item => ({type: `${key}_PREPEND`, item}),
+        create: (item, atEnd = false) => ({type: `${key}_CREATE`, item, atEnd}),
         remove: index => ({type: `${key}_REMOVE`, index}),
         replace: (index, item) => ({type: `${key}_REPLACE`, index, item}),
         error: error => ({type: `${key}_ERROR`, error}),

--- a/src/redux/studio-mutations.js
+++ b/src/redux/studio-mutations.js
@@ -171,10 +171,14 @@ const mutateFollowingStudio = shouldFollow => ((dispatch, getState) => {
 });
 
 const mutateStudioImage = input => ((dispatch, getState) => {
+    if (!input.files || !input.files[0]) return;
     const state = getState();
     const studioId = selectStudioId(state);
     const currentImage = selectStudioImage(state);
     dispatch(startMutation('image'));
+    if (input.files[0].size && input.files[0].size > 524288) {
+        return dispatch(completeMutation('image', currentImage, Errors.THUMBNAIL_TOO_LARGE));
+    }
     const formData = new FormData();
     formData.append('file', input.files[0]);
     api({

--- a/src/views/studio/lib/studio-member-actions.js
+++ b/src/views/studio/lib/studio-member-actions.js
@@ -8,13 +8,20 @@ import {selectStudioId, setRoles} from '../../../redux/studio';
 const Errors = keyMirror({
     NETWORK: null,
     SERVER: null,
-    PERMISSION: null
+    PERMISSION: null,
+    DUPLICATE: null
 });
 
 const normalizeError = (err, body, res) => {
     if (err) return Errors.NETWORK;
     if (res.statusCode === 401 || res.statusCode === 403) return Errors.PERMISSION;
     if (res.statusCode !== 200) return Errors.SERVER;
+    if (body && body.status === 'error') {
+        if (body.message.indexOf('already a curator') !== -1) {
+            return Errors.DUPLICATE;
+        }
+        return Errors.UNHANDLED;
+    }
     return null;
 };
 

--- a/src/views/studio/lib/studio-member-actions.js
+++ b/src/views/studio/lib/studio-member-actions.js
@@ -139,7 +139,7 @@ const promoteCurator = username => ((dispatch, getState) => new Promise((resolve
         const index = curatorList.findIndex(v => v.username === username);
         const curatorItem = curatorList[index];
         if (index !== -1) dispatch(curators.actions.remove(index));
-        dispatch(managers.actions.create(curatorItem));
+        dispatch(managers.actions.create(curatorItem, true));
         return resolve();
     });
 }));
@@ -163,7 +163,7 @@ const acceptInvitation = () => ((dispatch, getState) => new Promise((resolve, re
             if (userError) return reject(userError);
             // Note: this assumes that the user items from the curator endpoint
             // are the same structure as the single user data returned from /users/:username
-            dispatch(curators.actions.create(userBody));
+            dispatch(curators.actions.create(userBody, true));
             dispatch(setRoles({invited: false, curator: true}));
             return resolve();
         });

--- a/src/views/studio/studio-curator-inviter.jsx
+++ b/src/views/studio/studio-curator-inviter.jsx
@@ -10,7 +10,14 @@ const StudioCuratorInviter = ({onSubmit}) => {
     const [value, setValue] = useState('');
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState(null);
-
+    const submit = () => {
+        setSubmitting(true);
+        setError(null);
+        onSubmit(value)
+            .then(() => setValue(''))
+            .catch(e => setError(e))
+            .then(() => setSubmitting(false));
+    };
     return (
         <div className="studio-adder-section">
             <h3>✦ Invite Curators</h3>
@@ -19,6 +26,7 @@ const StudioCuratorInviter = ({onSubmit}) => {
                 type="text"
                 placeholder="<username>"
                 value={value}
+                onKeyDown={e => e.key === 'Enter' && submit()}
                 onChange={e => setValue(e.target.value)}
             />
             <button
@@ -26,14 +34,7 @@ const StudioCuratorInviter = ({onSubmit}) => {
                     'mod-mutating': submitting
                 })}
                 disabled={submitting}
-                onClick={() => {
-                    setSubmitting(true);
-                    setError(null);
-                    onSubmit(value)
-                        .then(() => setValue(''))
-                        .catch(e => setError(e))
-                        .then(() => setSubmitting(false));
-                }}
+                onClick={submit}
             >Invite</button>
             {error && <div>{error}</div>}
         </div>

--- a/src/views/studio/studio-project-adder.jsx
+++ b/src/views/studio/studio-project-adder.jsx
@@ -10,7 +10,14 @@ const StudioProjectAdder = ({onSubmit}) => {
     const [value, setValue] = useState('');
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState(null);
-
+    const submit = () => {
+        setSubmitting(true);
+        setError(null);
+        onSubmit(value)
+            .then(() => setValue(''))
+            .catch(e => setError(e))
+            .then(() => setSubmitting(false));
+    };
     return (
         <div className="studio-adder-section">
             <h3>✦ Add Projects</h3>
@@ -19,6 +26,7 @@ const StudioProjectAdder = ({onSubmit}) => {
                 type="text"
                 placeholder="<project id>"
                 value={value}
+                onKeyDown={e => e.key === 'Enter' && submit()}
                 onChange={e => setValue(e.target.value)}
             />
             <button
@@ -26,14 +34,7 @@ const StudioProjectAdder = ({onSubmit}) => {
                     'mod-mutating': submitting
                 })}
                 disabled={submitting}
-                onClick={() => {
-                    setSubmitting(true);
-                    setError(null);
-                    onSubmit(value)
-                        .then(() => setValue(''))
-                        .catch(e => setError(e))
-                        .then(() => setSubmitting(false));
-                }}
+                onClick={submit}
             >Add</button>
             {error && <div>{error}</div>}
         </div>

--- a/src/views/studio/studio-tab-nav.jsx
+++ b/src/views/studio/studio-tab-nav.jsx
@@ -19,15 +19,15 @@ const StudioTabNav = () => {
             </NavLink>
             <NavLink
                 activeClassName="active"
-                to={`${base}/curators`}
+                to={`${base}/comments`}
             >
-                <li>Curators</li>
+                <li>Comments</li>
             </NavLink>
             <NavLink
                 activeClassName="active"
-                to={`${base}/comments`}
+                to={`${base}/curators`}
             >
-                <li> Comments</li>
+                <li>Curators</li>
             </NavLink>
             <NavLink
                 activeClassName="active"

--- a/src/views/studio/studio-tab-nav.jsx
+++ b/src/views/studio/studio-tab-nav.jsx
@@ -3,8 +3,8 @@ import {useRouteMatch, NavLink} from 'react-router-dom';
 import SubNavigation from '../../components/subnavigation/subnavigation.jsx';
 
 const StudioTabNav = () => {
-    const match = useRouteMatch();
-
+    const {params: {studioPath, studioId}} = useRouteMatch();
+    const base = `/${studioPath}/${studioId}`;
     return (
         <SubNavigation
             align="left"
@@ -12,26 +12,26 @@ const StudioTabNav = () => {
         >
             <NavLink
                 activeClassName="active"
-                to={`${match.url}`}
+                to={base}
                 exact
             >
                 <li>Projects</li>
             </NavLink>
             <NavLink
                 activeClassName="active"
-                to={`${match.url}/curators`}
+                to={`${base}/curators`}
             >
                 <li>Curators</li>
             </NavLink>
             <NavLink
                 activeClassName="active"
-                to={`${match.url}/comments`}
+                to={`${base}/comments`}
             >
                 <li> Comments</li>
             </NavLink>
             <NavLink
                 activeClassName="active"
-                to={`${match.url}/activity`}
+                to={`${base}/activity`}
             >
                 <li>Activity</li>
             </NavLink>

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -35,7 +35,7 @@ $radius: 8px;
 .studio-info {
     justify-self: center;
     width: 300px;
-    height: fit-content;
+    height: max-content;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 20px;

--- a/test/unit/redux/infinite-list.test.js
+++ b/test/unit/redux/infinite-list.test.js
@@ -93,14 +93,17 @@ describe('Infinite List redux module', () => {
         });
 
         describe('CREATE', () => {
-            let action;
-            beforeEach(() => {
-                action = module.actions.create(7);
-            });
-            test('prepends the given item', () => {
+            test('prepends the given item by default', () => {
+                const action = module.actions.create(7);
                 initialState.items = [8, 9, 10, 11];
                 const newState = module.reducer(initialState, action);
                 expect(newState.items).toEqual([7, 8, 9, 10, 11]);
+            });
+            test('appends the given item if given `atEnd` arg', () => {
+                const action = module.actions.create(7, true);
+                initialState.items = [8, 9, 10, 11];
+                const newState = module.reducer(initialState, action);
+                expect(newState.items).toEqual([8, 9, 10, 11, 7]);
             });
         });
 


### PR DESCRIPTION
Each commit resolves an issue that was uncovered during the test of the studios playground on may 5:
- Catch the error that was being returned when trying to invite a user that was already a member of the studio
- Fix the grid layout of the sidebar on firefox
- Fix the issue where going to .../curators/ (with trailing slash) would prevent the tab nav from working the first time you clicked another tab
- Correct the tab ordering
- Fix the issue where promoted or added curators would go at the beginning of the list instead of the end
- Allow the "Enter" key to submit the curator invitation / project adder forms
- Catch situations where a thumbnail is too large on the client side (file-size-wise, not dimensionally)

@seotts each commit addresses a single issue, but the code all together is spread out. I recommend using the "commit-by-commit" view to review this PR.