### PR TITLE
Revert "Only request replies if reply_count > 0"

### DIFF
--- a/src/redux/project-comment-actions.js
+++ b/src/redux/project-comment-actions.js
@@ -69,10 +69,8 @@ const getTopLevelComments = (id, offset, ownerUsername, isAdmin, token) => (disp
         }
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments(body));
-        const commentsWithReplies = body.filter(comment => comment.reply_count > 0);
-        if (commentsWithReplies.length > 0) {
-            dispatch(getReplies(id, commentsWithReplies.map(comment => comment.id), 0, ownerUsername, isAdmin, token));
-        }
+        dispatch(getReplies(id, body.map(comment => comment.id), 0, ownerUsername, isAdmin, token));
+
         // If we loaded a full page of comments, assume there are more to load.
         // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
         // any more server query complexity, so seems worth it. In the case of a project with
@@ -107,9 +105,7 @@ const getCommentById = (projectId, commentId, ownerUsername, isAdmin, token) => 
         // If the comment is not a reply, show it as top level and load replies
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments([body]));
-        if (body.reply_count > 0) {
-            dispatch(getReplies(projectId, [body.id], 0, ownerUsername, isAdmin, token));
-        }
+        dispatch(getReplies(projectId, [body.id], 0, ownerUsername, isAdmin, token));
     });
 });
 

--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -90,10 +90,7 @@ const getTopLevelComments = () => ((dispatch, getState) => {
         }
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments(body));
-        const commentsWithReplies = body.filter(comment => comment.reply_count > 0);
-        if (commentsWithReplies.length > 0) {
-            dispatch(getReplies(commentsWithReplies.map(comment => comment.id), 0));
-        }
+        dispatch(getReplies(body.map(comment => comment.id), 0));
 
         // If we loaded a full page of comments, assume there are more to load.
         // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
@@ -133,9 +130,7 @@ const getCommentById = commentId => ((dispatch, getState) => {
         // If the comment is not a reply, show it as top level and load replies
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments([body]));
-        if (body.reply_count > 0) {
-            dispatch(getReplies(body.id, 0));
-        }
+        dispatch(getReplies(body.id, 0));
     });
 });
 


### PR DESCRIPTION
Reverts LLK/scratch-www#5630 due to a bug found in the bug hunt where the single comment view only shows the top-level comment for the reply that is linked, as opposed to the reply itself.