### PR TITLE
Fix tx-push script for conference 2021 page

### DIFF
--- a/bin/tx-push-www
+++ b/bin/tx-push-www
@@ -31,7 +31,7 @@ if (args[0] === '--execute') {
 const overrides = {
     'src/views/teachers/faq/l10n.json': 'teacher-faq-l10njson',
     'src/views/teachers/landing/l10n.json': 'educator-landing-l10njson',
-    'src/views/conference/2020/index/l10n.json': 'conference-index-2020-l10njson',
+    'src/views/conference/2021/index/l10n.json': 'conference-index-2021-l10njson',
     'src/views/conference/2019/index/l10n.json': 'conference-index-2019-l10njson',
     'src/views/conference/2017/index/l10n.json': 'conference-index-2017-l10njson'
 };


### PR DESCRIPTION
## Steps to land this PR:
1. rename the resource on transifex: `conference-2021-index-l10njson` to `conference-index-2021-l10njson` so that we don't lose any current translations.
2. merge the PR. Nightly update-translations job will execute the script.
3. rename or remove [conference-2021-index-l10njson](https://github.com/LLK/scratch-l10n/tree/master/www/scratch-website.conference-2021-index-l10njson) in scratch-l10n.

### Resolves:
Fixes #5912  : handling of the conference 2021 translation updates.

### Changes:

The conference views do not follow the conventions for naming the route based on the view. Translation files need to match the route, so they have to be overridden in the `tx-push-www` script. When we changed the 2020 conference view to 2021 we forgot about updating the script, so the resource in transifex doesn't match the route and is not found later when we're trying to build the translations for the view.

This PR changes the override in the script.

### Test Coverage:

Testing:
* run `./bin/tx-push-www`:
    * output shows what would run with the --execute flag.
    * look for `tx-push-src` wtih resource name 'conference-index-2021-l10njson', for the conference 2021 view.

DO NOT RUN THE SCRIPT WITH `--execute`
