### PR TITLE
use Circle’s BUILD_NUM instead of WORKFLOW_ID in saucelabs tests

### DIFF
--- a/test/integration-legacy/selenium-helpers.js
+++ b/test/integration-legacy/selenium-helpers.js
@@ -6,7 +6,7 @@ const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
 const usingCircle = process.env.CIRCLECI || false;
-const buildID = process.env.CIRCLE_WORKFLOW_ID || '0000';
+const buildID = process.env.CIRCLE_BUILD_NUM || '0000';
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -7,7 +7,7 @@ const headless = process.env.SMOKE_HEADLESS || false;
 const remote = process.env.SMOKE_REMOTE || false;
 const ci = process.env.CI || false;
 const usingCircle = process.env.CIRCLECI || false;
-const buildID = process.env.CIRCLE_WORKFLOW_ID || '0000';
+const buildID = process.env.CIRCLE_BUILD_NUM || '0000';
 const {SAUCE_USERNAME, SAUCE_ACCESS_KEY} = process.env;
 const {By, Key, until} = webdriver;
 


### PR DESCRIPTION
### Resolves:

The workflow ID is a long string of characters that isn't particularly useful in identifying which build is being used.

### Changes:

Uses the CIRCLE_BUILD_NUM environment variable instead, which will be a 4 digit number that is findable in CircleCI's UI and easy to associate with the build

### Test Coverage:

Saucelabs tests will present a useful build id during integration tests.
