### PR TITLE
Ignore querystrings when matching routes

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -95,7 +95,7 @@ async.auto({
         async.forEachOf(routes, function (route, id, cb2) {
             var condition = {
                 name: fastlyConfig.getConditionNameForRoute(route, 'request'),
-                statement: 'req.url ~ "' + route.pattern + '"',
+                statement: 'req.url.path ~ "' + route.pattern + '"',
                 type: 'REQUEST',
                 // Priority needs to be > 1 to not interact with http->https redirect
                 priority: 10 + id
@@ -118,7 +118,7 @@ async.auto({
                     responseCondition: function (cb3) {
                         var condition = {
                             name: fastlyConfig.getConditionNameForRoute(route, 'response'),
-                            statement: 'req.url ~ "' + route.pattern + '"',
+                            statement: 'req.url.path ~ "' + route.pattern + '"',
                             type: 'RESPONSE',
                             priority: id
                         };
@@ -223,7 +223,7 @@ async.auto({
             requestCondition: function (cb2) {
                 var condition = {
                     name: 'routes/projects/embed (request)',
-                    statement: 'req.url ~ "^/projects/embed/(\\d+)"',
+                    statement: 'req.url.path ~ "^/projects/embed/(\\d+)"',
                     type: 'REQUEST',
                     priority: 10
                 };
@@ -232,7 +232,7 @@ async.auto({
             responseCondition: function (cb2) {
                 var condition = {
                     name: 'routes/projects/embed (response)',
-                    statement: 'req.url ~ "^/projects/embed/(\\d+)"',
+                    statement: 'req.url.path ~ "^/projects/embed/(\\d+)"',
                     type: 'RESPONSE',
                     priority: 10
                 };


### PR DESCRIPTION
This should eliminate the issue where querystrings would cause URLs to skip S3 and fall back to scratchr2.  I opted to update every relevant instance of `req.url` -> `req.url.path`, but not all of them are strictly necessary. It should just help set a pattern to follow.