### PR TITLE
Use circleCI build ID for saucelabs test names instead

### DIFF
--- a/test/integration-legacy/selenium-helpers.js
+++ b/test/integration-legacy/selenium-helpers.js
@@ -5,7 +5,8 @@ require('chromedriver');
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
-const buildID = process.env.CIRCLE_WORKFLOW_ID;
+const usingCircle = process.env.CIRCLECI || false;
+const buildID = process.env.CIRCLE_WORKFLOW_ID || '0000';
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 
@@ -35,7 +36,8 @@ class SeleniumHelper {
         if (remote === 'true'){
             let nameToUse;
             if (ci === 'true'){
-                nameToUse = 'circleCI ' + buildID + ' : ' + name;
+                let ciName = usingCircle ? 'circleCi ' : 'unknown ';
+                nameToUse = ciName + buildID + ' : ' + name;
             } else {
                 nameToUse = name;
             }

--- a/test/integration-legacy/selenium-helpers.js
+++ b/test/integration-legacy/selenium-helpers.js
@@ -5,7 +5,7 @@ require('chromedriver');
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
-const buildID = process.env.TRAVIS_BUILD_NUMBER;
+const buildID = process.env.CIRCLE_WORKFLOW_ID;
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 
@@ -35,7 +35,7 @@ class SeleniumHelper {
         if (remote === 'true'){
             let nameToUse;
             if (ci === 'true'){
-                nameToUse = 'travis ' + buildID + ' : ' + name;
+                nameToUse = 'circleCI ' + buildID + ' : ' + name;
             } else {
                 nameToUse = name;
             }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -6,7 +6,8 @@ const chromedriverVersion = require('chromedriver').version;
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
-const buildID = process.env.CIRCLE_WORKFLOW_ID;
+const usingCircle = process.env.CIRCLECI || false;
+const buildID = process.env.CIRCLE_WORKFLOW_ID || '0000';
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 
@@ -36,7 +37,8 @@ class SeleniumHelper {
         if (remote === 'true'){
             let nameToUse;
             if (ci === 'true'){
-                nameToUse = 'circleCI ' + buildID + ' : ' + name;
+                let ciName = usingCircle ? 'circleCi ' : 'unknown ';
+                nameToUse = ciName + buildID + ' : ' + name;
             } else {
                 nameToUse = name;
             }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -6,7 +6,7 @@ const chromedriverVersion = require('chromedriver').version;
 const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
-const buildID = process.env.TRAVIS_BUILD_NUMBER;
+const buildID = process.env.CIRCLE_WORKFLOW_ID;
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 
@@ -36,7 +36,7 @@ class SeleniumHelper {
         if (remote === 'true'){
             let nameToUse;
             if (ci === 'true'){
-                nameToUse = 'travis ' + buildID + ' : ' + name;
+                nameToUse = 'circleCI ' + buildID + ' : ' + name;
             } else {
                 nameToUse = name;
             }


### PR DESCRIPTION
### Resolves:

The tap and jest integration tests were expecting a travis build id which didn't exist since we switched to travis.  

### Changes:

Both the integration and the integration-legacy selenium-helpers.js file now set the buildID to the Circle workflow id.  The text of the name passed to saucelabs also has been updated to say CircleCI instead of Travis.

### Test Coverage:

The integration tests should still pass and on saucelabs they should report the workflow id from circle.
