### PR TITLE
Prevent searches for empty strings

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -84,7 +84,7 @@ class Navigation extends React.Component {
     }
 
     handleSearchSubmit (formData) {
-        if(formData.q.trim() === '') return // don't submit empty searches
+        if (formData.q.trim() === '') return; // don't submit empty searches
         
         let targetUrl = '/search/projects';
         if (formData.q) {

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -84,6 +84,8 @@ class Navigation extends React.Component {
     }
 
     handleSearchSubmit (formData) {
+        if(formData.q === '') return // don't submit empty searches
+
         let targetUrl = '/search/projects';
         if (formData.q) {
             targetUrl += `?q=${encodeURIComponent(formData.q)}`;

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -84,7 +84,7 @@ class Navigation extends React.Component {
     }
 
     handleSearchSubmit (formData) {
-        if (formData.q.trim() === '') return; // don't submit empty searches
+        if (formData.q.trim() === '') return null; // don't submit empty searches
         
         let targetUrl = '/search/projects';
         if (formData.q) {

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -84,8 +84,8 @@ class Navigation extends React.Component {
     }
 
     handleSearchSubmit (formData) {
-        if(formData.q === '') return // don't submit empty searches
-
+        if(formData.q.trim() === '') return // don't submit empty searches
+        
         let targetUrl = '/search/projects';
         if (formData.q) {
             targetUrl += `?q=${encodeURIComponent(formData.q)}`;

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -84,7 +84,7 @@ class Navigation extends React.Component {
     }
 
     handleSearchSubmit (formData) {
-        if (formData.q.trim() === '') return null; // don't submit empty searches
+        if (formData.q.trim() === '') return; // don't submit empty searches
         
         let targetUrl = '/search/projects';
         if (formData.q) {


### PR DESCRIPTION
### Resolves:

Resolves: #5487

### Changes:

When the search form is submitted, don't redirect when the `q` field is an empty string. This prevents clicking the icon/pressing enter from redirecting to the blank results page.

### Test Coverage:

- Pressing the icon with something in the field correctly searches for the item
- Pressing enter with something in the field correctly searches for the item
- Pressing the icon with an empty query field does not do anything
- Pressing enter with an empty query field does not do anything