### PR TITLE
Outlines for avatars

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -159,6 +159,8 @@
 
     .avatar {
         margin-right: .5rem;
+        border-radius: 4px;
+        box-shadow: 0px 0px 0px 1px rgba(77, 151, 255, 0.25);
     }
 
     .comment-body {

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -161,6 +161,8 @@
         margin-right: .5rem;
         border-radius: 4px;
         box-shadow: 0px 0px 0px 1px rgba(77, 151, 255, 0.25);
+        width: 3rem;
+        height: 3rem;
     }
 
     .comment-body {


### PR DESCRIPTION
Round and outline avatars for comments. The spec actually wants these outlines to be black and inset, but having such an outline that is also rounded is not supported on most browsers yet (see https://bugs.chromium.org/p/chromium/issues/detail?id=81556) so I put the border outside the avatar instead and instead made it the color of the dotted line around editable fields

Spec:
<img width="135" alt="Screen Shot 2021-05-13 at 17 53 16" src="https://user-images.githubusercontent.com/2855464/118192464-2d763800-b414-11eb-8f73-58933b73677c.png">

Current:
<img width="116" alt="Screen Shot 2021-05-13 at 17 53 31" src="https://user-images.githubusercontent.com/2855464/118192474-323aec00-b414-11eb-829a-c6e8de889ec3.png">

Proposed:
<img width="126" alt="Screen Shot 2021-05-13 at 17 54 59" src="https://user-images.githubusercontent.com/2855464/118192621-6a422f00-b414-11eb-9af9-64d3864c4e9c.png">
