### PR TITLE
Admins can view deleted studios

### DIFF
--- a/src/lib/admin-requests.js
+++ b/src/lib/admin-requests.js
@@ -1,0 +1,23 @@
+import {selectIsAdmin, selectToken} from '../redux/session';
+
+/**
+ * Augment an `options` object that will be used by api.js
+ * to automatically include admin authentication token and
+ * /admin url prefix if the user is an admin.
+ *
+ * @param {object} opts Object argument for api.js request
+ * @param {string} opts.uri A uri that may be prefixed with /admin
+ * @param {object} state The full redux state tree to use with session selectors
+ * @returns {object} The augmented options object
+ */
+const withAdmin = (opts, state) => {
+    if (selectIsAdmin(state)) {
+        return Object.assign({}, opts, {
+            uri: `/admin${opts.uri}`,
+            authentication: selectToken(state)
+        });
+    }
+    return opts;
+};
+
+export {withAdmin};

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -26,6 +26,7 @@ const getInitialState = () => ({
     followers: 0,
     managers: 0,
     owner: null,
+    public: null,
 
     // BEWARE: classroomId is only loaded if the user is an educator
     classroomId: null,
@@ -111,6 +112,7 @@ const selectIsFetchingInfo = state => state.studio.infoStatus === Status.FETCHIN
 const selectIsFollowing = state => state.studio.following;
 const selectIsFetchingRoles = state => state.studio.rolesStatus === Status.FETCHING;
 const selectClassroomId = state => state.studio.classroomId;
+const selectStudioPublic = state => state.studio.public;
 
 // Thunks
 const getInfo = () => ((dispatch, getState) => {
@@ -133,7 +135,8 @@ const getInfo = () => ((dispatch, getState) => {
             followers: body.stats.followers,
             managers: body.stats.managers,
             projectCount: body.stats.projects,
-            owner: body.owner
+            owner: body.owner,
+            public: body.public
         }));
     });
 });
@@ -202,5 +205,6 @@ module.exports = {
     selectIsFetchingInfo,
     selectIsFetchingRoles,
     selectIsFollowing,
-    selectClassroomId
+    selectClassroomId,
+    selectStudioPublic
 };

--- a/src/redux/studio.js
+++ b/src/redux/studio.js
@@ -1,4 +1,5 @@
 const keyMirror = require('keymirror');
+const {withAdmin} = require('../lib/admin-requests');
 
 const api = require('../lib/api');
 const log = require('../lib/log');
