### PR TITLE
Comment thread limit

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -338,7 +338,7 @@
     "comments.cancel": "Cancel",
     "comments.lengthWarning": "{remainingCharacters, plural, one {1 character left} other {{remainingCharacters} characters left}}",
     "comments.loadMoreReplies": "See more replies",
-    "comments.reachedThreadLimit": "This comment thread has reached its limit. To continue commenting, you can start a new thread.",
+    "comments.replyLimitReached": "This comment thread has reached its limit. To continue commenting, you can start a new thread.",
     "comments.status.delbyusr": "Deleted by project owner",
     "comments.status.censbyfilter": "Censored by filter",
     "comments.status.delbyparentcomment": "Parent comment deleted",

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -338,6 +338,7 @@
     "comments.cancel": "Cancel",
     "comments.lengthWarning": "{remainingCharacters, plural, one {1 character left} other {{remainingCharacters} characters left}}",
     "comments.loadMoreReplies": "See more replies",
+    "comments.reachedThreadLimit": "This comment thread has reached its limit. To continue commenting, you can start a new thread.",
     "comments.status.delbyusr": "Deleted by project owner",
     "comments.status.censbyfilter": "Censored by filter",
     "comments.status.delbyparentcomment": "Parent comment deleted",

--- a/src/views/preview/comment/comment.jsx
+++ b/src/views/preview/comment/comment.jsx
@@ -26,6 +26,7 @@ class Comment extends React.Component {
             'handleConfirmReport',
             'handleCancelReport',
             'handlePostReply',
+            'handleReply',
             'handleToggleReplying',
             'handleRestore',
             'setRef'
@@ -47,6 +48,14 @@ class Comment extends React.Component {
     handlePostReply (comment) {
         this.setState({replying: false});
         this.props.onAddComment(comment);
+    }
+
+    handleReply () {
+        if (this.props.hasReachedThreadLimit) {
+            this.props.onReply(this.props.id, (this.props.parentId || this.props.id));
+        } else {
+            this.handleToggleReplying();
+        }
     }
 
     handleToggleReplying () {
@@ -220,7 +229,7 @@ class Comment extends React.Component {
                             {(canReply && visible) ? (
                                 <span
                                     className="comment-reply"
-                                    onClick={this.handleToggleReplying}
+                                    onClick={this.handleReply}
                                 >
                                     <FormattedMessage id="comments.reply" />
                                 </span>
@@ -278,10 +287,12 @@ Comment.propTypes = {
     canRestore: PropTypes.bool,
     content: PropTypes.string,
     datetimeCreated: PropTypes.string,
+    hasReachedThreadLimit: PropTypes.bool,
     highlighted: PropTypes.bool,
     id: PropTypes.number,
     onAddComment: PropTypes.func,
     onDelete: PropTypes.func,
+    onReply: PropTypes.func,
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
     parentId: PropTypes.number,

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -279,6 +279,15 @@
     }
 }
 
+.thread-limit-status {
+    width: calc(100% - 10rem);
+    margin-left: auto;
+    
+    .comment-status-icon {
+        display: none;
+    }
+}
+
 .compose-disabled {
     opacity: .5;
 }

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -155,7 +155,7 @@ class TopLevelComment extends React.Component {
                 {commentHasReplyStatus(id, id) &&
                     <CommentingStatus className="thread-limit-status">
                         <p>
-                            <FormattedMessage id="comments.reachedThreadLimit" />
+                            <FormattedMessage id="comments.replyLimitReached" />
                         </p>
                     </CommentingStatus>
                 }

--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -63,6 +63,8 @@ class TopLevelComment extends React.Component {
     }
 
     handleReplyStatus (id, parentId) {
+        // Send the parentId up to track which thread got "reply" clicked on
+        if (this.props.onReply) this.props.onReply(parentId);
         this.setState({threadLimitCommentId: id, threadLimitParentId: parentId});
     }
 
@@ -100,6 +102,7 @@ class TopLevelComment extends React.Component {
             onRestore,
             replies,
             postURI,
+            threadHasReplyStatus,
             visibility
         } = this.props;
 
@@ -111,12 +114,17 @@ class TopLevelComment extends React.Component {
         /*
             Check all the following conditions:
             - hasReachedThreadLimit: the thread has reached the limit
+            - threadHasReplyStatus: this thread should be showing the status
+                (false, if the user just clicked reply elsewhere and another thread/comment stole the status message)
             - Use the comment id and parent id of this particular comment in this thread
                 to see if it has the reply status,
                 only one comment in a thread can have the status
+
+            All of these conditions together ensure that the user only sees one status message on the comments page.
         */
         const commentHasReplyStatus = (commentId, commentParentId) =>
             hasReachedThreadLimit &&
+            threadHasReplyStatus &&
             (this.state.threadLimitCommentId === commentId) &&
             (this.state.threadLimitParentId === commentParentId);
 
@@ -235,11 +243,13 @@ TopLevelComment.propTypes = {
     onAddComment: PropTypes.func,
     onDelete: PropTypes.func,
     onLoadMoreReplies: PropTypes.func,
+    onReply: PropTypes.func,
     onReport: PropTypes.func,
     onRestore: PropTypes.func,
     parentId: PropTypes.number,
     postURI: PropTypes.string,
     replies: PropTypes.arrayOf(PropTypes.object),
+    threadHasReplyStatus: PropTypes.bool,
     visibility: PropTypes.string
 };
 
@@ -247,7 +257,8 @@ TopLevelComment.defaultProps = {
     canDeleteWithoutConfirm: false,
     defaultExpanded: false,
     hasThreadLimit: false,
-    moreRepliesToLoad: false
+    moreRepliesToLoad: false,
+    threadHasReplyStatus: false
 };
 
 module.exports = TopLevelComment;

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -69,6 +69,7 @@ const StudioComments = ({
                 }
                 {comments.map(comment => (
                     <TopLevelComment
+                        hasThreadLimit
                         author={comment.author}
                         canDelete={canDeleteComment}
                         canDeleteWithoutConfirm={canDeleteCommentWithoutConfirm}

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {FormattedMessage} from 'react-intl';
@@ -54,6 +54,18 @@ const StudioComments = ({
         if (isAdmin !== wasAdmin) handleResetComments();
     }, [isAdmin]);
 
+    const [replyStatusCommentId, setReplyStatusCommentId] = useState('');
+    
+    const hasReplyStatus = function (comment) {
+        return (
+            comment.parent_id && comment.parent_id === replyStatusCommentId
+        ) || (comment.id === replyStatusCommentId);
+    };
+    
+    const handleReplyStatusChange = function (id) {
+        setReplyStatusCommentId(id);
+    };
+
     return (
         <div>
             <div className="studio-header-container">
@@ -84,10 +96,13 @@ const StudioComments = ({
                         parentId={comment.parent_id}
                         postURI={postURI}
                         replies={replies && replies[comment.id] ? replies[comment.id] : []}
+                        threadHasReplyStatus={hasReplyStatus(comment)}
                         visibility={comment.visibility}
                         onAddComment={handleNewComment}
                         onDelete={handleDeleteComment}
                         onRestore={handleRestoreComment}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onReply={handleReplyStatusChange}
                         onReport={handleReportComment}
                         onLoadMoreReplies={handleLoadMoreReplies}
                     />


### PR DESCRIPTION
### Changes:

Towards the Studios migration work. 

- Introduce a comment thread limit and display messaging when a user tries to add to a comment thread that has reached the limit.
- The user should not see more than one thread limit messaging box on a comments page.

### Test Coverage:

Tested locally.
For easier local testing you might want to adjust the thread limit number.

On the studios page:
- Ensure that clicking reply on a comment thread that has reached the limit displays the blue messaging box.
    - Clicking reply on any comment thread that has reached the limit should display the blue messaging box below the comment the user tried to reply to
    - If there was another open, it should go away.
- Ensure that clicking reply on a comment thread that hasn't reached the limit still displays the comment compose box.

The project page should be unaffected by this work. Ensure that you can continue to reply to comments in threads that have reached or exceeded the limit.