### PR TITLE
fix(gh-5989): adjust comment load batch size

### DIFF
--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -3,7 +3,7 @@ const eachLimit = require('async/eachLimit');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const COMMENT_LIMIT = 20;
+const COMMENT_LIMIT = 25;
 
 const {
     addNewComment,

--- a/src/redux/studio-comment-actions.js
+++ b/src/redux/studio-comment-actions.js
@@ -3,7 +3,8 @@ const eachLimit = require('async/eachLimit');
 const api = require('../lib/api');
 const log = require('../lib/log');
 
-const COMMENT_LIMIT = 25;
+const COMMENT_LIMIT = 20;
+const REPLY_LIMIT = 25;
 
 const {
     addNewComment,
@@ -44,7 +45,7 @@ const getReplies = (commentIds, offset) => ((dispatch, getState) => {
         api({
             uri: `${isAdmin ? '/admin' : ''}/studios/${studioId}/comments/${parentId}/replies`,
             authentication: token ? token : null,
-            params: {offset: offset || 0, limit: COMMENT_LIMIT}
+            params: {offset: offset || 0, limit: REPLY_LIMIT}
         }, (err, body, res) => {
             if (err) {
                 return callback(`Error fetching comment replies: ${err}`);


### PR DESCRIPTION
### Resolves:

Resolves #5989 

### Changes:

Adjust the studio reply comment load batch size to 25 instead of 20.

### Test Coverage:

Searched for test cases that interact directly with this value, didn't find any.
