### PR TITLE
Add a partial profile reply integration test

### DIFF
--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -40,6 +40,7 @@ let profileComment = buildNumber + ' profile';
 let studioComment = buildNumber + ' studio';
 
 let projectReply = projectComment + ' reply';
+let profileReply = profileComment + ' reply';
 let studioReply = studioComment + ' reply';
 
 if (remote) {
@@ -282,6 +283,24 @@ describe('comment tests', async () => {
             let postedReply = await findByXpath(`//span[contains(text(), "${projectReply}")]`);
             let commentVisible = await postedReply.isDisplayed();
             await expect(commentVisible).toBe(true);
+        });
+
+        test('profile reply to comment', async () => {
+            await driver.get(profileUrl);
+            // find the comment and click reply
+            let commentXpath = `//div[contains(text(), "${profileComment}")]/..`;
+            await clickXpath(commentXpath + '//a[@class = "reply"]');
+
+            // select reply box and type reply
+            let replyComposeBox = await findByXpath(commentXpath + '//textArea');
+            await replyComposeBox.sendKeys(profileReply);
+
+            // click post
+            await clickXpath(commentXpath + '//a[contains(text(), "Post")]');
+
+            // reload the page step has been skipped because caching causes failure
+            // The reply wasn't findable by xpath after several attempts, but it seems
+            // better to have this much of a test
         });
 
         test('studio: reply to comment', async () => {


### PR DESCRIPTION
### Changes:

Adds a partial integration test for leaving a reply to a profile comment.  It leaves the comment but does not check to see if the comment appears.  There was some trouble with finding the comment by xpath that I could not resolve, so it seemed better to have a partial test than no test.
