### PR TITLE
Reduce reply requests, for real this time I promise

### DIFF
--- a/src/redux/project-comment-actions.js
+++ b/src/redux/project-comment-actions.js
@@ -69,8 +69,10 @@ const getTopLevelComments = (id, offset, ownerUsername, isAdmin, token) => (disp
         }
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments(body));
-        dispatch(getReplies(id, body.map(comment => comment.id), 0, ownerUsername, isAdmin, token));
-
+        const commentsWithReplies = body.filter(comment => comment.reply_count > 0);
+        if (commentsWithReplies.length > 0) {
+            dispatch(getReplies(id, commentsWithReplies.map(comment => comment.id), 0, ownerUsername, isAdmin, token));
+        }
         // If we loaded a full page of comments, assume there are more to load.
         // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
         // any more server query complexity, so seems worth it. In the case of a project with
@@ -105,7 +107,9 @@ const getCommentById = (projectId, commentId, ownerUsername, isAdmin, token) => 
         // If the comment is not a reply, show it as top level and load replies
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments([body]));
-        dispatch(getReplies(projectId, [body.id], 0, ownerUsername, isAdmin, token));
+        if (body.reply_count > 0) {
+            dispatch(getReplies(projectId, [body.id], 0, ownerUsername, isAdmin, token));
+        }
     });
 });
 

--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -90,7 +90,10 @@ const getTopLevelComments = () => ((dispatch, getState) => {
         }
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments(body));
-        dispatch(getReplies(body.map(comment => comment.id), 0));
+        const commentsWithReplies = body.filter(comment => comment.reply_count > 0);
+        if (commentsWithReplies.length > 0) {
+            dispatch(getReplies(commentsWithReplies.map(comment => comment.id), 0));
+        }
 
         // If we loaded a full page of comments, assume there are more to load.
         // This will be wrong (1 / COMMENT_LIMIT) of the time, but does not require
@@ -130,7 +133,9 @@ const getCommentById = commentId => ((dispatch, getState) => {
         // If the comment is not a reply, show it as top level and load replies
         dispatch(setFetchStatus('comments', Status.FETCHED));
         dispatch(setComments([body]));
-        dispatch(getReplies(body.id, 0));
+        if (body.reply_count > 0) {
+            dispatch(getReplies(body.id, 0));
+        }
     });
 });
 


### PR DESCRIPTION
Revert #5660 which reverted #5630, so actually apply #5630. There was no bug with the code in this PR, it was just incompatible with our backend which was incorrectly telling the frontend that every comment loaded by id had a reply_count of 0, which caused notifications linking to project replies to not actually load the replies. 

This PR will reduce the number of requests for replies proportionally with how many comments have 0 replies, which is a win for the client side and the server side. 👑

This PR should has to be deployed _after_ the backend fix is in. 

/cc @kchadha lets keep this revert chain alive