### PR TITLE
rename .close-button style to not conflict

### DIFF
--- a/src/components/forms/button.jsx
+++ b/src/components/forms/button.jsx
@@ -6,7 +6,7 @@ const React = require('react');
 require('./button.scss');
 
 const Button = props => {
-    const classes = classNames('button', props.className, {'close-button': props.isCloseType});
+    const classes = classNames('button', props.className, {'forms-close-button': props.isCloseType});
 
     return (
         <button

--- a/src/components/forms/button.scss
+++ b/src/components/forms/button.scss
@@ -54,7 +54,7 @@ $pass-bg: $ui-aqua;
     }
 }
 
-.close-button {
+.forms-close-button {
     padding: 0;
 
     position: absolute;
@@ -69,6 +69,6 @@ $pass-bg: $ui-aqua;
     line-height: 2rem;
 }
 
-.close-button img {
+.forms-close-button img {
     padding-top: 0.5rem;
 }


### PR DESCRIPTION
Follow-on to https://github.com/LLK/scratch-www/pull/5345 , which used an existing classname, `.close-button`, that conflicted with the modal close button used in the add to studio and copy link modals.

Renames it to `.forms-close-button`.