### PR TITLE
Use font weight bold consistently for teacher registration form labels

### DIFF
--- a/src/components/forms/radio-group.jsx
+++ b/src/components/forms/radio-group.jsx
@@ -11,7 +11,7 @@ require('./radio-group.scss');
 
 const RadioGroup = props => (
     <FRCRadioGroup
-        className={classNames('radio-group', props.className)}
+        rowClassName={classNames('radio-group', props.className)}
         {... props}
     />
 );

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -792,7 +792,7 @@ class OrganizationStep extends React.Component {
                             }}
                         />
                         <div className="organization-type">
-                            <b><intl.FormattedMessage id="teacherRegistration.orgType" /></b>
+                            <b class="row-label"><intl.FormattedMessage id="teacherRegistration.orgType" /></b>
                             <p className="help-text">
                                 <intl.FormattedMessage id="teacherRegistration.checkAll" />
                             </p>
@@ -833,7 +833,7 @@ class OrganizationStep extends React.Component {
                             />
                         </div>
                         <div className="url-input">
-                            <b><intl.FormattedMessage id="general.website" /></b>
+                            <b className="row-label"><intl.FormattedMessage id="general.website" /></b>
                             <p className="help-text">
                                 <intl.FormattedMessage id="teacherRegistration.notRequired" />
                             </p>

--- a/src/components/registration/steps.jsx
+++ b/src/components/registration/steps.jsx
@@ -792,7 +792,7 @@ class OrganizationStep extends React.Component {
                             }}
                         />
                         <div className="organization-type">
-                            <b class="row-label"><intl.FormattedMessage id="teacherRegistration.orgType" /></b>
+                            <b className="row-label"><intl.FormattedMessage id="teacherRegistration.orgType" /></b>
                             <p className="help-text">
                                 <intl.FormattedMessage id="teacherRegistration.checkAll" />
                             </p>

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -26,6 +26,10 @@
         }
     }
 
+    .row-label {
+        font-weight: 500;
+    }
+
     .help-text {
         margin: .25rem 0;
         text-align: left;
@@ -64,6 +68,14 @@
     }
 
     &.demographics-step {
+        .radio-group {
+            .control-label {
+                strong {
+                    font-weight: 500;
+                }
+            }
+        }
+
         .radio {
             margin: 1.5rem 1.5rem 0 0;
         }

--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -26,8 +26,16 @@
         }
     }
 
-    .row-label {
-        font-weight: 500;
+    .row {
+        label {
+            font-weight: bold;
+        }
+
+        .checkbox {
+            label {
+                font-weight: 300;
+            }
+        }
     }
 
     .help-text {
@@ -68,16 +76,12 @@
     }
 
     &.demographics-step {
-        .radio-group {
-            .control-label {
-                strong {
-                    font-weight: 500;
-                }
-            }
-        }
-
         .radio {
             margin: 1.5rem 1.5rem 0 0;
+
+            label {
+                font-weight: 300;
+            }
         }
 
         input[type="radio"] {


### PR DESCRIPTION
### Resolves:

Resolves #3589

### Changes:

Adds CSS to set the font weight of labels with help text and the "Gender" label to 500 to match the weight of other labels in the teacher registration form.

### Test Coverage:

All labels have the same weight after this change:
![image](https://user-images.githubusercontent.com/51849865/148683812-e38a486f-c40d-477f-9034-ca6e4cd451fd.png)
![image](https://user-images.githubusercontent.com/51849865/148683814-4b75390b-0d2c-424a-ad3d-d528bccafb06.png)
![image](https://user-images.githubusercontent.com/51849865/148683818-627206c4-bc72-4a63-9026-56b17e3e8bb5.png)