### PR TITLE
fix logic for when to show intro to users

### DIFF
--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -165,6 +165,13 @@ class Splash extends React.Component {
     shouldShowHOCMiddleBanner () {
         return false; // we did not use this middle banner in last HoC
     }
+    shouldShowIntro () {
+        return (
+            this.props.sessionStatus === sessionActions.Status.FETCHED && // done fetching session
+            Object.keys(this.props.user).length === 0 && // no user session found
+            this.shouldShowHOCTopBanner() !== true
+        );
+    }
     shouldShowDonateBanner () {
         return (
             this.state.dismissedDonateBanner === false &&
@@ -180,7 +187,7 @@ class Splash extends React.Component {
         const showDonateBanner = this.shouldShowDonateBanner() || false;
         const showHOCTopBanner = this.shouldShowHOCTopBanner() || false;
         const showHOCMiddleBanner = this.shouldShowHOCMiddleBanner() || false;
-        const showIntro = showHOCTopBanner !== true;
+        const showIntro = this.shouldShowIntro() || false;
         const showWelcome = this.shouldShowWelcome();
         const homepageRefreshStatus = this.getHomepageRefreshStatus();
 


### PR DESCRIPTION
Follow up to https://github.com/LLK/scratch-www/pull/5345 , fixing logic around when to show intro banner.

Originally, the logic was:

* if user is logged out, AND we're not showing hour of code banner, show intro banner

https://github.com/LLK/scratch-www/pull/5345 mistakenly changed the logic to:

* if we're not showing hour of code banner, show intro banner

This change changes the logic back to:

* if user is logged out, AND we're not showing hour of code banner, show intro banner

