### PR TITLE
Update Annual Report Routes - no redirects

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -10,7 +10,9 @@
         "name": "annual-report",
         "pattern": "^/annual-report/?(\\?.*)?$",
         "routeAlias": "/annual-report/?$",
-        "redirect": "/annual-report/2019"
+        "view": "annual-report/2019/annual-report",
+        "title": "Annual Report 2019",
+        "viewportWidth": "device-width"
     },
     {
         "name": "annual-report-2019",


### PR DESCRIPTION
Update the /annual-report route to just point to the appropriate 2019 (or in the future, 2020) Annual Report view instead of redirecting to a different route and updating the redirect each year.

@rschamp putting this PR up for discussion, we can talk about other alternatives as well.

### Resolves:

Resolves an issue where redirects signify a page that has permanently moved to another page instead of the way we expect to use this page where the content of the page will get updated every year.

### Changes:

Change the routes configuration so that /annual-report points to a specific view and we can update that view each year as opposed to updating a redirect (which isn't supposed to change).
