### PR TITLE
Add studio host transfer notification to the activity feed

### DIFF
--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -87,6 +87,8 @@
     "studio.activityBecomeCurator": "{newCuratorProfileLink} accepted an invitation from {inviterProfileLink} to curate this studio",
     "studio.activityRemoveCurator": "{removerProfileLink} removed the curator {removedProfileLink}",
     "studio.activityBecomeOwner": "{promotedProfileLink} was promoted to manager by {promotorProfileLink}",
+    "studio.activityBecomeHost": "{newHostProfileLink} was made the studio host by {actorProfileLink}",
+    "studio.activityBecomeHostAdminActor": "{newHostProfileLink} was made the studio host by a Scratch Team member.",
 
     "studio.lastUpdated": "Updated {lastUpdatedDate, date, medium}",
     "studio.followerCount": "{followerCount} followers",

--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -88,7 +88,7 @@
     "studio.activityRemoveCurator": "{removerProfileLink} removed the curator {removedProfileLink}",
     "studio.activityBecomeOwner": "{promotedProfileLink} was promoted to manager by {promotorProfileLink}",
     "studio.activityBecomeHost": "{newHostProfileLink} was made the studio host by {actorProfileLink}",
-    "studio.activityBecomeHostAdminActor": "{newHostProfileLink} was made the studio host by a Scratch Team member.",
+    "studio.activityBecomeHostAdminActor": "{newHostProfileLink} was made the studio host by a Scratch Team member",
 
     "studio.lastUpdated": "Updated {lastUpdatedDate, date, medium}",
     "studio.followerCount": "{followerCount} followers",

--- a/src/views/studio/studio-activity.jsx
+++ b/src/views/studio/studio-activity.jsx
@@ -167,6 +167,44 @@ const getComponentForItem = item => {
                 />
             </SocialMessage>
         );
+    case 'becomehoststudio':
+        return (
+            <SocialMessage
+                datetime={item.datetime_created}
+                iconSrc="/svgs/studio/activity-curator.svg"
+                iconAlt="curator activity icon"
+                imgClassName="studio-activity-icon"
+                key={item.id}
+            >
+                {item.admin_actor ?
+                    <FormattedMessage
+                        id="studio.activityBecomeHostAdminActor"
+                        values={{
+                            newHostProfileLink: (
+                                <a href={`/users/${item.recipient_username}`}>
+                                    {item.recipient_username}
+                                </a>
+                            )
+                        }}
+                    /> :
+                    <FormattedMessage
+                        id="studio.activityBecomeHost"
+                        values={{
+                            newHostProfileLink: (
+                                <a href={`/users/${item.recipient_username}`}>
+                                    {item.recipient_username}
+                                </a>
+                            ),
+                            actorProfileLink: (
+                                <a href={`/users/${item.recipient_username}`}>
+                                    {item.actor_username}
+                                </a>
+                            )
+                        }}
+                    />
+                }
+            </SocialMessage>
+        );
     }
 };
 


### PR DESCRIPTION
This adds record of studio transfer to the activity feed, with two slightly different messages depending on whether it was done by an admin or the former host.
![image](https://user-images.githubusercontent.com/4612592/129616125-f418bdbc-2d34-4d92-9e87-231242660247.png)

This should be fine to merge at any time, including before launch of the feature. (If there are no becomehoststudio notifications, they will not be displayed.)