### PR TITLE
Use reply_count to check whether reply limit is reached

### DIFF
--- a/src/views/preview/comment/top-level-comment.jsx
+++ b/src/views/preview/comment/top-level-comment.jsx
@@ -103,13 +103,14 @@ class TopLevelComment extends React.Component {
             replies,
             postURI,
             threadHasReplyStatus,
+            totalReplyCount,
             visibility
         } = this.props;
 
         const parentVisible = visibility === 'visible';
 
         // Check whether this comment thread has reached the thread limit
-        const hasReachedThreadLimit = hasThreadLimit && replies.length >= THREAD_LIMIT;
+        const hasReachedThreadLimit = hasThreadLimit && totalReplyCount >= THREAD_LIMIT;
         
         /*
             Check all the following conditions:
@@ -250,6 +251,7 @@ TopLevelComment.propTypes = {
     postURI: PropTypes.string,
     replies: PropTypes.arrayOf(PropTypes.object),
     threadHasReplyStatus: PropTypes.bool,
+    totalReplyCount: PropTypes.number,
     visibility: PropTypes.string
 };
 

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -102,6 +102,7 @@ const StudioComments = ({
                         postURI={postURI}
                         replies={replies && replies[comment.id] ? replies[comment.id] : []}
                         threadHasReplyStatus={hasReplyStatus(comment)}
+                        totalReplyCount={comment.reply_count}
                         visibility={comment.visibility}
                         onAddComment={handleNewComment}
                         onDelete={handleDeleteComment}


### PR DESCRIPTION
### Resolves:

Resolves an issue found during the bug hunt:

> In studios-playground comments, can add more than 25 replies to a comment
> 
> Steps:
> add 25 replies to a top level comment
> reload page so that replies are hidden like this:
>  ![image2](https://user-images.githubusercontent.com/1786240/120556212-2f576980-c3ca-11eb-8a87-b88fddbad33a.png)
> click reply on the top level comment, or on any reply
> you’ll see the comments form appear normally


### Changes:

Add `totalReplyCount` prop to TopLevelComment component, and pass it in from StudioComments. Use this new prop to check whether thread has reached limit instead of checking only the 20 we load on the first try.

### Test Coverage:

Follow the repro steps described above. In the last step, instead of seeing the comments compose box appear, you should see the reply status box saying that the limit is reached.
