### PR TITLE
Fix "transferring" misspelling

### DIFF
--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -102,7 +102,7 @@
     "studio.transfer.alert.somethingWentWrong": "Something went wrong transferring this studio to a new host.",
     "studio.transfer.alert.wasntTheRightPassword": "Hmm, that wasn’t the right password.",
     "studio.transfer.alert.tooManyPasswordAttempts": "Too many password attempts. Please try again later.",
-    "studio.transfer.alert.thisUserCannotBecomeHost": "This user cannot become the host — try transfering to another manager",
+    "studio.transfer.alert.thisUserCannotBecomeHost": "This user cannot become the host — try transferring to another manager",
 
     "studio.remove": "Remove",
     "studio.promote": "Promote",


### PR DESCRIPTION
### Resolves:

"Transferring" was misspelled as "transfering" in one of the studio host transfer error messages.

### Changes:

Fixes the word.