### PR TITLE
Finalize Circleci setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,10 +154,8 @@ workflows:
             - scratch-www-staging
           filters:
             branches:
-              only:
-                - develop
-                - /^hotfix\/.*/
-                - /^release\/.*/
+              ignore:
+                - master
       - build-production:
           context:
             - scratch-www-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,11 @@ aliases:
       - *save_build_cache
       - store_test_results:
           path: test/results
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf build.tar build
       - store_artifacts:
-          path: build
+          path: build.tar
   - &deploy
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ aliases:
             python3 get-pip.py pip==21.0.1
             pip install s3cmd==2.1.0
       - run:
-          name: "deploy to staging"
+          name: "deploy"
           command: |
             npm run deploy
   - &integration_jest


### PR DESCRIPTION
### Resolves:

Lets us run checks on branches before merging PRs
The deploy step was called "deploy staging" even when pushing to production
Pushing up the artifacts from the build step was quite slow

### Changes:

Makes build-develop job run on circle for all branches except master
Renames the name of a run step to be more generic
compress artifacts before storing them