@@ -113,8 +114,10 @@ const selectClassroomId = state => state.studio.classroomId;
 
 // Thunks
 const getInfo = () => ((dispatch, getState) => {
-    const studioId = selectStudioId(getState());
-    api({uri: `/studios/${studioId}`}, (err, body, res) => {
+    const state = getState();
+    const studioId = selectStudioId(state);
+    const opts = {uri: `/studios/${studioId}`};
+    api(withAdmin(opts, state), (err, body, res) => {
         if (err || typeof body === 'undefined' || res.statusCode !== 200) {
             dispatch(setFetchStatus('infoStatus', Status.ERROR, err));
             return;

--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -6,6 +6,8 @@
     "studio.tabNavCommentsWithCount": "Comments {commentCount}",
     "studio.tabNavActivity": "Activity",
 
+    "studio.showingDeleted": "Showing Deleted Studio",
+
     "studio.title": "Title",
     "studio.description": "Description",
     "studio.thumbnail": "Thumbnail",

--- a/src/views/studio/lib/studio-activity-actions.js
+++ b/src/views/studio/lib/studio-activity-actions.js
@@ -3,6 +3,7 @@ import keyMirror from 'keymirror';
 import api from '../../../lib/api';
 import {activity} from './redux-modules';
 import {selectStudioId} from '../../../redux/studio';
+import {withAdmin} from '../../../lib/admin-requests';
 
 const Errors = keyMirror({
     NETWORK: null,
@@ -27,10 +28,11 @@ const loadActivity = () => ((dispatch, getState) => {
         // the date of the oldest one we've already loaded
         params.dateLimit = items[items.length - 1].datetime_created;
     }
-    api({
+    const opts = {
         uri: `/studios/${studioId}/activity/`,
         params
-    }, (err, body, res) => {
+    };
+    api(withAdmin(opts, state), (err, body, res) => {
         const error = normalizeError(err, body, res);
         if (error) return dispatch(activity.actions.error(error));
         const ids = items.map(item => item.id);

--- a/src/views/studio/lib/studio-member-actions.js
+++ b/src/views/studio/lib/studio-member-actions.js
@@ -4,6 +4,7 @@ import api from '../../../lib/api';
 import {curators, managers} from './redux-modules';
 import {selectUsername} from '../../../redux/session';
 import {selectStudioId, setRoles, setInfo} from '../../../redux/studio';
+import {withAdmin} from '../../../lib/admin-requests';
 
 const Errors = keyMirror({
     NETWORK: null,
@@ -40,10 +41,11 @@ const loadManagers = () => ((dispatch, getState) => {
     const studioId = selectStudioId(state);
     const managerCount = managers.selector(state).items.length;
     const managersPerPage = 20;
-    api({
+    const opts = {
         uri: `/studios/${studioId}/managers/`,
         params: {limit: managersPerPage, offset: managerCount}
-    }, (err, body, res) => {
+    };
+    api(withAdmin(opts, state), (err, body, res) => {
         const error = normalizeError(err, body, res);
         if (error) return dispatch(managers.actions.error(error));
         dispatch(managers.actions.append(body, body.length === managersPerPage));
@@ -55,10 +57,11 @@ const loadCurators = () => ((dispatch, getState) => {
     const studioId = selectStudioId(state);
     const curatorCount = curators.selector(state).items.length;
     const curatorsPerPage = 20;
-    api({
+    const opts = {
         uri: `/studios/${studioId}/curators/`,
         params: {limit: curatorsPerPage, offset: curatorCount}
-    }, (err, body, res) => {
+    };
+    api(withAdmin(opts, state), (err, body, res) => {
         const error = normalizeError(err, body, res);
         if (error) return dispatch(curators.actions.error(error));
         dispatch(curators.actions.append(body, body.length === curatorsPerPage));

--- a/src/views/studio/lib/studio-project-actions.js
+++ b/src/views/studio/lib/studio-project-actions.js
@@ -1,4 +1,5 @@
 import keyMirror from 'keymirror';
+import {withAdmin} from '../../../lib/admin-requests';
 import api from '../../../lib/api';
 
 import {selectToken} from '../../../redux/session';
@@ -32,10 +33,11 @@ const loadProjects = () => ((dispatch, getState) => {
     const studioId = selectStudioId(state);
     const projectCount = projects.selector(state).items.length;
     const projectsPerPage = 20;
-    api({
+    const opts = {
         uri: `/studios/${studioId}/projects/`,
         params: {limit: projectsPerPage, offset: projectCount}
-    }, (err, body, res) => {
+    };
+    api(withAdmin(opts, state), (err, body, res) => {
         const error = normalizeError(err, body, res);
         if (error) return dispatch(projects.actions.error(error));
         dispatch(projects.actions.append(body, body.length === projectsPerPage));

--- a/src/views/studio/studio-deleted.jsx
+++ b/src/views/studio/studio-deleted.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {FormattedMessage} from 'react-intl';
+import {selectStudioPublic} from '../../redux/studio';
+
+const StudioDeleted = ({deleted}) => {
+    if (!deleted) return null;
+    return (<div className="studio-deleted studio-info-box studio-info-box-error">
+        <FormattedMessage id="studio.showingDeleted" />
+    </div>);
+};
+
+StudioDeleted.propTypes = {
+    deleted: PropTypes.bool
+};
+
+export default connect(
+    state => ({
+        deleted: selectStudioPublic(state) === false
+    })
+)(StudioDeleted);

--- a/src/views/studio/studio-info.jsx
+++ b/src/views/studio/studio-info.jsx
@@ -10,15 +10,11 @@ import StudioStats from './studio-stats.jsx';
 import StudioTitle from './studio-title.jsx';
 
 import {selectIsLoggedIn} from '../../redux/session';
-import {getInfo, getRoles} from '../../redux/studio';
+import {getRoles} from '../../redux/studio';
 
 const StudioInfo = ({
-    isLoggedIn, onLoadInfo, onLoadRoles
+    isLoggedIn, onLoadRoles
 }) => {
-    useEffect(() => { // Load studio info after first render
-        onLoadInfo();
-    }, []);
-
     useEffect(() => { // Load roles info once the user is logged in is available
         if (isLoggedIn) onLoadRoles();
     }, [isLoggedIn]);
@@ -43,7 +39,6 @@ const StudioInfo = ({
 
 StudioInfo.propTypes = {
     isLoggedIn: PropTypes.bool,
-    onLoadInfo: PropTypes.func,
     onLoadRoles: PropTypes.func
 };
 
@@ -52,7 +47,6 @@ export default connect(
         isLoggedIn: selectIsLoggedIn(state)
     }),
     {
-        onLoadInfo: getInfo,
         onLoadRoles: getRoles
     }
 )(StudioInfo);

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {
     BrowserRouter as Router,
     Switch,
@@ -34,20 +34,25 @@ import {
     userProjects
 } from './lib/redux-modules';
 
-const {getInitialState, studioReducer, selectStudioLoadFailed} = require('../../redux/studio');
+const {getInitialState, studioReducer, selectStudioLoadFailed, getInfo} = require('../../redux/studio');
 const {studioReportReducer} = require('../../redux/studio-report');
 const {commentsReducer} = require('../../redux/comments');
 const {studioMutationsReducer} = require('../../redux/studio-mutations');
 
 import './studio.scss';
-import {selectMuteStatus} from '../../redux/session.js';
+import {selectIsAdmin, selectMuteStatus} from '../../redux/session.js';
 import {formatRelativeTime} from '../../lib/format-time.js';
 import CommentingStatus from '../../components/commenting-status/commenting-status.jsx';
 import {FormattedMessage} from 'react-intl';
 import {selectShowCuratorMuteError} from '../../redux/studio-permissions.js';
 
-const StudioShell = ({showCuratorMuteError, muteExpiresAtMs, studioLoadFailed}) => {
+const StudioShell = ({isAdmin, showCuratorMuteError, muteExpiresAtMs, studioLoadFailed, onLoadInfo}) => {
     const match = useRouteMatch();
+
+    useEffect(() => {
+        onLoadInfo();
+    }, [isAdmin]); // Reload any time isAdmin changes to allow admins to view deleted studios
+
     return (
         studioLoadFailed ?
             <NotAvailable /> :
@@ -101,17 +106,23 @@ const StudioShell = ({showCuratorMuteError, muteExpiresAtMs, studioLoadFailed}) 
 };
 
 StudioShell.propTypes = {
+    isAdmin: PropTypes.bool,
     showCuratorMuteError: PropTypes.bool,
     muteExpiresAtMs: PropTypes.number,
-    studioLoadFailed: PropTypes.bool
+    studioLoadFailed: PropTypes.bool,
+    onLoadInfo: PropTypes.func
 };
 
 const ConnectedStudioShell = connect(
     state => ({
         showCuratorMuteError: selectShowCuratorMuteError(state),
         studioLoadFailed: selectStudioLoadFailed(state),
-        muteExpiresAtMs: (selectMuteStatus(state).muteExpiresAt * 1000 || 0)
+        muteExpiresAtMs: (selectMuteStatus(state).muteExpiresAt * 1000 || 0),
+        isAdmin: selectIsAdmin(state)
     }),
+    {
+        onLoadInfo: getInfo
+    }
 )(StudioShell);
 
 render(

--- a/src/views/studio/studio.jsx
+++ b/src/views/studio/studio.jsx
@@ -25,6 +25,7 @@ import StudioActivity from './studio-activity.jsx';
 import StudioCuratorInvite from './studio-curator-invite.jsx';
 import StudioMeta from './studio-meta.jsx';
 import StudioAdminPanel from './studio-admin-panel.jsx';
+import StudioDeleted from './studio-deleted.jsx';
 
 import {
     projects,
@@ -57,6 +58,7 @@ const StudioShell = ({isAdmin, showCuratorMuteError, muteExpiresAtMs, studioLoad
         studioLoadFailed ?
             <NotAvailable /> :
             <div className="studio-shell">
+                <StudioDeleted />
                 <StudioMeta />
                 <div className="studio-info">
                     <StudioInfo />

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -46,6 +46,13 @@ $radius: 8px;
     }
 }
 
+.studio-deleted {
+    /* Always make this box take up all the columns */
+    grid-column: 1 / -1;
+    padding: 1rem;
+    box-sizing: border-box;
+}
+
 .studio-info {
     justify-self: center;
     width: 300px;


### PR DESCRIPTION
This PR allows admins to view studios that have been deleted.

1. Add the `withAdmin()` helper to API requests for studio info, curators, managers, projects and activity feed. This will add the `/admin` prefix to the URL and the `authentication: token` property if the user is an admin. Comments already do this. 
2. Move the `getInfo` call up from the studio info component to the top level component, and make it rerun if `isAdmin` changes. This is because we show the `oops` page if you get a 404 for studio info, which prevents StudioInfo from re-rendering on isAdmin changes. 

One thing to note: in order to get data rendered as fast as possible, the studio info request does not wait for the session to be fetched first. This means studio info will always be fetched as a normal user first, and then re-fetched if the session comes back and the user is an admin. If you are viewing a deleted studio, this means you'll see the "oops" 404 page flash and then once the session comes back it'll re-render. 

You'll need the corresponding api PR pulled (or merged) before being able to use this locally.