### PR TITLE
When a user gets muted, update mute status in the session

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -121,6 +121,18 @@ module.exports.refreshSessionWithRetry = () => (dispatch => {
     });
 });
 
+module.exports.updateMuteStatus = muteStatus => ((dispatch, getState) => {
+    const session = getState().session.session;
+    const newSession = {
+        ...session,
+        permissions: {
+            ...session.permissions,
+            mute_status: muteStatus
+        }
+    };
+    dispatch(module.exports.setSession(newSession));
+});
+
 // Selectors
 module.exports.selectIsLoggedIn = state => !!get(state, ['session', 'session', 'user'], false);
 module.exports.selectUsername = state => get(state, ['session', 'session', 'user', 'username'], null);

--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -17,7 +17,7 @@ const formatTime = require('../../../lib/format-time');
 const connect = require('react-redux').connect;
 
 const api = require('../../../lib/api');
-const {selectMuteStatus} = require('../../../redux/session.js');
+const {selectMuteStatus, updateMuteStatus} = require('../../../redux/session.js');
 
 require('./comment.scss');
 
@@ -118,6 +118,7 @@ class ComposeComment extends React.Component {
                     showWarning = body.status.mute_status.showWarning;
                     muteType = body.status.mute_status.currentMessageType;
                     this.setupMuteExpirationTimeout(muteExpiresAtMs);
+                    this.props.dispatch(updateMuteStatus(body.status.mute_status));
                 }
                 // Note: does not reset the message state
                 this.setState({
@@ -425,6 +426,7 @@ class ComposeComment extends React.Component {
 
 ComposeComment.propTypes = {
     commenteeId: PropTypes.number,
+    dispatch: PropTypes.func,
     isReply: PropTypes.bool,
     muteStatus: PropTypes.shape({
         offenses: PropTypes.array,


### PR DESCRIPTION
Previously, if you got muted while in a studio, and then stayed in the studio, the frontend would behave as if you were not muted, because the mute status was not yet in the session. This PR updates the session with the mute status when you get muted.

To test, get muted in a studio that you curate/manage/own and then try to interact with it in other ways.

This change also impacts comments on project pages, so we should double check that the behavior on project pages is the same (or better, but not worse!) For example, the behavior when you try to reply after just getting muted is slightly improved, as it no longer lets you compose.