### PR TITLE
Show "students projects" filter on studio project browser

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -127,6 +127,7 @@ module.exports.selectUsername = state => get(state, ['session', 'session', 'user
 module.exports.selectToken = state => get(state, ['session', 'session', 'user', 'token'], null);
 module.exports.selectIsAdmin = state => get(state, ['session', 'session', 'permissions', 'admin'], false);
 module.exports.selectIsSocial = state => get(state, ['session', 'session', 'permissions', 'social'], false);
+module.exports.selectIsEducator = state => get(state, ['session', 'session', 'permissions', 'educator'], false);
 
 // NB logged out user id as NaN so that it can never be used in equality testing since NaN !== NaN
 module.exports.selectUserId = state => get(state, ['session', 'session', 'user', 'id'], NaN);

--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -38,6 +38,7 @@
     "studio.sharedFilter": "Shared",
     "studio.favoritedFilter": "Favorited",
     "studio.recentFilter": "Recent",
+    "studio.studentsFilter": "Students",
     
     "studio.activityAddProjectToStudio": "{profileLink} added the project {projectLink}",
     "studio.activityRemoveProjectStudio": "{profileLink} removed the project {projectLink}",

--- a/src/views/studio/modals/user-projects-modal.jsx
+++ b/src/views/studio/modals/user-projects-modal.jsx
@@ -85,15 +85,18 @@ const UserProjectsModal = ({
                             onRemove={onRemove}
                         />
                     ))}
+                    {moreToLoad &&
                     <div className="studio-projects-load-more">
-                        {loading ? <small>Loading...</small> : (
-                            moreToLoad ?
-                                <button onClick={() => onLoadMore(filter)}>
-                                    <FormattedMessage id="general.loadMore" />
-                                </button> :
-                                <small>No more to load</small>
-                        )}
+                        <button
+                            className={classNames('button', {
+                                'mod-mutating': loading
+                            })}
+                            onClick={onLoadMore}
+                        >
+                            <FormattedMessage id="general.loadMore" />
+                        </button>
                     </div>
+                    }
                 </div>
             </ModalInnerContent>
         </Modal>

--- a/src/views/studio/modals/user-projects-modal.jsx
+++ b/src/views/studio/modals/user-projects-modal.jsx
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
 
+import {selectClassroomId} from '../../../redux/studio';
 import {addProject, removeProject} from '../lib/studio-project-actions';
 import {userProjects} from '../lib/redux-modules';
 import {Filters, loadUserProjects, clearUserProjects} from '../lib/user-projects-actions';
@@ -16,10 +17,11 @@ import SubNavigation from '../../../components/subnavigation/subnavigation.jsx';
 import UserProjectsTile from './user-projects-tile.jsx';
 
 import './user-projects-modal.scss';
+import {selectIsEducator} from '../../../redux/session';
 
 const UserProjectsModal = ({
-    items, error, loading, moreToLoad, onLoadMore, onClear,
-    onAdd, onRemove, onRequestClose
+    items, error, loading, moreToLoad, showStudentsFilter,
+    onLoadMore, onClear, onAdd, onRemove, onRequestClose
 }) => {
     const [filter, setFilter] = useState(Filters.SHARED);
 
@@ -60,6 +62,14 @@ const UserProjectsModal = ({
                 >
                     <FormattedMessage id="studio.recentFilter" />
                 </li>
+                {showStudentsFilter &&
+                    <li
+                        className={classNames({active: filter === Filters.STUDENTS})}
+                        onClick={() => setFilter(Filters.STUDENTS)}
+                    >
+                        <FormattedMessage id="studio.studentsFilter" />
+                    </li>
+                }
             </SubNavigation>
             <ModalInnerContent className="user-projects-modal-content">
                 {error && <div>Error loading {filter}: {error}</div>}
@@ -91,6 +101,7 @@ const UserProjectsModal = ({
 };
 
 UserProjectsModal.propTypes = {
+    showStudentsFilter: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.id,
         image: PropTypes.string,
@@ -108,7 +119,8 @@ UserProjectsModal.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    ...userProjects.selector(state)
+    ...userProjects.selector(state),
+    showStudentsFilter: selectIsEducator(state) && selectClassroomId(state)
 });
 
 const mapDispatchToProps = ({


### PR DESCRIPTION
This PR connects the "students" filter up to the new api endpoints for getting projects shared by students who are in the classroom the studio is a part of (phew, that was a mouthful). @seotts this uses both the endpoints you introduced, first if the user is an educator, check if the studio is part of a classroom. Then the user-projects-modal shows a "students" filter, which requests projects from the other endpoint. 

As a bonus, i also updated the "recent" filter to have the correct uri and also send authentication along. That endpoint isn't in production yet, but i tested it locally and it was working well /cc @cwillisf. 

![Screen Shot 2021-05-13 at 1 30 08 PM](https://user-images.githubusercontent.com/654102/118162943-59cb8d80-b3ef-11eb-8855-9020985c426a.png)