### PR TITLE
Studio creators and managers can delete their own comments

### DIFF
--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -20,9 +20,11 @@ const selectShowCommentComposer = state => selectIsSocial(state);
 const selectCanReportComment = state => selectIsSocial(state);
 const selectCanRestoreComment = state => selectIsAdmin(state);
 // On the project page, project owners can delete comments with a confirmation,
-// and admins can delete comments without a confirmation. For now, only admins
-// can delete studio comments, so the following two are the same.
-const selectCanDeleteComment = state => selectIsAdmin(state);
+// and admins can delete comments without a confirmation.
+// On the studio page, studio creators and managers have the ability to delete *their own* comments with confirmation.
+// Admins can delete comments without a confirmation.
+const selectCanDeleteAnyComment = state => selectIsAdmin(state);
+const selectCanDeleteOwnComment = state => isCreator(state) || isManager(state);
 const selectCanDeleteCommentWithoutConfirm = state => selectIsAdmin(state);
 
 const selectCanFollowStudio = state => selectIsLoggedIn(state);
@@ -77,7 +79,8 @@ export {
     selectCanAddProjects,
     selectCanFollowStudio,
     selectShowCommentComposer,
-    selectCanDeleteComment,
+    selectCanDeleteAnyComment,
+    selectCanDeleteOwnComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
     selectCanRestoreComment,

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -10,10 +10,11 @@ import studioCommentActions from '../../redux/studio-comment-actions.js';
 import StudioCommentsAllowed from './studio-comments-allowed.jsx';
 import StudioCommentsNotAllowed from './studio-comments-not-allowed.jsx';
 
-import {selectIsAdmin, selectHasFetchedSession} from '../../redux/session';
+import {selectIsAdmin, selectHasFetchedSession, selectUsername} from '../../redux/session';
 import {
     selectShowCommentComposer,
-    selectCanDeleteComment,
+    selectCanDeleteAnyComment,
+    selectCanDeleteOwnComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
     selectCanRestoreComment,
@@ -32,7 +33,9 @@ const StudioComments = ({
     replies,
     postURI,
     shouldShowCommentComposer,
-    canDeleteComment,
+    username,
+    canDeleteAnyComment,
+    canDeleteOwnComment,
     canDeleteCommentWithoutConfirm,
     canEditCommentsAllowed,
     canReportComment,
@@ -88,7 +91,7 @@ const StudioComments = ({
                     <TopLevelComment
                         hasThreadLimit
                         author={comment.author}
-                        canDelete={canDeleteComment}
+                        canDelete={canDeleteAnyComment || (canDeleteOwnComment && comment.author.username === username)}
                         canDeleteWithoutConfirm={canDeleteCommentWithoutConfirm}
                         canReply={shouldShowCommentComposer}
                         canReport={canReportComment}
@@ -136,7 +139,9 @@ StudioComments.propTypes = {
     moreCommentsToLoad: PropTypes.bool,
     replies: PropTypes.shape({}),
     shouldShowCommentComposer: PropTypes.bool,
-    canDeleteComment: PropTypes.bool,
+    username: PropTypes.string,
+    canDeleteAnyComment: PropTypes.bool,
+    canDeleteOwnComment: PropTypes.bool,
     canDeleteCommentWithoutConfirm: PropTypes.bool,
     canEditCommentsAllowed: PropTypes.bool,
     canReportComment: PropTypes.bool,
@@ -160,9 +165,11 @@ export default connect(
         isAdmin: selectIsAdmin(state),
         moreCommentsToLoad: state.comments.moreCommentsToLoad,
         replies: state.comments.replies,
+        username: selectUsername(state),
         commentsAllowed: selectStudioCommentsAllowed(state),
         shouldShowCommentComposer: selectShowCommentComposer(state),
-        canDeleteComment: selectCanDeleteComment(state),
+        canDeleteAnyComment: selectCanDeleteAnyComment(state),
+        canDeleteOwnComment: selectCanDeleteOwnComment(state),
         canDeleteCommentWithoutConfirm: selectCanDeleteCommentWithoutConfirm(state),
         canEditCommentsAllowed: selectCanEditCommentsAllowed(state),
         canReportComment: selectCanReportComment(state),

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -2,7 +2,8 @@ import {
     selectCanEditInfo,
     selectCanAddProjects,
     selectShowCommentComposer,
-    selectCanDeleteComment,
+    selectCanDeleteAnyComment,
+    selectCanDeleteOwnComment,
     selectCanDeleteCommentWithoutConfirm,
     selectCanReportComment,
     selectCanRestoreComment,
@@ -195,7 +196,7 @@ describe('studio comments', () => {
         });
     });
 
-    describe('can delete comment', () => {
+    describe('can delete any comment', () => {
         test.each([
             ['admin', true],
             ['curator', false],
@@ -208,7 +209,26 @@ describe('studio comments', () => {
             ['muted logged in', false]
         ])('%s: %s', (role, expected) => {
             setStateByRole(role);
-            expect(selectCanDeleteComment(state)).toBe(expected);
+            expect(selectCanDeleteAnyComment(state)).toBe(expected);
+        });
+    });
+
+    describe('can delete own comment', () => {
+        test.each([
+            ['admin', false], // This is false here because we check for `canDeleteAnyComment` separately
+            ['curator', false],
+            ['manager', true],
+            ['creator', true],
+            ['logged in', false],
+            ['unconfirmed', false],
+            ['logged out', false],
+            ['muted creator', true],
+            ['muted manager', true],
+            ['muted curator', false],
+            ['muted logged in', false]
+        ])('%s: %s', (role, expected) => {
+            setStateByRole(role);
+            expect(selectCanDeleteOwnComment(state)).toBe(expected);
         });
     });
 


### PR DESCRIPTION
### Resolves:

Updates comment deletion permissions for studios to match existing studio behavior.

### Changes:

Studio creators and managers can delete their own comments on a studio.

### Test Coverage:

Updated the studio permissions test.

Tested locally including with teacher accounts.
