### PR TITLE
circleci add build_pr job that runs on prs, old build doesn't run on prs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ workflows:
                 - develop
   build-test-pr:
     jobs:
-      - build_pr:
+      - build-pr:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,33 @@ aliases:
       keys:
         - v1-build-{{ .Revision }}
         - v1-build-
+  - &build_pr
+    <<: *defaults
+    resource_class: medium+
+    steps:
+      - checkout
+      - run:
+          name: "setup"
+          command: |
+            npm --production=false ci
+            mkdir ./test/results
+      - run:
+          name: "run lint tests"
+          command: |
+            npm run test:lint:ci
+      - run:
+          name: "run npm build"
+          command: |
+            WWW_VERSION=${CIRCLE_SHA1:0:5} npm run build
+      - run:
+          name: "Run unit tests"
+          command: |
+            JEST_JUNIT_OUTPUT_NAME=unit-jest-results.xml npm run test:unit:jest:unit -- --reporters=jest-junit
+            JEST_JUNIT_OUTPUT_NAME=localization-jest-results.xml npm run test:unit:jest:localization -- --reporters=jest-junit
+            npm run test:unit:tap -- --output-file ./test/results/unit-raw.tap
+            npm run test:unit:convertReportToXunit
+      - store_test_results:
+          path: test/results
   - &build
     <<: *defaults
     resource_class: medium+
@@ -129,6 +156,8 @@ jobs:
     <<: *integration_jest
   update-translations:
     <<: *update-translations
+  build-pr:
+    <<: *build_pr
 
 workflows:
   build-test-deploy:
@@ -139,8 +168,10 @@ workflows:
             - scratch-www-staging
           filters:
             branches:
-              ignore:
-                - master
+              only:
+                - develop
+                - /^hotfix\/.*/
+                - /^release\/.*/
       - build-production:
           context:
             - scratch-www-all
@@ -209,3 +240,13 @@ workflows:
             branches:
               only:
                 - develop
+  build-test-pr:
+    jobs:
+      - build_pr:
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+                - /^hotfix\/.*/
+                - /^release\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ aliases:
       keys:
         - v1-build-{{ .Revision }}
         - v1-build-
-  - &build_pr
+  - &build_no_cache
     <<: *defaults
     resource_class: medium+
     steps:
@@ -156,8 +156,8 @@ jobs:
     <<: *integration_jest
   update-translations:
     <<: *update-translations
-  build-pr:
-    <<: *build_pr
+  build-no-cache:
+    <<: *build_no_cache
 
 workflows:
   build-test-deploy:
@@ -240,9 +240,9 @@ workflows:
             branches:
               only:
                 - develop
-  build-test-pr:
+  build-test-no-deploy:
     jobs:
-      - build-pr:
+      - build-no-cache:
           filters:
             branches:
               ignore:


### PR DESCRIPTION
### Resolves:

build jobs were storing artifacts and caches when running on PRs, wasting resources.

### Changes:

Makes a new version of the build job, build_pr, that will be run on PRs only.
Stops running the old build job on PRs.


