### PR TITLE
Correct link href for studio host transfer message

### DIFF
--- a/src/views/studio/studio-activity.jsx
+++ b/src/views/studio/studio-activity.jsx
@@ -195,7 +195,7 @@ const getComponentForItem = item => {
                                 </a>
                             ),
                             actorProfileLink: (
-                                <a href={`/users/${item.recipient_username}`}>
+                                <a href={`/users/${item.actor_username}`}>
                                     {item.actor_username}
                                 </a>
                             )


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-www/issues/6367

### Resolves:

https://github.com/LLK/scratch-www/issues/6367

### Changes:

Corrected username for profile link in studio host transfer log entry.

### Test Coverage:

To test:

1. Open https://scratch.mit.edu/mystuff/
2. Create studio
> I created a bookmarklet to automate this.
> ```javascript
> javascript:if(window.location.href=="https://scratch.mit.edu/mystuff/") {document.getElementById("new_studio").children[1].click();}
> ```
3. Invite user to new studio
4. Promote user to manager
5. Give user `host` privileges
6. Observe (authentication is not required) the `href` of the user profile links on the `/activity` endpoint of the studio. If the usernames correspond to the link destinations, this PR works.