### PR TITLE
CircleCI use correct integration test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ aliases:
       - run:
           name: "integration tests with Jest"
           command: |
-            JEST_JUNIT_OUTPUT_NAME=integration-jest-results.xml npm run test:integration:jest:remote -- --reporters=jest-junit
+            JEST_JUNIT_OUTPUT_NAME=integration-jest-results.xml npm run test:integration:remote -- --reporters=jest-junit
       - store_test_results:
           path: test/results
   - &update-translations


### PR DESCRIPTION
### Resolves:

The Jest integration tests were not being run on Circle because they were trying to run the old npm script.

### Changes:

Uses the correct npm script: test:integration:remote.  test:integration:jest:remote is no longer valid

### Test Coverage:

This should allow the Jest integration tests to run
