### PR TITLE
Change copy of transfer rate-limit error

### DIFF
--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -160,5 +160,5 @@
     "studio.alertManagerPromoteError": "Something went wrong promoting \"{name}\"",
     "studio.alertMemberRemoveError": "Something went wrong removing \"{name}\"",
     "studio.alertTransfer": "\"{name}\" is now the host",
-    "studio.alertTransferRateLimit": "You can only change the host once a day. Try again tomorrow."
+    "studio.alertTransferRateLimit": "A studio can only change hosts once per day. Try again tomorrow."
 }


### PR DESCRIPTION
Changes the error message for when a studio has been transferred too recently, to reflect that the limit is _per studio_ not _per user_.
