### PR TITLE
Switch studios route to real version for testing on staging

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -304,10 +304,10 @@
     },
     {
         "name": "studio",
-        "pattern": "^/studios-playground/\\d+(/projects|/curators|/activity|/comments)?/?(\\?.*)?$",
-        "routeAlias": "/studios-playground/?$",
+        "pattern": "^/studios/\\d+(/projects|/curators|/activity|/comments)?/?(\\?.*)?$",
+        "routeAlias": "/studios/?$",
         "view": "studio/studio",
-        "title": "Studio Playground",
+        "title": "Scratch Studio",
         "dynamicMetaTags": true
     },
     {


### PR DESCRIPTION
We need to switch the studios playground route to the real /studios/ route in order to do more realistic testing. We'll need to make sure we aren't accidentally stomping on any other backend route that still exists at /studios/... (I'm combing through scratchr2 now)

Since this PR is likely to be reverted after testing to unblock other deploys, just a note @BryceLTaylor if we need to unroll this from staging we'll have to manually clear out the route (reverting/re-deploying won't clear out an old route per @rschamp). 