### PR TITLE
Add open search ability

### DIFF
--- a/src/template.ejs
+++ b/src/template.ejs
@@ -33,6 +33,7 @@
         <link rel="stylesheet" href="/css/lib/normalize.min.css" />
         <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.chunks.common.css[0] %>" />
         <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.chunks[htmlWebpackPlugin.options.route.name].css[0] %>" />
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Scratch"/>
 
         <!-- Polyfills -->
         <script src="/js/polyfill.min.js"></script>

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Scratch</ShortName>
+    <Description>Search Scratch</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://scratch.mit.edu/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://scratch.mit.edu/search/projects?q={searchTerms}"/>
+    <moz:SearchForm>https://scratch.mit.edu/search/projects</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
### Resolves:

Fixes #4166

### Changes:

The PR adds an opensearch tag to the website, which allows users to search the scratch.mit.edu website by pressing the tab button when typing into the onmibox.

### Test Coverage:

This change does not modify any javascript, so no tests fail. This is what it should look like after the change is implemented:
![image](https://user-images.githubusercontent.com/53224922/135550378-04937a12-510e-4d24-b11b-561bfa3e68d9.png)
