### PR TITLE
Fix flaky comments tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,9 +4655,9 @@
       }
     },
     "chromedriver": {
-      "version": "95.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
-      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
+      "version": "96.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
+      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "babel-preset-es2015": "6.22.0",
     "babel-preset-react": "6.22.0",
     "bowser": "1.9.4",
-    "chromedriver": "95.0.0",
+    "chromedriver": "96.0.0",
     "classnames": "2.2.5",
     "cookie": "0.4.1",
     "copy-webpack-plugin": "4.6.0",

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -81,10 +81,6 @@ describe('comment tests', async () => {
             await findByXpath(`//textarea[contains(text(), "${projectComment}")]`);
             await clickXpath('//button[@class="button compose-post"]');
 
-            // reload the page
-            await driver.sleep(5000);
-            await driver.get(projectUrl);
-
             // find the comment
             let commentXpath = await `//div[@class="comment-bubble"]/span/span[contains(text(),` +
                 ` "${projectComment}")]`;
@@ -101,9 +97,6 @@ describe('comment tests', async () => {
             let commentArea = await findByXpath(commentXpath);
             await commentArea.sendKeys(profileComment);
             await clickXpath('//div[@class="button small"]/a[contains(text(), "Post")]');
-
-            // reload page
-            await driver.get(profileUrl);
 
             // find the comment
             let newComment = await findByXpath(`//div[@class="comment "]/div/div[contains(text(),` +
@@ -123,10 +116,6 @@ describe('comment tests', async () => {
             await commentBox.sendKeys(studioComment);
             await findByXpath(`//textarea[contains(text(), "${studioComment}")]`);
             await clickXpath('//button[@class="button compose-post"]');
-
-            // reload the page
-            await driver.sleep(5000);
-            await driver.get(studioUrl);
 
             // find the comment
             let commentXpath = `//div[@class="comment-bubble"]/span/span[contains(text(), "${studioComment}")]`;
@@ -278,9 +267,6 @@ describe('comment tests', async () => {
             let postButton = await findByXpath(replyRow + '//button[@class = "button compose-post"]');
             await postButton.click();
 
-            // find reply
-            await driver.sleep(500);
-            await driver.get(projectUrl);
             let postedReply = await findByXpath(`//span[contains(text(), "${projectReply}")]`);
             let commentVisible = await postedReply.isDisplayed();
             await expect(commentVisible).toBe(true);
@@ -299,7 +285,6 @@ describe('comment tests', async () => {
             // click post
             await clickXpath(commentXpath + '//a[contains(text(), "Post")]');
 
-            // reload the page step has been skipped because caching causes failure
             // The reply wasn't findable by xpath after several attempts, but it seems
             // better to have this much of a test
         });
@@ -321,9 +306,8 @@ describe('comment tests', async () => {
             let postButton = await findByXpath(replyRow + '//button[@class = "button compose-post"]');
             await postButton.click();
 
-            // reload page and find reply
-            let replyXpath = `//span[contains(text(), "${studioReply}")]`;
-            let postedReply = await loadPageUntilVisible(studioUrl, replyXpath, 10);
+            // find reply
+            let postedReply = await findByXpath(`//span[contains(text(), "${studioReply}")]`);
             let commentVisible = await postedReply.isDisplayed();
             await expect(commentVisible).toBe(true);
         });

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -8,7 +8,6 @@ const {
     clickXpath,
     containsClass,
     findByXpath,
-    loadPageUntilVisible,
     signIn
 } = new SeleniumHelper();
 

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -3,11 +3,12 @@
 import SeleniumHelper from './selenium-helpers.js';
 
 const {
-    findByXpath,
     buildDriver,
-    clickXpath,
     clickText,
+    clickXpath,
     containsClass,
+    findByXpath,
+    loadPageUntilVisible,
     signIn
 } = new SeleniumHelper();
 
@@ -320,10 +321,9 @@ describe('comment tests', async () => {
             let postButton = await findByXpath(replyRow + '//button[@class = "button compose-post"]');
             await postButton.click();
 
-            // find reply
-            await driver.sleep(500);
-            await driver.get(studioUrl);
-            let postedReply = await findByXpath(`//span[contains(text(), "${studioReply}")]`);
+            // reload page and find reply
+            let replyXpath = `//span[contains(text(), "${studioReply}")]`;
+            let postedReply = await loadPageUntilVisible(studioUrl, replyXpath, 10);
             let commentVisible = await postedReply.isDisplayed();
             await expect(commentVisible).toBe(true);
         });

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -61,7 +61,7 @@ describe('comment tests', async () => {
 
     describe('leave comments', async () => {
         beforeAll(async () => {
-            await signIn(username1, password, driver);
+            await signIn(username1, password);
             await findByXpath('//span[contains(@class, "profile-name")]');
         });
 
@@ -137,7 +137,7 @@ describe('comment tests', async () => {
 
     describe('second user tests', async () => {
         beforeAll(async () => {
-            await signIn(username2, password, driver);
+            await signIn(username2, password);
             await findByXpath('//span[contains(@class, "profile-name")]');
         });
 

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -99,7 +99,7 @@ describe('www-integration my_stuff', () => {
         await clickXpath('//form[@id="new_studio"]/button[@type="submit"]');
         let tabs = await findByXpath('//div[@class="studio-tabs"]');
         let tabsVisible = await tabs.isDisplayed();
-        expect(tabsVisible).toBe(true);
+        await expect(tabsVisible).toBe(true);
     });
 
     test('New studio rate limited to five', async () =>{

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -3,10 +3,11 @@
 const SeleniumHelper = require('./selenium-helpers.js');
 
 const {
+    buildDriver,
     clickText,
-    findByXpath,
     clickXpath,
-    buildDriver
+    findByXpath,
+    signIn
 } = new SeleniumHelper();
 
 let username = process.env.SMOKE_USERNAME + '1';
@@ -30,14 +31,7 @@ describe('www-integration my_stuff', () => {
         driver = await buildDriver('www-integration my_stuff');
         await driver.get(rootUrl);
         await driver.sleep(1000);
-        await clickXpath('//li[@class="link right login-item"]/a');
-        let name = await findByXpath('//input[@id="frc-username-1088"]');
-        await name.sendKeys(username);
-        let word = await findByXpath('//input[@id="frc-password-1088"]');
-        await word.sendKeys(password);
-        await driver.sleep(500);
-        await clickXpath('//button[contains(@class, "button") and ' +
-            'contains(@class, "submit-button") and contains(@class, "white")]');
+        await signIn(username, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
     });
 

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -3,9 +3,10 @@
 const SeleniumHelper = require('./selenium-helpers.js');
 
 const {
-    findByXpath,
+    buildDriver,
     clickXpath,
-    buildDriver
+    findByXpath,
+    waitUntilVisible
 } = new SeleniumHelper();
 
 let remote = process.env.SMOKE_REMOTE || false;
@@ -31,7 +32,7 @@ describe('www-integration project-page signed out', () => {
     beforeEach(async () => {
         await driver.get(projectUrl);
         let gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
-        await gfOverlay.isDisplayed();
+        await waitUntilVisible(gfOverlay, driver);
     });
 
     afterAll(async () => await driver.quit());

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -30,6 +30,7 @@ class SeleniumHelper {
             'getDriver',
             'getLogs',
             'getSauceDriver',
+            'loadPageUntilVisible',
             'signIn',
             'urlMatches',
             'waitUntilGone'
@@ -199,6 +200,21 @@ class SeleniumHelper {
 
     async waitUntilVisible (element, driver) {
         await driver.wait(until.elementIsVisible(element));
+    }
+
+    async loadPageUntilVisible (url, elementXpath, maxTries) {
+        for (let i = 0; i < maxTries; i++){
+            try {
+                await this.driver.get(url);
+                let element = await this.driver.wait(until.elementLocated(
+                    By.xpath(elementXpath)), 200, 'could not find element within 200ms');
+                // let element = await this.findByXpath(elementXpath);
+                return await element;
+            } catch (e) {
+                console.log('reloaded the page');
+            }
+        }
+        console.log('reached max tries');
     }
 
 }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -202,20 +202,6 @@ class SeleniumHelper {
         await driver.wait(until.elementIsVisible(element));
     }
 
-    async loadPageUntilVisible (url, elementXpath, maxTries) {
-        for (let i = 0; i < maxTries; i++){
-            try {
-                await this.driver.get(url);
-                let element = await this.driver.wait(until.elementLocated(
-                    By.xpath(elementXpath)), 200, 'could not find element within 200ms');
-                return await element;
-            } catch (e) {
-                // :) eslint-disable-line no-console
-            }
-        }
-        console.error('reached max tries looking for ' + elementXpath); // eslint-disable-line no-console
-    }
-
 }
 
 module.exports = SeleniumHelper;

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -30,7 +30,6 @@ class SeleniumHelper {
             'getDriver',
             'getLogs',
             'getSauceDriver',
-            'loadPageUntilVisible',
             'signIn',
             'urlMatches',
             'waitUntilGone'

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -151,15 +151,13 @@ class SeleniumHelper {
     }
 
     // must be used on a www page
-    async signIn (username, password, driver) {
+    async signIn (username, password) {
         await this.clickXpath('//li[@class="link right login-item"]/a');
         let name = await this.findByXpath('//input[@id="frc-username-1088"]');
         await name.sendKeys(username);
         let word = await this.findByXpath('//input[@id="frc-password-1088"]');
-        await word.sendKeys(password);
-        await driver.sleep(500);
-        await this.clickXpath('//button[contains(@class, "button") and ' +
-            'contains(@class, "submit-button") and contains(@class, "white")]');
+        await word.sendKeys(password + this.getKey('ENTER'));
+        await this.findByXpath('//span[contains(@class, "profile-name")]');
     }
 
     urlMatches (regex) {

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -208,13 +208,12 @@ class SeleniumHelper {
                 await this.driver.get(url);
                 let element = await this.driver.wait(until.elementLocated(
                     By.xpath(elementXpath)), 200, 'could not find element within 200ms');
-                // let element = await this.findByXpath(elementXpath);
                 return await element;
             } catch (e) {
-                console.log('reloaded the page');
+                // :) eslint-disable-line no-console
             }
         }
-        console.log('reached max tries');
+        console.error('reached max tries looking for ' + elementXpath); // eslint-disable-line no-console
     }
 
 }

--- a/test/integration/sign-in-and-out.test.js
+++ b/test/integration/sign-in-and-out.test.js
@@ -77,7 +77,7 @@ describe('www-integration sign-in-and-out', () => {
     describe('sign out', () => {
         beforeEach(async () => {
             await driver.get(wwwURL);
-            await signIn(username, password, driver);
+            await signIn(username, password);
             await driver.sleep(500);
         });
 

--- a/test/integration/sign-in-and-out.test.js
+++ b/test/integration/sign-in-and-out.test.js
@@ -113,6 +113,7 @@ describe('www-integration sign-in-and-out', () => {
 
             // find error
             let error = await findByXpath('//form[@id="login"]//div[@class="error"]');
+            await waitUntilVisible(error, driver);
             let errorText = await error.getText();
             await expect(errorText).toEqual('This field is required.');
         });

--- a/test/integration/sign-in-and-out.test.js
+++ b/test/integration/sign-in-and-out.test.js
@@ -3,11 +3,12 @@
 const SeleniumHelper = require('./selenium-helpers.js');
 
 const {
-    clickText,
-    findByXpath,
-    clickXpath,
-    clickButton,
     buildDriver,
+    clickButton,
+    clickText,
+    clickXpath,
+    findByXpath,
+    getKey,
     signIn,
     waitUntilVisible
 } = new SeleniumHelper();
@@ -108,8 +109,7 @@ describe('www-integration sign-in-and-out', () => {
             await driver.get(scratchr2url);
             await clickXpath('//li[@class="sign-in dropdown"]/span');
             let name = await findByXpath('//input[@id="login_dropdown_username"]');
-            await name.sendKeys(nonsenseUsername);
-            await clickButton('Sign in');
+            await name.sendKeys(nonsenseUsername + getKey('ENTER'));
 
             // find error
             let error = await findByXpath('//form[@id="login"]//div[@class="error"]');
@@ -126,8 +126,7 @@ describe('www-integration sign-in-and-out', () => {
             let name = await findByXpath('//input[@id="login_dropdown_username"]');
             await name.sendKeys(nonsenseUsername);
             let word = await findByXpath('//input[@name="password"]');
-            await word.sendKeys(password);
-            await clickButton('Sign in');
+            await word.sendKeys(password + getKey('ENTER'));
 
             // find error
             let error = await findByXpath('//form[@id="login"]//div[@class="error"]');
@@ -145,8 +144,7 @@ describe('www-integration sign-in-and-out', () => {
             let name = await findByXpath('//input[@id="login_dropdown_username"]');
             await name.sendKeys(username);
             let word = await findByXpath('//input[@name="password"]');
-            await word.sendKeys(nonsensePassword);
-            await clickButton('Sign in');
+            await word.sendKeys(nonsensePassword + getKey('ENTER'));
 
             // find error
             let error = await findByXpath('//form[@id="login"]//div[@class="error"]');

--- a/test/integration/studios-page.test.js
+++ b/test/integration/studios-page.test.js
@@ -85,7 +85,7 @@ describe('studio management', () => {
         await clickXpath('//form[@id="new_studio"]/button[@type="submit"]');
         await findByXpath('//div[@class="studio-tabs"]');
         promoteStudioURL = await driver.getCurrentUrl();
-        curatorTab = promoteStudioURL + 'curators';
+        curatorTab = await promoteStudioURL + 'curators';
     });
 
     beforeEach(async () => {
@@ -108,7 +108,7 @@ describe('studio management', () => {
         await clickXpath('//div[@class="studio-adder-row"]/button');
         let inviteAlert = await findByXpath('//div[@class="alert-msg"]'); // the confirm alert
         let alertText = await inviteAlert.getText();
-        let successText = `Curator invite sent to "${username3}"`;
+        let successText = await `Curator invite sent to "${username3}"`;
         await expect(alertText).toMatch(successText);
     });
 
@@ -132,9 +132,9 @@ describe('studio management', () => {
         await driver.get(curatorTab);
 
         // promote user3
-        let user3href = '/users/' + username3;
+        let user3href = await '/users/' + username3;
         // click kebab menu on the user tile
-        let kebabMenuXpath = `//a[@href = "${user3href}"]/` +
+        let kebabMenuXpath = await `//a[@href = "${user3href}"]/` +
         'following-sibling::div[@class="overflow-menu-container"]';
         await clickXpath(kebabMenuXpath + '/button[@class="overflow-menu-trigger"]');
         // click promote
@@ -156,9 +156,9 @@ describe('studio management', () => {
         await driver.get(curatorTab);
 
         // open kebab menu
-        let user2href = '/users/' + username2;
+        let user2href = await '/users/' + username2;
         // click kebab menu on the user tile
-        let kebabMenuXpath = `//a[@href = "${user2href}"]/` +
+        let kebabMenuXpath = await `//a[@href = "${user2href}"]/` +
         'following-sibling::div[@class="overflow-menu-container"]';
         await clickXpath(kebabMenuXpath + '/button[@class="overflow-menu-trigger"]');
 

--- a/test/integration/studios-page.test.js
+++ b/test/integration/studios-page.test.js
@@ -78,7 +78,7 @@ describe('studio management', () => {
         await driver.get(rootUrl);
 
         // create a studio for tests
-        await signIn(username2, password, driver);
+        await signIn(username2, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
         await driver.get(rateLimitCheck);
         await driver.get(myStuffURL);
@@ -99,7 +99,7 @@ describe('studio management', () => {
 
     test('invite a curator', async () => {
         // sign in as user2
-        await signIn(username2, password, driver);
+        await signIn(username2, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
 
         // invite user3 to curate
@@ -114,7 +114,7 @@ describe('studio management', () => {
 
     test('accept curator invite', async () => {
         // Sign in user3
-        await signIn(username3, password, driver);
+        await signIn(username3, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
 
         // accept the curator invite
@@ -126,7 +126,7 @@ describe('studio management', () => {
 
     test('promote to manager', async () => {
         // sign in as user2
-        await signIn(username2, password, driver);
+        await signIn(username2, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
         // for some reason the user isn't showing up without reloading the page
         await driver.get(curatorTab);
@@ -150,7 +150,7 @@ describe('studio management', () => {
 
     test('transfer studio host', async () => {
         // sign in as user2
-        await signIn(username2, password, driver);
+        await signIn(username2, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
         // for some reason the user isn't showing up without reloading the page
         await driver.get(curatorTab);

--- a/test/integration/studios-page.test.js
+++ b/test/integration/studios-page.test.js
@@ -128,7 +128,8 @@ describe('studio management', () => {
         // sign in as user2
         await signIn(username2, password);
         await findByXpath('//span[contains(@class, "profile-name")]');
-        // for some reason the user isn't showing up without reloading the page
+        // for some reason the user isn't showing up without waiting and reloading the page
+        await driver.sleep(2000);
         await driver.get(curatorTab);
 
         // promote user3


### PR DESCRIPTION
### Resolves:

The Integration Tests that check comments were failing sometimes.  

### Changes:

Makes a number of adjustments to the Integration Tests to try to improve their stability locally and in CI.
* Updates Chromedriver
* Updates the Helper SignIn function to use sendKeys(ENTER) rather than clicking the post button.  This more reliably waits until the username and password have been typed before submitting the form.
* The SignIn function is called slightly differently, so changes were made to those calls.
* Changes how several of the other tests sign in to use the Helper SignIn function
* Sign in with the enter key in tests that don't use the Helper SignIn function
* Use WaitUntilVisible Helper function in several places rather than just checking once if an element is visible (Project Page and sign-in-and-out tests)
* Make sure we're using awaits where necessary
* Add a wait before going to the curators page to the promote manager test (studios-page) to make sure the page the new curator appears
* Create a LoadPageUntilVisible function to make sure comments appear after reloading the page.  They don't always appear on the first try
