### PR TITLE
Added Nasir and reordered lang organizers alphabetically by first name

### DIFF
--- a/src/views/credits/credits.jsx
+++ b/src/views/credits/credits.jsx
@@ -47,8 +47,9 @@ const Credits = () => (
                         <FormattedMessage id="credits.acknowledgementsLanguageOrganizers" />
                         {' '}
                         <span>
-                            Brenda Nyaringita (Kiswahili), Hans de Jong (Nederlands),
-                             Farshid Meidani (فارسی‎), Karin Colsman (Gàidhlig).
+                            Brenda Nyaringita (Kiswahili), Farshid Meidani (فارسی‎),
+                             Hans de Jong (Nederlands), Karin Colsman (Gàidhlig),
+                             Nasir Khan Saikat (বাংলা).
                         </span>
                     </p>
                 </div>


### PR DESCRIPTION
Changes: 
- Add "Nasir Khan Saikat (বাংলা)" as a language organizer for Bengali (added to the Credits page)
- sort the language organizers by first name:

- Brenda
- Farshid
- Hans
- Karin
- Nasir


Fixes issue: https://github.com/LLK/scratch-www/issues/5957