### PR TITLE
check rate limit for studio creation integration test

### DIFF
--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -10,8 +10,10 @@ const {
 let username = process.env.SMOKE_USERNAME + '1';
 let password = process.env.SMOKE_PASSWORD;
 let remote = process.env.SMOKE_REMOTE || false;
+
 let rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 let myStuffURL = rootUrl + '/mystuff';
+let rateLimitCheck = process.env.RATE_LIMIT_CHECK || rootUrl;
 
 if (remote){
     jest.setTimeout(60000);
@@ -88,6 +90,7 @@ describe('www-integration my_stuff', () => {
     });
 
     test('+ New Studio button should take you to the studio page', async ()=>{
+        await driver.get(rateLimitCheck);
         await driver.get(myStuffURL);
         await clickXpath('//form[@id="new_studio"]/button[@type="submit"]');
         await driver.sleep(500);


### PR DESCRIPTION
### Resolves:

Ensures that the integration tests don't run into the rate limit for studio creation when run in CI.

### Changes:

adds a check to the test that creates a studio from the my-stuff page.

