### PR TITLE
Handle more types of project add errors

### DIFF
--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -27,10 +27,10 @@
     "studio.projectsEmpty2": "Suggest projects you want to add in the comments!",
     "studio.browseProjects": "Browse Projects",
     "studio.projectErrors.checkUrl": "Could not find that project. Check the URL and try again.",
-    "studio.projectErrors.generic": "Could not add project",
-    "studio.projectErrors.tooFast": "You are adding projects too quickly",
-    "studio.projectErrors.permission": "You do not have permission to add that project",
-    "studio.projectErrors.duplicate": "That project is already in this studio",
+    "studio.projectErrors.generic": "Could not add project.",
+    "studio.projectErrors.tooFast": "You are adding projects too quickly.",
+    "studio.projectErrors.permission": "You do not have permission to add that project.",
+    "studio.projectErrors.duplicate": "That project is already in this studio.",
 
     "studio.creatorRole": "Studio Creator",
 

--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -26,7 +26,11 @@
     "studio.projectsEmpty1": "This studio has no projects yet.",
     "studio.projectsEmpty2": "Suggest projects you want to add in the comments!",
     "studio.browseProjects": "Browse Projects",
-    "studio.projectErrors.checkUrl": "Could not add project. Check the URL and try again.",
+    "studio.projectErrors.checkUrl": "Could not find that project. Check the URL and try again.",
+    "studio.projectErrors.generic": "Could not add project",
+    "studio.projectErrors.tooFast": "You are adding projects too quickly",
+    "studio.projectErrors.permission": "You do not have permission to add that project",
+    "studio.projectErrors.duplicate": "That project is already in this studio",
 
     "studio.creatorRole": "Studio Creator",
 

--- a/src/views/studio/studio-project-adder.jsx
+++ b/src/views/studio/studio-project-adder.jsx
@@ -5,9 +5,21 @@ import {connect} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage, intlShape, injectIntl} from 'react-intl';
 
-import {addProject} from './lib/studio-project-actions';
+import {Errors, addProject} from './lib/studio-project-actions';
 import UserProjectsModal from './modals/user-projects-modal.jsx';
 import ValidationMessage from '../../components/forms/validation-message.jsx';
+
+const errorToMessageId = error => {
+    switch (error) {
+    case Errors.NETWORK: return 'studio.projectErrors.generic';
+    case Errors.SERVER: return 'studio.projectErrors.generic';
+    case Errors.PERMISSION: return 'studio.projectErrors.permission';
+    case Errors.DUPLICATE: return 'studio.projectErrors.duplicate';
+    case Errors.RATE_LIMIT: return 'studio.projectErrors.tooFast';
+    case Errors.UNKNOWN_PROJECT: return 'studio.projectErrors.checkUrl';
+    default: return 'studio.projectErrors.generic';
+    }
+};
 
 const StudioProjectAdder = ({intl, onSubmit}) => {
     const [value, setValue] = useState('');
@@ -30,7 +42,7 @@ const StudioProjectAdder = ({intl, onSubmit}) => {
                     <ValidationMessage
                         mode="error"
                         className="validation-left"
-                        message={<FormattedMessage id="studio.projectErrors.checkUrl" />}
+                        message={<FormattedMessage id={errorToMessageId(error)} />}
                     />
                 </div>}
                 <input


### PR DESCRIPTION
Fixes an issue where all "add project" errors were being flattened into a single error message. I added text for more of the errors, which will definitely help with testing, even if we don't choose to keep all the messaging.

This uses the same `errorToMessageId(error)` pattern from the curator adder