### PR TITLE
Fix admin panel space remaining after logging out

### DIFF
--- a/src/views/studio/studio-admin-panel.jsx
+++ b/src/views/studio/studio-admin-panel.jsx
@@ -48,8 +48,11 @@ const StudioAdminPanel = ({studioId, showAdminPanel}) => {
     const [adminPanelOpen, setAdminPanelOpen] = useState(getAdminPanelOpen());
 
     useEffect(() => {
-        storeAdminPanelOpen(adminPanelOpen);
-    }, [adminPanelOpen]);
+        // This effect will both keep localStorage up-to-date AND cause
+        // the spacing to change to allow for the open admin panel, so make
+        // sure the admin panel should be visible at all before making any changes.
+        if (showAdminPanel) storeAdminPanelOpen(adminPanelOpen);
+    }, [showAdminPanel, adminPanelOpen]);
 
     useEffect(() => {
         if (!showAdminPanel) return;

--- a/test/unit/components/studio-admin-panel.test.jsx
+++ b/test/unit/components/studio-admin-panel.test.jsx
@@ -39,6 +39,20 @@ describe('Studio comments', () => {
             expect(child.prop('isOpen')).toBe(false);
         });
     });
+    describe('non admins', () => {
+        test('should not have localStorage set with a false value', () => {
+            mountWithIntl(<StudioAdminPanel showAdminPanel={false} />);
+            expect(global.localStorage.getItem(adminPanelOpenKey)).toBe(null);
+        });
+        test('should not have css class set even if localStorage contains open key', () => {
+            // Regression test for situation where admin logs out but localStorage still
+            // contains "open", causing extra space to appear
+            global.localStorage.setItem(adminPanelOpenKey, 'open');
+            const component = mountWithIntl(<StudioAdminPanel showAdminPanel={false} />);
+            const child = component.find(AdminPanel);
+            expect(viewEl.classList.contains(adminPanelOpenClass)).toBe(false);
+        });
+    });
     test('calling onOpen sets a class on the #viewEl and records in local storage', () => {
         const component = mountWithIntl(<StudioAdminPanel showAdminPanel />);
         let child = component.find(AdminPanel);

--- a/test/unit/components/studio-admin-panel.test.jsx
+++ b/test/unit/components/studio-admin-panel.test.jsx
@@ -48,8 +48,7 @@ describe('Studio comments', () => {
             // Regression test for situation where admin logs out but localStorage still
             // contains "open", causing extra space to appear
             global.localStorage.setItem(adminPanelOpenKey, 'open');
-            const component = mountWithIntl(<StudioAdminPanel showAdminPanel={false} />);
-            const child = component.find(AdminPanel);
+            mountWithIntl(<StudioAdminPanel showAdminPanel={false} />);
             expect(viewEl.classList.contains(adminPanelOpenClass)).toBe(false);
         });
     });


### PR DESCRIPTION
We were incorrectly calling the `storeAdminPanelOpen` function any time the studio page was rendered, even if the user wasn't an admin. This caused two issues:
1. Non-admin users got a value of `{adminPanelToggled_studios: 'closed'}` set in localstorage, even if they weren't an admin. Nobody really noticed this, but we shouldn't be storing things in localstorage that users don't need (even if they aren't technically "false", just unapplicable).
2. Admin users who had the admin panel open and then logged out would still see the space where the admin panel would go, because `storeAdminPanelOpen` would cause the CSS class to be applied. It wasn't checking if the admin panel should even be rendered at all.

I put in tests for both of these and fixed the issue with a one line change.