### PR TITLE
Allow admins to promote curators to managers

### DIFF
--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -52,7 +52,7 @@ const selectCanRemoveCurator = (state, username) => {
 };
 const selectCanRemoveManager = (state, managerId) =>
     !selectIsMuted(state) && (selectIsAdmin(state) || isManager(state)) && managerId !== state.studio.host;
-const selectCanPromoteCurators = state => !selectIsMuted(state) && isManager(state);
+const selectCanPromoteCurators = state => !selectIsMuted(state) && (isManager(state) || selectIsAdmin(state));
 
 const selectCanTransfer = (state, managerId) => {
     // Nobody can transfer a class studio.

--- a/test/unit/redux/studio-permissions.test.js
+++ b/test/unit/redux/studio-permissions.test.js
@@ -344,7 +344,7 @@ describe('studio members', () => {
 
     describe('can promote curators', () => {
         test.each([
-            ['admin', false],
+            ['admin', true],
             ['curator', false],
             ['manager', true],
             ['creator', true],


### PR DESCRIPTION
This gives admins permission to promote curators to managers, even if they are not a manager. This is a feature request by the community team.

To be consistent with other permissions, admins do not have permission to do this if they happen to be muted.

### Test Coverage:
I modified the test of this permission.

In bughunt, we should test that admins can promote curators (including themselves.) Other non-admin, non-managers should not be able to promote curators.