### PR TITLE
Studio single comment view

### DIFF
--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -3,7 +3,7 @@ const eachLimit = require('async/eachLimit');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const COMMENT_LIMIT = 20;
+const COMMENT_LIMIT = 25;
 
 const {
     addNewComment,

--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -3,7 +3,7 @@ const eachLimit = require('async/eachLimit');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const COMMENT_LIMIT = 25;
+const COMMENT_LIMIT = 20;
 
 const {
     addNewComment,

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -41,11 +41,27 @@ const StudioComments = ({
     handleRestoreComment,
     handleResetComments,
     handleReportComment,
-    handleLoadMoreReplies
+    handleLoadMoreReplies,
+    handleLoadSingleComment
 }) => {
+    const commentHashPrefix = '#comments-';
+    const [singleCommentId, setSingleCommentId] = useState(
+        window.location.hash.indexOf(commentHashPrefix) !== -1 &&
+        parseInt(window.location.hash.replace(commentHashPrefix, ''), 10));
+
     useEffect(() => {
+        if (singleCommentId) {
+            handleLoadSingleComment(singleCommentId);
+            return;
+        }
         if (comments.length === 0 && hasFetchedSession) handleLoadMoreComments();
-    }, [comments.length === 0, hasFetchedSession]);
+    }, [comments.length === 0, hasFetchedSession, singleCommentId]);
+
+    const handleSeeAllComments = () => {
+        setSingleCommentId(false);
+        history.pushState('', document.title, window.location.pathname + window.location.search);
+        handleResetComments();
+    };
 
     // The comments you see depend on your admin status
     // so reset them if isAdmin changes.
@@ -95,6 +111,7 @@ const StudioComments = ({
                         canRestore={canRestoreComment}
                         content={comment.content}
                         datetimeCreated={comment.datetime_created}
+                        highlightedCommentId={singleCommentId}
                         id={comment.id}
                         key={comment.id}
                         moreRepliesToLoad={comment.moreRepliesToLoad}
@@ -113,6 +130,15 @@ const StudioComments = ({
                         onLoadMoreReplies={handleLoadMoreReplies}
                     />
                 ))}
+                {!!singleCommentId &&
+                    <Button
+                        className="button load-more-button"
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onClick={handleSeeAllComments}
+                    >
+                        <FormattedMessage id="general.seeAllComments" />
+                    </Button>
+                }
                 {moreCommentsToLoad &&
                     <Button
                         className="button load-more-button"
@@ -146,6 +172,7 @@ StudioComments.propTypes = {
     handleReportComment: PropTypes.func,
     handleResetComments: PropTypes.func,
     handleLoadMoreReplies: PropTypes.func,
+    handleLoadSingleComment: PropTypes.func,
     postURI: PropTypes.string
 };
 
@@ -171,6 +198,7 @@ export default connect(
     }),
     {
         handleLoadMoreComments: studioCommentActions.getTopLevelComments,
+        handleLoadSingleComment: studioCommentActions.getCommentById,
         handleNewComment: studioCommentActions.addNewComment,
         handleDeleteComment: studioCommentActions.deleteComment,
         handleRestoreComment: studioCommentActions.restoreComment,

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -111,6 +111,7 @@ const StudioComments = ({
                         canRestore={canRestoreComment}
                         content={comment.content}
                         datetimeCreated={comment.datetime_created}
+                        defaultExpanded={singleCommentId}
                         highlightedCommentId={singleCommentId}
                         id={comment.id}
                         key={comment.id}

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -50,11 +50,13 @@ const StudioComments = ({
         parseInt(window.location.hash.replace(commentHashPrefix, ''), 10));
 
     useEffect(() => {
-        if (singleCommentId) {
-            handleLoadSingleComment(singleCommentId);
-            return;
+        if (comments.length === 0 && hasFetchedSession) {
+            if (singleCommentId) {
+                handleLoadSingleComment(singleCommentId);
+            } else {
+                handleLoadMoreComments();
+            }
         }
-        if (comments.length === 0 && hasFetchedSession) handleLoadMoreComments();
     }, [comments.length === 0, hasFetchedSession, singleCommentId]);
 
     const handleSeeAllComments = () => {

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -471,6 +471,10 @@ $radius: 8px;
 
 .studio-compose-container {
     padding-top: 8px;
+
+    .load-more-button {
+        width: 100%;
+    }
 }
 
 .studio-comments-not-allowed {


### PR DESCRIPTION
Add the ability to load a view of the studio page showing a single comment. This happens when you receive a message notifying you of someone's reply to a comment that you made on a studio. The link in the message has a comment id in the URL. The page loads only the thread containing this comment, highlights the comment, and scrolls to it. A button lets you view the full set of comments. This should match the functionality of single comment view on the project page.