### PR TITLE
Fix Scroll Bar on Project Fullscreen

### DIFF
--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -1,16 +1,21 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+const classNames = require('classnames');
+
 require('./footer.scss');
 
 const FooterBox = props => (
-    <div className="inner">
+    <div className={classNames("inner", {
+        hidden: props.hidden
+    })}>
         {props.children}
     </div>
 );
 
 FooterBox.propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    hidden: PropTypes.bool
 };
 
 module.exports = FooterBox;

--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -6,7 +6,7 @@ const classNames = require('classnames');
 require('./footer.scss');
 
 const FooterBox = props => (
-    <div 
+    <div
         className={classNames('inner', {hidden: props.hidden})}
     >
         {props.children}

--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -6,9 +6,11 @@ const classNames = require('classnames');
 require('./footer.scss');
 
 const FooterBox = props => (
-    <div className={classNames("inner", {
-        hidden: props.hidden
-    })}>
+    <div 
+        className={classNames("inner", {
+            hidden: props.hidden
+        })}
+    >
         {props.children}
     </div>
 );

--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -6,11 +6,11 @@ const classNames = require('classnames');
 require('./footer.scss');
 
 const FooterBox = props => (
-    <div 
-        className={classNames('inner', {
+    <div className={
+        classNames('inner', {
             hidden: props.hidden
-        })}
-    >
+        })
+    }>
         {props.children}
     </div>
 );

--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -6,11 +6,9 @@ const classNames = require('classnames');
 require('./footer.scss');
 
 const FooterBox = props => (
-    <div className={
-        classNames('inner', {
-            hidden: props.hidden
-        })
-    }>
+    <div 
+        className={classNames('inner', {hidden: props.hidden})}
+    >
         {props.children}
     </div>
 );

--- a/src/components/footer/container/footer.jsx
+++ b/src/components/footer/container/footer.jsx
@@ -7,7 +7,7 @@ require('./footer.scss');
 
 const FooterBox = props => (
     <div 
-        className={classNames("inner", {
+        className={classNames('inner', {
             hidden: props.hidden
         })}
     >

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -15,7 +15,7 @@ const getScratchWikiLink = require('../../../lib/scratch-wiki');
 require('./footer.scss');
 
 const Footer = props => (
-    <FooterBox hidden={props.isFullScreen}>
+    <FooterBox hidden={props.projectIsFullScreen}>
         <MediaQuery maxWidth={frameless.mobileIntermediate - 1}>
             <div className="lists">
                 <dl>
@@ -220,7 +220,7 @@ const Footer = props => (
 Footer.propTypes = {
     intl: intlShape.isRequired,
     scratchWikiLink: PropTypes.string,
-    isFullScreen: PropTypes.bool
+    projectIsFullScreen: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -228,7 +228,7 @@ const mapStateToProps = (state, ownProps) => {
         scratchWikiLink: getScratchWikiLink(ownProps.intl.locale)
     };
     if (state.scratchGui) {
-        result.isFullScreen = state.scratchGui.mode.isFullScreen;
+        result.projectIsFullScreen = state.scratchGui.mode.isFullScreen;
     }
     return result;
 };

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -224,13 +224,13 @@ Footer.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-    const result = {
+    const propResults = {
         scratchWikiLink: getScratchWikiLink(ownProps.intl.locale)
     };
     if (state.scratchGui) {
-        result.projectIsFullScreen = state.scratchGui.mode.isFullScreen;
+        propResults.projectIsFullScreen = state.scratchGui.mode.isFullScreen;
     }
-    return result;
+    return propResults;
 };
 
 const ConnectedFooter = connect(mapStateToProps)(Footer);

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -15,7 +15,7 @@ const getScratchWikiLink = require('../../../lib/scratch-wiki');
 require('./footer.scss');
 
 const Footer = props => (
-    <FooterBox>
+    <FooterBox hidden={props.isFullScreen}>
         <MediaQuery maxWidth={frameless.mobileIntermediate - 1}>
             <div className="lists">
                 <dl>
@@ -219,11 +219,13 @@ const Footer = props => (
 
 Footer.propTypes = {
     intl: intlShape.isRequired,
-    scratchWikiLink: PropTypes.string
+    scratchWikiLink: PropTypes.string,
+    isFullScreen: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    scratchWikiLink: getScratchWikiLink(ownProps.intl.locale)
+    scratchWikiLink: getScratchWikiLink(ownProps.intl.locale),
+    isFullScreen: state.scratchGui.mode.isFullScreen
 });
 
 const ConnectedFooter = connect(mapStateToProps)(Footer);

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -223,10 +223,15 @@ Footer.propTypes = {
     isFullScreen: PropTypes.bool
 };
 
-const mapStateToProps = (state, ownProps) => ({
-    scratchWikiLink: getScratchWikiLink(ownProps.intl.locale),
-    isFullScreen: state.scratchGui.mode.isFullScreen
-});
+const mapStateToProps = (state, ownProps) => {
+    const result = {
+        scratchWikiLink: getScratchWikiLink(ownProps.intl.locale)
+    };
+    if (state.scratchGui) {
+        result.isFullScreen = state.scratchGui.mode.isFullScreen;
+    }
+    return result;
+};
 
 const ConnectedFooter = connect(mapStateToProps)(Footer);
 module.exports = injectIntl(ConnectedFooter);

--- a/src/main.scss
+++ b/src/main.scss
@@ -176,6 +176,16 @@ dl {
     background-color: $background-color;
     padding: 20px 0;
     min-width: 100%;
+    min-height: 80%;
+}
+
+html, body, #app, .page {
+  height: 100%;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
 }
 
 .hidden {

--- a/src/main.scss
+++ b/src/main.scss
@@ -176,18 +176,5 @@ dl {
     background-color: $background-color;
     padding: 20px 0;
     min-width: 100%;
-    min-height: 80%;
-}
-
-html, body, #app, .page {
-    height: 100%;
-}
-
-.footer {
-    position: absolute;
-    bottom: 0;
-}
-
-.hidden {
-    display: none;
+    min-height: 680px;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -180,12 +180,12 @@ dl {
 }
 
 html, body, #app, .page {
-  height: 100%;
+    height: 100%;
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
+    position: absolute;
+    bottom: 0;
 }
 
 .hidden {

--- a/src/main.scss
+++ b/src/main.scss
@@ -176,5 +176,8 @@ dl {
     background-color: $background-color;
     padding: 20px 0;
     min-width: 100%;
-    min-height: 680px;
+}
+
+.hidden {
+    display: none;
 }

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -554,7 +554,9 @@ const PreviewPresentation = ({
                             </FlexRow>
                         }
                     </div>
-                    <div className="project-lower-container">
+                    <div className={classNames('project-lower-container', {
+                        hidden: isFullScreen
+                    })}>
                         <div className="inner">
                             <FlexRow className="preview-row">
                                 <div className="comments-container">

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -554,11 +554,11 @@ const PreviewPresentation = ({
                             </FlexRow>
                         }
                     </div>
-                    <div className={
-                        classNames('project-lower-container', {
+                    <div 
+                        className={classNames('project-lower-container', {
                             hidden: isFullScreen
-                        })
-                    }>
+                        })}
+                    >
                         <div className="inner">
                             <FlexRow className="preview-row">
                                 <div className="comments-container">

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -554,9 +554,11 @@ const PreviewPresentation = ({
                             </FlexRow>
                         }
                     </div>
-                    <div className={classNames('project-lower-container', {
-                        hidden: isFullScreen
-                    })}>
+                    <div className={
+                        classNames('project-lower-container', {
+                            hidden: isFullScreen
+                        })
+                    }>
                         <div className="inner">
                             <FlexRow className="preview-row">
                                 <div className="comments-container">

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -554,7 +554,7 @@ const PreviewPresentation = ({
                             </FlexRow>
                         }
                     </div>
-                    <div 
+                    <div
                         className={classNames('project-lower-container', {
                             hidden: isFullScreen
                         })}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -671,3 +671,7 @@ $stage-width: 480px;
         }
     }
 }
+
+.hidden {
+    display: none;
+}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -671,7 +671,3 @@ $stage-width: 480px;
         }
     }
 }
-
-.hidden {
-    display: none;
-}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -671,3 +671,20 @@ $stage-width: 480px;
         }
     }
 }
+
+#view {
+    min-height: 80%;
+}
+
+html, body, #app, .page {
+    height: 100%;
+}
+
+.footer {
+    position: absolute;
+    bottom: 0;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
### Resolves:

Fixes #4190 

### Changes:

This adds a `hidden` class with `display: none`, applies this class to the footer and comment section on fullscreen, and modifies the CSS to remove `min-height` for `#view`, along with some fixes to prevent #2729 from resurfacing.

Hiding the footer and comment section fix #4190 when added with the removal of the `min-height` that was set to 680 pixels. Other updates were made to fix the lack of padding on the 404 page, at least temporarily. 

There are issues where you still have to scroll to get to the bottom of the footer on tall pages and where there is still a padding issues on extremely small pages. I am not entirely sure, but I think these could possibly be fixed by CSS media queries.

### Test Coverage:

I tested on a local build of my fork of scratch-www and the bugs of #4190 were fixed and the only remaining bugs relating to #2729 were those mentioned (see comments in #4190 for screenshots).