### PR TITLE
Fix integration test broken in #5476

### DIFF
--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -139,7 +139,7 @@ describe('www-integration footer links', () => {
         await clickText('Scratch Conference');
         let url = await driver.getCurrentUrl();
         let pathname = (new URL(url)).pathname;
-        expect(pathname).toMatch(/^\/conference\/2020\/?$/);
+        expect(pathname).toMatch(/^\/conference\/2021\/?$/);
     });
 
 });


### PR DESCRIPTION
### Resolves:

One of our integration tests depends on /conference/2020, so update to the new date