### PR TITLE
Update the reply_count when you leave a reply

### DIFF
--- a/src/redux/comments.js
+++ b/src/redux/comments.js
@@ -70,8 +70,9 @@ module.exports.commentsReducer = (state, action) => {
             return Object.assign({}, state, {
                 replies: Object.assign({}, state.replies, {
                     // Replies to comments go at the end  of the thread
-                    [action.topLevelCommentId]: (
-                        state.replies[action.topLevelCommentId] || []).concat(action.comment)
+                    [action.topLevelCommentId]:
+                        (state.replies[action.topLevelCommentId] || [])
+                            .concat(action.comment)
                 }),
                 comments: state.comments.map(comment => {
                     if (comment.id === action.topLevelCommentId) {

--- a/src/redux/comments.js
+++ b/src/redux/comments.js
@@ -70,7 +70,16 @@ module.exports.commentsReducer = (state, action) => {
             return Object.assign({}, state, {
                 replies: Object.assign({}, state.replies, {
                     // Replies to comments go at the end  of the thread
-                    [action.topLevelCommentId]: state.replies[action.topLevelCommentId].concat(action.comment)
+                    [action.topLevelCommentId]: (
+                        state.replies[action.topLevelCommentId] || []).concat(action.comment)
+                }),
+                comments: state.comments.map(comment => {
+                    if (comment.id === action.topLevelCommentId) {
+                        return Object.assign({}, comment, {
+                            reply_count: comment.reply_count + 1
+                        });
+                    }
+                    return comment;
                 })
             });
         }

--- a/test/unit-legacy/redux/comments-test.js
+++ b/test/unit-legacy/redux/comments-test.js
@@ -43,9 +43,9 @@ tap.test('setComments', t => {
 
 const commentState = {
     comments: [
-        {id: 'id1', visibility: 'visible'},
-        {id: 'id2', visibility: 'visible'},
-        {id: 'id3', visibility: 'visible'}
+        {id: 'id1', visibility: 'visible', reply_count: 2},
+        {id: 'id2', visibility: 'visible', reply_count: 0},
+        {id: 'id3', visibility: 'visible', reply_count: 0}
     ],
     replies: {
         id1: [
@@ -108,6 +108,12 @@ tap.test('addNewComment, reply comment', t => {
     state = reducer(commentState, Comments.addNewComment({id: 'new comment'}, 'id1'));
     // Adds replies to the end of the replies list
     t.equal(state.replies.id1[2].id, 'new comment');
+    t.equal(state.comments[0].reply_count, 3);
+
+    // Also check a top-level comment that doesn't have replies yet
+    state = reducer(commentState, Comments.addNewComment({id: 'new comment2'}, 'id2'));
+    t.equal(state.replies.id2[0].id, 'new comment2');
+    t.equal(state.comments[1].reply_count, 1);
     t.end();
 });
 


### PR DESCRIPTION
This resolves issues where things that rely on a `comment.reply_count` won't work correctly after the user has left one or more replies to a thread.

Added a couple tests for this, which also uncovered an issue where calling `addNewComment` before initializing the reply array `replies[id] = [];` would cause an error. This currently doesn't happens because we always call `setReplies()` on every top level comment, but if we stop calling setReplies, e.g. in https://github.com/LLK/scratch-www/pull/5630, replying to a top level comment that didn't have replies already wouldn't work. Glad we caught this, since it didn't come up in that PR. 