### PR TITLE
Focus comment reply textarea when it appears

### DIFF
--- a/src/views/preview/comment/compose-comment.jsx
+++ b/src/views/preview/comment/compose-comment.jsx
@@ -360,6 +360,7 @@ class ComposeComment extends React.Component {
                                     type="textarea"
                                     value={this.state.message}
                                     onInput={this.handleInput}
+                                    autoFocus={this.props.isReply}
                                 />
                                 <FlexRow className="compose-bottom-row">
                                     <Button


### PR DESCRIPTION
### Resolves:

Resolves #2668

### Changes:

Adds `autoFocus` to the textarea for replying to a comment.

### Test Coverage:

Tested manually by clicking "reply" on comments on a project and in a studio. I was able to start typing a reply immediately after clicking the button.