### PR TITLE
Host transfer activity item links to correct actor

### DIFF
--- a/src/views/studio/studio-activity.jsx
+++ b/src/views/studio/studio-activity.jsx
@@ -195,7 +195,7 @@ const getComponentForItem = item => {
                                 </a>
                             ),
                             actorProfileLink: (
-                                <a href={`/users/${item.recipient_username}`}>
+                                <a href={`/users/${item.actor_username}`}>
                                     {item.actor_username}
                                 </a>
                             )


### PR DESCRIPTION
### Resolves:

#6367

In the below notification, both username links linked to the new host's profile (user_pbkdf2_10000.) The actor's username (user_sha1) should link to the actor's profile.
![image](https://user-images.githubusercontent.com/4612592/145457419-f4b91634-e6ba-406a-8b17-92468ab00415.png)

### Changes:

The activity feed notification for host transfer now links correctly to the actor's profile.

### Test Coverage:

The studio activity component currently does not have test coverage.

To test this manually:
* In a studio that you (a non-admin) own with at least one other manager, transfer the studio to another manager:
![image](https://user-images.githubusercontent.com/4612592/145458312-1fae7759-8144-4e1e-9910-8ec795364d40.png)
* Go to the studio activity tab and click the links in the new activity item.
