### PR TITLE
use large resource_class in CircleCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ aliases:
         - v1-build-
   - &build
     <<: *defaults
-    resource_class: medium+
+    resource_class: large
     steps:
       - *restore_git_cache
       - checkout


### PR DESCRIPTION
### Resolves:

Builds have been failing because we've run out of RAM in Circle

### Changes:

Upgrades to the Large resource_class for the build job


