### PR TITLE
Make the title scroll after a certain length, and long words wrap

### DIFF
--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -113,6 +113,9 @@ $radius: 8px;
     .studio-title {
         font-size: 28px;
         font-weight: 700;
+        word-wrap: break-word;
+        max-height: 8rem;
+        overflow-y: auto;
     }
 
     .studio-description {


### PR DESCRIPTION
When logged out, the title would not wrap long words, and could occupy arbitrarily much space vertically
before 
<img width="348" alt="Screen Shot 2021-06-09 at 14 58 51" src="https://user-images.githubusercontent.com/2855464/121413028-46024100-c933-11eb-8c5e-1d20ba9adf22.png">
after
<img width="413" alt="Screen Shot 2021-06-09 at 15 01 25" src="https://user-images.githubusercontent.com/2855464/121413391-a2fdf700-c933-11eb-9c0c-627c64003da9.png">
