### PR TITLE
Add line breaks to description

### DIFF
--- a/src/views/studio/modals/studio-report-modal.scss
+++ b/src/views/studio/modals/studio-report-modal.scss
@@ -61,6 +61,7 @@
         overflow-wrap: break-word;
         height: 90px;
         padding: 0.5rem;
+        white-space: pre-wrap;
     }
 
     .studio-report-title-text {


### PR DESCRIPTION
### Resolves:

https://github.com/LLK/scratch-www/issues/5710
It's been 10 days since the last comment lol

### Changes:

Adds `white-space: pre-wrap;` to the text boxes in the studio report modal

### Test Coverage:

Before
![image](https://user-images.githubusercontent.com/79767244/126894969-1affab7d-a943-46cb-8a5d-ca8c65ff5856.png)

After
![image](https://user-images.githubusercontent.com/79767244/126894981-f94ad368-dba3-4b3c-9a55-8283a04568e5.png)
