### PR TITLE
Show "Studio Host" on manager tile

### DIFF
--- a/src/views/studio/studio-member-tile.jsx
+++ b/src/views/studio/studio-member-tile.jsx
@@ -160,7 +160,7 @@ const ManagerTile = connect(
         canRemove: selectCanRemoveManager(state, ownProps.id),
         canPromote: false,
         canTransferHost: selectCanTransfer(state, ownProps.id),
-        isCreator: state.studio.owner === ownProps.id
+        isCreator: state.studio.host === ownProps.id
     }),
     {
         onRemove: removeManager


### PR DESCRIPTION
The logic that decides whether to show "Studio Host" on the host's tile was looking for "owner." I changed it to host.