### PR TITLE
Remove First `decodeURIComponent` In Search Page Query Parsing

### DIFF
--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -59,7 +59,7 @@ class Search extends React.Component {
     componentDidMount () {
         // just in case there's a URL in the wild with pluses to indicate spaces,
         // convert pluses to url-encoded spaces before decoding.
-        const query = decodeURIComponent(window.location.search.split('+').join('%20'));
+        const query = window.location.search.split('+').join('%20');
         let term = query;
 
         const stripQueryValue = function (queryTerm) {


### PR DESCRIPTION
### Resolves:

#5486 

### Changes:

This PR simply removes the first `decodeURIComponent` from the search page. The problem in #5486 was that the query was decoded twice instead of once, and when encoding the search terms back, it only encoded it once. Removing the first `decodeURIComponent` will make it so that it is decoded once and encoded once, to balance this out and prevent failures while searching.

### Test Coverage:

I have not tested this, but this is a fairly simple logic error.



**Note:** I know this issue is not labelled `help wanted`, but it is simple to fix and I did not receive a response when I said I was willing to submit a pull request, so I'm going ahead and doing so.