### PR TITLE
Increase default alert duration to 6 seconds

### DIFF
--- a/src/components/alert/alert-provider.jsx
+++ b/src/components/alert/alert-provider.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import AlertStatus from './alert-status.js';
 import AlertContext from './alert-context.js';
 
+const DEFAULT_TIMEOUT_SECONDS = 6;
+
 const AlertProvider = ({children}) => {
     const defaultState = {
         status: AlertStatus.NONE,
@@ -19,7 +21,7 @@ const AlertProvider = ({children}) => {
         setState(defaultState);
     };
 
-    const handleAlert = (status, data, timeoutSeconds = 3) => {
+    const handleAlert = (status, data, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS) => {
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
         setState({status, data, showClear: !timeoutSeconds});
         if (timeoutSeconds) {
@@ -37,9 +39,9 @@ const AlertProvider = ({children}) => {
                 data: state.data,
                 showClear: state.showClear,
                 clearAlert: clearAlert,
-                successAlert: (newData, timeoutSeconds = 3) =>
+                successAlert: (newData, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS) =>
                     handleAlert(AlertStatus.SUCCESS, newData, timeoutSeconds),
-                errorAlert: (newData, timeoutSeconds = 3) =>
+                errorAlert: (newData, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS) =>
                     handleAlert(AlertStatus.ERROR, newData, timeoutSeconds)
             }}
         >


### PR DESCRIPTION
Increase the default amount of time that alerts for success and errors are shown, from 3 to 6 seconds. Currently all alerts use this default time. The aim is to help ensure that people have enough time to read the alert message before it disappears.

