### PR TITLE
Adjust thumbnail css

### DIFF
--- a/src/views/studio/modals/studio-report-modal.scss
+++ b/src/views/studio/modals/studio-report-modal.scss
@@ -75,9 +75,12 @@
     }
 
     .studio-report-tile-image {
-        border-radius: 0.5rem;
-        max-width: 130px;
-        max-height: 100px;
+        width: 150px;
+        height: 98px;
+        border-radius: 4px;
+        background: white;
+        box-sizing: border-box;
+        border: 2px solid rgba(0, 0, 0, 0.15);
     }
 
     .studio-report-selected {

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -151,9 +151,9 @@ $radius: 8px;
     .studio-image {
         width: 300px;
         height: 195px;
-        object-fit: stretch;
         border-radius: 8px;
         background: white;
+        box-sizing: border-box;
         border: 2px solid rgba(0, 0, 0, 0.15);
     }
 

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -150,9 +150,11 @@ $radius: 8px;
 
     .studio-image {
         width: 300px;
-        height: 225px;
-        object-fit: cover;
+        height: 195px;
+        object-fit: stretch;
         border-radius: 8px;
+        background: white;
+        border: 2px solid rgba(0, 0, 0, 0.15);
     }
 
     .studio-follow-button {


### PR DESCRIPTION
Make thumbnails 195 * 300 and stretch to fit to match old studios.
Thumbs have a 15% black 2px border.
Transparent thumbs now have a white background.

Before:
<img width="243" alt="Screen Shot 2021-06-15 at 03 47 45" src="https://user-images.githubusercontent.com/2855464/122014136-deae1c00-cd8c-11eb-8068-5a18ba92c8c7.png">

After:
<img width="337" alt="Screen Shot 2021-06-15 at 03 49 25" src="https://user-images.githubusercontent.com/2855464/122014176-e8d01a80-cd8c-11eb-8a26-ba27a552144f.png">
