### PR TITLE
Move FAQ page to /faq

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -138,7 +138,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="/info/faq">
+                        <a href="/faq">
                             <FormattedMessage id="general.faq" />
                         </a>
                     </dd>

--- a/src/routes.json
+++ b/src/routes.json
@@ -151,8 +151,8 @@
     },
     {
         "name": "faq",
-        "pattern": "^/info/faq/?(\\?.*)?$",
-        "routeAlias": "/info/(cards|credits|faq)/?$",
+        "pattern": "^/faq/?(\\?.*)?$",
+        "routeAlias": "/faq",
         "view": "faq/faq",
         "title": "FAQ"
     },
@@ -391,6 +391,12 @@
         "pattern": "^/info/credits/?$",
         "routeAlias": "/info/(cards|credits|faq|donate)/?$",
         "redirect" : "/credits"
+    },
+    {
+        "name" : "faq-redirect",
+        "pattern": "^/info/faq/?$",
+        "routeAlias": "/info/(cards|credits|faq|donate)/?$",
+        "redirect" : "/faq"
     },
     {
         "name": "donate-redirect",

--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -175,7 +175,7 @@ const About = () => (
                             <a href="/ideas"><FormattedMessage id="about.learnMoreHelp" /></a>
                         </li>
                         <li>
-                            <a href="/info/faq"><FormattedMessage id="about.learnMoreFaq" /></a>
+                            <a href="/faq"><FormattedMessage id="about.learnMoreFaq" /></a>
                         </li>
                         <li>
                             <a href="/parents"><FormattedMessage id="about.learnMoreParents" /></a>

--- a/src/views/contact-us/contact-us.jsx
+++ b/src/views/contact-us/contact-us.jsx
@@ -57,7 +57,7 @@ class ContactUs extends React.Component {
                         <p><FormattedMessage
                             id="contactUs.faqInfo"
                             values={{faqLink: (
-                                <a href="/info/faq"><FormattedMessage id="contactUs.faqLinkText" /></a>
+                                <a href="/faq"><FormattedMessage id="contactUs.faqLinkText" /></a>
                             )}}
                         /></p>
                         <h3>
@@ -115,7 +115,7 @@ class ContactUs extends React.Component {
                 <nav>
                     <ol>
                         <li className="nav-header"><FormattedMessage id="contactUs.findHelp" /></li>
-                        <li><a href="/info/faq"><FormattedMessage id="contactUs.faqLinkText" /></a></li>
+                        <li><a href="/faq"><FormattedMessage id="contactUs.faqLinkText" /></a></li>
                     </ol>
                 </nav>
                 {this.state.showForm && (

--- a/src/views/parents/parents.jsx
+++ b/src/views/parents/parents.jsx
@@ -114,7 +114,7 @@ const Landing = () => (
                             id="parents.faqMoreAndAsk"
                             values={{
                                 faqPage: (
-                                    <a href="/info/faq">
+                                    <a href="/faq">
                                         <FormattedMessage
                                             id="parents.faqLinkText"
                                         />

--- a/src/views/preview/unsupported-browser.jsx
+++ b/src/views/preview/unsupported-browser.jsx
@@ -35,7 +35,7 @@ const UnsupportedBrowser = () => (
                             faqLink: (
                                 <a
                                     className="faq-link"
-                                    href="/info/faq"
+                                    href="/faq"
                                 >
                                     <FormattedMessage id="general.faq" />
                                 </a>

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -389,7 +389,7 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                         >
                             Confirm your email
                         </a>{' '}to enable sharing.{' '}
-                        <a href="/info/faq/#accounts">
+                        <a href="/faq/#accounts">
                             Having trouble?
                         </a>
                     </DropdownBanner>,

--- a/src/views/terms/terms.jsx
+++ b/src/views/terms/terms.jsx
@@ -265,7 +265,7 @@ const Terms = () => (
                 </p>
                 <p>
                     5.3 The source code for Scratch 1.4 is available for download and subject
-                    to the copyright notice as indicated on the <a href="/info/faq">Scratch FAQ</a>
+                    to the copyright notice as indicated on the <a href="/faq">Scratch FAQ</a>
                     {' '}page.
                 </p>
                 <p>

--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -93,7 +93,7 @@ describe('www-integration footer links', () => {
         await clickText('FAQ');
         let url = await driver.getCurrentUrl();
         let pathname = (new URL(url)).pathname;
-        expect(pathname).toMatch(/^\/info\/faq\/?$/);
+        expect(pathname).toMatch(/^\/faq\/?$/);
     });
 
     test('click Download link', async () => {


### PR DESCRIPTION
### Resolves:
Resolves #4298

### Changes:
Moves FAQ page to `/faq`, adds a redirect from `/info/faq` to `/faq`, and changes FAQ URLs in links from `/info/faq` to `/faq`.

### Test Coverage:
Manually tested.

An integration test is also changed to check for the new URL.
