### PR TITLE
Increase max-width of studio titles on Explore and search

### DIFF
--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -85,6 +85,12 @@
                     height: 120px;
                 }
             }
+
+            .thumbnail-info {
+                .thumbnail-title {
+                    max-width: 204px;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Resolves:

Resolves #3998 (the part that was not fixed by #4216)

### Changes:

Increases the maximum width of studio titles on the Explore page and in search results to 204 pixels, which is the full width of the tile.

### Test Coverage:

With this change, studio titles are only truncated if they reach the full width of the tile:
![image](https://user-images.githubusercontent.com/51849865/148684362-8fea33a9-96b7-4822-ab5b-7a4e4f0a1481.png)