### PR TITLE
Make author username alignment consistent on Explore and search

### DIFF
--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -49,6 +49,7 @@
             .thumbnail-title {
                 float: left;
                 max-width: 164px;
+                text-align: left;
 
                 .thumbnail-creator a {
                     color: $type-gray;


### PR DESCRIPTION
### Resolves:

Resolves #4823

### Changes:

Makes project author usernames on Explore and in search results always left-aligned when the viewport width is below 942px.

### Test Coverage:

Tested on different widths on Explore and search pages.