### PR TITLE
Only show reply button when comments are allowed on a studio

### DIFF
--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -130,7 +130,7 @@ const StudioComments = ({
                             canDelete={canDeleteAnyComment ||
                                 (canDeleteOwnComment && comment.author.username === username)}
                             canDeleteWithoutConfirm={canDeleteCommentWithoutConfirm}
-                            canReply={shouldShowCommentComposer}
+                            canReply={shouldShowCommentComposer && commentsAllowed}
                             canReport={canReportComment}
                             canRestore={canRestoreComment}
                             content={comment.content}


### PR DESCRIPTION
Fixes an issue where comments still showed the `reply` button in studios even if the studio owner had turned off comments. This is inconsistent with the project page and would cause some confusion (even though trying to submit a comment _does_ return an appropriate message).