### PR TITLE
Fix keyboard navigation in "add to studio" modal

### DIFF
--- a/src/components/subnavigation/subnavigation.scss
+++ b/src/components/subnavigation/subnavigation.scss
@@ -12,7 +12,7 @@
     flex-wrap: wrap;
     
 
-    li {
+    li, button {
         display: inline-block;
         margin: 5px;
         border: 1px solid $active-gray;

--- a/src/views/studio/modals/user-projects-modal.jsx
+++ b/src/views/studio/modals/user-projects-modal.jsx
@@ -44,31 +44,31 @@ const UserProjectsModal = ({
                 align="left"
                 className="user-projects-modal-nav"
             >
-                <li
+                <button
                     className={classNames({active: filter === Filters.SHARED})}
                     onClick={() => setFilter(Filters.SHARED)}
                 >
                     <FormattedMessage id="studio.sharedFilter" />
-                </li>
-                <li
+                </button>
+                <button
                     className={classNames({active: filter === Filters.FAVORITED})}
                     onClick={() => setFilter(Filters.FAVORITED)}
                 >
                     <FormattedMessage id="studio.favoritedFilter" />
-                </li>
-                <li
+                </button>
+                <button
                     className={classNames({active: filter === Filters.RECENT})}
                     onClick={() => setFilter(Filters.RECENT)}
                 >
                     <FormattedMessage id="studio.recentFilter" />
-                </li>
+                </button>
                 {showStudentsFilter &&
-                    <li
+                    <button
                         className={classNames({active: filter === Filters.STUDENTS})}
                         onClick={() => setFilter(Filters.STUDENTS)}
                     >
                         <FormattedMessage id="studio.studentsFilter" />
-                    </li>
+                    </button>
                 }
             </SubNavigation>
             <ModalInnerContent className="user-projects-modal-content">

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -13,7 +13,7 @@
     }
     .user-projects-modal-nav {
         padding: 6px 12px;
-        li {
+        button {
             cursor: pointer;
             background: rgba(0, 0, 0, 0.15);
             &.active { background: $ui-blue; }


### PR DESCRIPTION
Keyboard navigation works with interactive HTML elements, like links and buttons. Our subnavigation component expects list items as children, for styling. In many places on www, these list items are wrapped in `<a>` elements, so keyboard navigation does work (e.g. on the "explore" page). 

This change:
- changes the subnavigation styling so it can apply to list items or to buttons
- changes the studio page's "add to studio" modal subnav to use buttons instead of list items, so that keyboard nav can work