### PR TITLE
Update Release Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           git config --global user.name "${{ github.actor }}"
           git checkout -b ${{ steps.vars.outputs.branch }}
-          git merge origin/develop
+          git merge --no-ff origin/develop
           git push --set-upstream origin ${{ steps.vars.outputs.branch }}
       - name: Develop PR
         uses: repo-sync/pull-request@v2


### PR DESCRIPTION
Add --no-ff flag to `git merge` line in the release branch creation workflow. This should ensure that we're always creating a merge commit on the release branch when pulling in changes from develop to stage for the release.