### PR TITLE
Update manager permissions for studios.

### DIFF
--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -8,7 +8,7 @@ const isCurator = state => state.studio.curator;
 const isManager = state => state.studio.manager || isCreator(state);
 
 // Action-based permissions selectors
-const selectCanEditInfo = state => !selectIsMuted(state) && (selectIsAdmin(state) || isManager(state));
+const selectCanEditInfo = state => !selectIsMuted(state) && (selectIsAdmin(state) || isCreator(state));
 const selectCanAddProjects = state =>
     !selectIsMuted(state) &&
     (isManager(state) ||

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -89,7 +89,7 @@ describe('studio info', () => {
         test.each([
             ['admin', true],
             ['curator', false],
-            ['manager', true],
+            ['manager', false],
             ['creator', true],
             ['logged in', false],
             ['unconfirmed', false],


### PR DESCRIPTION
### Changes:

Update the permissions for managers on studios. Only the studio creator can edit the title/description/thumbnail of the studio.

### Test Coverage:

Tested locally.

CC/ @paulkaplan 