### PR TITLE
Bump conference URL one year

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -25,7 +25,7 @@
         "name": "conference-index",
         "pattern": "^/conference/?(\\?.*)?$",
         "routeAlias": "/conference(?!/201[4-9])",
-        "redirect": "/conference/2020"
+        "redirect": "/conference/2021"
     },
     {
         "name": "conference-index-2017",
@@ -82,6 +82,12 @@
     {
         "name": "conference-index-2020",
         "pattern": "^/conference/2020/?$",
+        "routeAlias": "/conference(?!/201[4-9])",
+        "redirect": "/conference/2021"
+    },
+    {
+        "name": "conference-index-2021",
+        "pattern": "^/conference/2021/?$",
         "routeAlias": "/conference(?!/201[4-9])",
         "view": "conference/2020/index/index",
         "title": "Scratch Conferences",


### PR DESCRIPTION
Resolves #5197

To test:

- /conference redirects to /conference/2021
- /conference/2020 redirects to /conference/2021
- /conference/2021 shows the same content as /conference/2020 does currently
- /conference/2019 (and below) still works as it did previously