### PR TITLE
Fixed problem introduced by previous fix

### DIFF
--- a/src/views/developers/developers.jsx
+++ b/src/views/developers/developers.jsx
@@ -365,7 +365,7 @@ const Developers = () => (
                                         ),
                                         contactUsLink: (
                                             <a href="/contact-us">
-                                                Contact Us
+                                                <FormattedMessage id="general.contactUs" />
                                             </a>
                                         )
                                     }}


### PR DESCRIPTION
In the last fix, we introduced a problem where "Contact Us" was not a FormattedMessage. This PR fixes that
