### PR TITLE
Set up studios view with 404 page

### DIFF
--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -26,7 +26,9 @@ const getInitialState = () => ({
     manager: false,
     curator: false,
     following: false,
-    invited: false
+    invited: false,
+    
+    studioNotAvailable: false
 });
 
 const studioReducer = (state, action) => {
@@ -50,6 +52,13 @@ const studioReducer = (state, action) => {
     case 'SET_FETCH_STATUS':
         if (action.error) {
             log.error(action.error);
+        }
+        if (action.fetchType === 'infoStatus' && action.fetchStatus === Status.ERROR) {
+            return {
+                ...state,
+                [action.fetchType]: action.fetchStatus,
+                studioNotAvailable: true
+            };
         }
         return {
             ...state,
@@ -94,6 +103,7 @@ const selectStudioCommentsAllowed = state => state.studio.commentsAllowed;
 const selectIsFetchingInfo = state => state.studio.infoStatus === Status.FETCHING;
 const selectIsFollowing = state => state.studio.following;
 const selectIsFetchingRoles = state => state.studio.rolesStatus === Status.FETCHING;
+const selectIsStudioAvailable = state => !state.studio.studioNotAvailable;
 
 // Thunks
 const getInfo = () => ((dispatch, getState) => {
@@ -159,5 +169,6 @@ module.exports = {
     selectStudioCommentsAllowed,
     selectIsFetchingInfo,
     selectIsFetchingRoles,
-    selectIsFollowing
+    selectIsFollowing,
+    selectIsStudioAvailable
 };

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -6,9 +6,14 @@ import {
     Redirect,
     useRouteMatch
 } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
 
 import Page from '../../components/page/www/page.jsx';
 import render from '../../lib/render.jsx';
+import NotAvailable from '../../components/not-available/not-available.jsx';
+
 
 import StudioTabNav from './studio-tab-nav.jsx';
 import StudioProjects from './studio-projects.jsx';
@@ -25,48 +30,60 @@ import {
     activity
 } from './lib/redux-modules';
 
-const {getInitialState, studioReducer} = require('../../redux/studio');
+const {getInitialState, studioReducer, selectIsStudioAvailable} = require('../../redux/studio');
 const {studioReportReducer} = require('../../redux/studio-report');
 const {commentsReducer} = require('../../redux/comments');
 const {studioMutationsReducer} = require('../../redux/studio-mutations');
 
 import './studio.scss';
 
-const StudioShell = () => {
+const StudioShell = ({isStudioAvailable}) => {
     const match = useRouteMatch();
 
     return (
-        <div className="studio-shell">
-            <div className="studio-info">
-                <StudioInfo />
-            </div>
-            <div className="studio-tabs">
-                <StudioTabNav />
-                <div>
-                    <Switch>
-                        <Route path={`${match.path}/curators`}>
-                            <StudioManagers />
-                            <StudioCurators />
-                        </Route>
-                        <Route path={`${match.path}/comments`}>
-                            <StudioComments />
-                        </Route>
-                        <Route path={`${match.path}/activity`}>
-                            <StudioActivity />
-                        </Route>
-                        <Route path={`${match.path}/projects`}>
-                            {/* We can force /projects back to / this way */}
-                            <Redirect to={match.url} />
-                        </Route>
-                        <Route path={match.path}>
-                            <StudioProjects />
-                        </Route>
-                    </Switch>
+        isStudioAvailable ?
+            <div className="studio-shell">
+                <div className="studio-info">
+                    <StudioInfo />
                 </div>
-            </div>
-        </div>
+                <div className="studio-tabs">
+                    <StudioTabNav />
+                    <div>
+                        <Switch>
+                            <Route path={`${match.path}/curators`}>
+                                <StudioManagers />
+                                <StudioCurators />
+                            </Route>
+                            <Route path={`${match.path}/comments`}>
+                                <StudioComments />
+                            </Route>
+                            <Route path={`${match.path}/activity`}>
+                                <StudioActivity />
+                            </Route>
+                            <Route path={`${match.path}/projects`}>
+                                {/* We can force /projects back to / this way */}
+                                <Redirect to={match.url} />
+                            </Route>
+                            <Route path={match.path}>
+                                <StudioProjects />
+                            </Route>
+                        </Switch>
+                    </div>
+                </div>
+            </div> :
+            <NotAvailable />
     );
 };
+
+StudioShell.propTypes = {
+    isStudioAvailable: PropTypes.bool
+};
+
+const ConnectedStudioShell = connect(
+    state => ({
+        isStudioAvailable: selectIsStudioAvailable(state)
+    }),
+)(StudioShell);
 
 render(
     <Page className="studio-page">
@@ -74,7 +91,7 @@ render(
             <Switch>
                 {/* Use variable studioPath to support /studio-playground/ or future route */}
                 <Route path="/:studioPath/:studioId">
-                    <StudioShell />
+                    <ConnectedStudioShell />
                 </Route>
             </Switch>
         </Router>


### PR DESCRIPTION
### Changes:

Display the 404 page when fetching a studio results in a 404.

Add info about studio availability to the studio reducer.
Hook up the studio availability state to the StudioShell to display a 404 page if we get an error while fetching the studio.

### Test Coverage:

Tested locally:
- get a 404 page when using a fake studio ID
- get the studio page when going using an existing studio ID
