### PR TITLE
Style fixes for "add to studio" modal

### DIFF
--- a/src/views/studio/modals/user-projects-modal.jsx
+++ b/src/views/studio/modals/user-projects-modal.jsx
@@ -20,6 +20,7 @@ import './user-projects-modal.scss';
 import {selectIsEducator} from '../../../redux/session';
 import AlertProvider from '../../../components/alert/alert-provider.jsx';
 import Alert from '../../../components/alert/alert.jsx';
+import Spinner from '../../../components/spinner/spinner.jsx';
 
 const UserProjectsModal = ({
     items, error, loading, moreToLoad, showStudentsFilter,
@@ -77,7 +78,7 @@ const UserProjectsModal = ({
                 <AlertProvider>
                     {error && <div>Error loading {filter}: {error}</div>}
                     <Alert className="studio-alert" />
-                    {items.length > 0 ? (
+                    {items.length > 0 &&
                         <React.Fragment>
                             <div className="user-projects-modal-grid">
                                 {items.map(project => (
@@ -105,7 +106,8 @@ const UserProjectsModal = ({
                                 </div>
                             }
                         </React.Fragment>
-                    ) :
+                    }
+                    {!loading && items.length === 0 &&
                         <div className="studio-projects-empty">
                             <img
                                 src="/svgs/studio/add-to-studio-empty.svg"
@@ -121,6 +123,12 @@ const UserProjectsModal = ({
                                     <FormattedMessage id="studio.addProjects.noStudentsYet" />}
                             </div>
                         </div>
+                    }
+                    {loading &&
+                        <Spinner
+                            className="studio-projects-spinner"
+                            color="blue"
+                        />
                     }
                 </AlertProvider>
             </ModalInnerContent>

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -52,6 +52,7 @@
         display: flex;
         justify-content: flex-end;
         padding: 6px 12px;
+        border-top: 1px solid $active-gray;
     }
 
     .studio-projects-empty {

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -22,12 +22,11 @@
     .user-projects-modal-content {
         padding: 0 30px 30px;
         background: #E9F1FC;
-        max-height: calc(100vh - 270px);
-        min-height: 300px;
+        height: calc(100vh - 300px);
         overflow-y: auto;
         overscroll-behavior: contain;
         @media #{$intermediate-and-smaller} {
-            & { max-height: calc(100vh - 175px); }
+            & { height: calc(100vh - 170px); }
         }
     }
 

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -13,10 +13,24 @@
     }
     .user-projects-modal-nav {
         padding: 6px 12px;
+        border-bottom: 1px solid $active-gray;
+        width: unset;
         button {
             cursor: pointer;
-            background: rgba(0, 0, 0, 0.15);
-            &.active { background: $ui-blue; }
+            background: white;
+            border: 1px solid rgba(0, 0, 0, 0.15);
+            color: #575e75;
+            &.active { 
+                background: $ui-blue; 
+                color: white;
+            }
+            &:active {
+                padding: .75em 1.5em;
+            }
+        }
+        button:hover {
+            background: $ui-blue-25percent;
+            border: 1px solid $ui-blue-10percent;
         }
     }
     .user-projects-modal-content {

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -34,7 +34,7 @@
         }
     }
     .user-projects-modal-content {
-        padding: 0 30px 30px;
+        padding: 0 30px 8px;
         background: #E9F1FC;
         height: calc(100vh - 300px);
         overflow-y: auto;

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -55,6 +55,10 @@
         line-height: 1.5rem;
         margin-top: 1rem;
     }
+
+    .studio-projects-spinner {
+        margin: auto;
+    }
 }
 
 .studio-tile-added {

--- a/src/views/studio/modals/user-projects-modal.scss
+++ b/src/views/studio/modals/user-projects-modal.scss
@@ -45,13 +45,14 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        margin: 4rem;
+        margin: auto;
     }
 
     .studio-projects-empty-text {
         color: hsla(215, 100, 65, .75);
-        width: 325px;
+        max-width: 325px;
         text-align: center;
+        line-height: 1.5rem;
         margin-top: 1rem;
     }
 }


### PR DESCRIPTION
Styling fixes for the "add to studio" modal:
- Add loading spinner
- Improved responsive sizing: modal has same responsive height regardless of content
- Improved layout of empty state content
- Improved text color contrast on nav buttons to match studio nav buttons
- Removed extra padding below "load more" button
- Add faint gray border at top and bottom of scroll area
