### PR TITLE
Use client-side image preview for studio thumbnail instead of server response

### DIFF
--- a/src/redux/studio-mutations.js
+++ b/src/redux/studio-mutations.js
@@ -194,6 +194,18 @@ const mutateStudioImage = input => ((dispatch, getState) => {
         const error = normalizeError(err, body, res);
         dispatch(completeMutation('image', error ? currentImage : body.thumbnail_url, error));
     });
+
+    // Return a promise with the data-url of the uploaded image
+    return new Promise((resolve, reject) => {
+        try {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = reject;
+            reader.readAsDataURL(input.files[0]);
+        } catch (e) {
+            reject(e);
+        }
+    });
 });
 
 const mutateStudioCommentsAllowed = shouldAllow => ((dispatch, getState) => {

--- a/src/views/studio/studio-image.jsx
+++ b/src/views/studio/studio-image.jsx
@@ -25,11 +25,13 @@ const blankImage = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAA
 const StudioImage = ({
     imageError, isFetching, isMutating, image, canEditInfo, handleUpdate
 }) => {
+    const [uploadPreview, setUploadPreview] = React.useState(null);
     const fieldClassName = classNames('studio-info-section', {
         'mod-fetching': isFetching,
         'mod-mutating': isMutating
     });
-    const src = isMutating ? blankImage : (image || blankImage);
+    let src = image || blankImage;
+    if (uploadPreview && !imageError) src = uploadPreview;
     return (
         <div className={fieldClassName}>
             <img
@@ -43,7 +45,8 @@ const StudioImage = ({
                         type="file"
                         accept="image/*"
                         onChange={e => {
-                            handleUpdate(e.target);
+                            handleUpdate(e.target)
+                                .then(dataUrl => setUploadPreview(dataUrl));
                             e.target.value = '';
                         }}
                     />


### PR DESCRIPTION
This PR addresses an issue where the thumbnail image may not update after submitting a new studio thumbnail file.

The fix is to make the studio thumbnail update action to return a promise with a base64 encoded image source, read directly from the uploaded file. The thumbnail component will prefer to use that preview, instead of the response from the server, if available. This is because the image is uploaded but may not be available from the CDN immediately. 

The upload action does purge the image cache, but that is an async thing and can take a variable amount of time, so cannot be relied on. This is the equivalent to a "don't GET after POST-ing" replication-lag-esq problem, but instead of a lag between the primary and the replica db, it is between the primary image store and the edge cdn cache. And similar to that problem, the solution is to not re-request data if you know what the response _should_ be. There is some logic to allow the server response to be used in case the browser fails to use the `FileReader#readAsDataUrl` api, but that api is used in other parts of scratch so is not a big concern.

/cc @rschamp, i don't know if we have this issue elsewhere yet, but a similar thing will come up when changing user profile images, e.g.

@ericrosenbaum thanks for seeing this issue. The actual cdn cache race condition won't be replicable locally, but you should see the correct image after uploading one (no guarantees on continuing to see it after refreshing, i don't think we have thumbnail images wired up correctly locally...). 