### PR TITLE
Fix reply status box alignment.

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -285,7 +285,7 @@
 }
 
 .thread-limit-status {
-    width: calc(100% - 10rem);
+    width: calc(100% - 4rem);
     margin-left: auto;
     
     .comment-status-icon {


### PR DESCRIPTION
Fixes the alignment of the reply status box which appears when the comment thread limit has been reached. The status box should align with the comment bubbles.

**After this change:**
![image](https://user-images.githubusercontent.com/1786240/120559147-82cbb680-c3ce-11eb-8549-65c4b2428f51.png)
