### PR TITLE
Left-align project instructions and notes on medium window widths

### DIFF
--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -482,8 +482,13 @@ $stage-width: 480px;
         white-space: pre-line;
         font-size: 1rem;
         line-height: 1.5rem;
+        text-align: left;
         flex: 1;
         overflow-wrap: break-word;
+
+        @media #{$medium-and-smaller} {
+            text-align: center;
+        }
     }
 
     .project-description:last-of-type {


### PR DESCRIPTION
### Resolves:

Resolves #4151

### Changes:

Makes project instructions and Notes and Credits always left-aligned on 768px viewport or wider.

### Test Coverage:

Tested on different window widths.