### PR TITLE
[Hotfix][Master] Fix issue with "see more replies" button on old studio comment threads with > 25 replies

### DIFF
--- a/src/redux/comments.js
+++ b/src/redux/comments.js
@@ -2,7 +2,13 @@ const keyMirror = require('keymirror');
 const mergeWith = require('lodash.mergewith');
 const uniqBy = require('lodash.uniqby');
 
-const COMMENT_LIMIT = 20;
+// Number of replies to fetch at a time.
+// The way this code is currently structured, it expects
+// this number to be the same for project comment reply threads
+// as well as studio comment reply threads.
+// These could be decoupled in the future.
+const REPLY_FETCH_LIMIT = 25;
+
 
 module.exports.Status = keyMirror({
     FETCHED: null,
@@ -108,7 +114,7 @@ module.exports.commentsReducer = (state, action) => {
             comments: state.comments.map(comment => {
                 if (action.replies[comment.id]) {
                     return Object.assign({}, comment, {
-                        moreRepliesToLoad: action.replies[comment.id].length === COMMENT_LIMIT
+                        moreRepliesToLoad: action.replies[comment.id].length === REPLY_FETCH_LIMIT
                     });
                 }
                 return comment;

--- a/src/redux/project-comment-actions.js
+++ b/src/redux/project-comment-actions.js
@@ -4,6 +4,7 @@ const api = require('../lib/api');
 const log = require('../lib/log');
 
 const COMMENT_LIMIT = 20;
+const REPLY_LIMIT = 25; // Number of replies to fetch at a time
 
 const {
     addNewComment,
@@ -28,7 +29,7 @@ const getReplies = (projectId, commentIds, offset, ownerUsername, isAdmin, token
         api({
             uri: `${isAdmin ? '/admin' : `/users/${ownerUsername}`}/projects/${projectId}/comments/${parentId}/replies`,
             authentication: token ? token : null,
-            params: {offset: offset || 0, limit: COMMENT_LIMIT}
+            params: {offset: offset || 0, limit: REPLY_LIMIT}
         }, (err, body, res) => {
             if (err) {
                 return callback(`Error fetching comment replies: ${err}`);

--- a/test/unit-legacy/redux/comments-test.js
+++ b/test/unit-legacy/redux/comments-test.js
@@ -140,9 +140,9 @@ tap.test('setReplies', t => {
     t.equal(state.comments[0].moreRepliesToLoad, false);
     t.equal(state.comments[1].moreRepliesToLoad, false);
 
-    // Getting 20 (COMMENT_LIMIT) replies sets moreRepliesToLoad to true
+    // Getting 25 (REPLY_FETCH_LIMIT) replies sets moreRepliesToLoad to true
     state = reducer(state, Comments.setReplies({
-        id3: (new Array(20)).map((_, i) => ({id: `id${i + 1}`}))
+        id3: (new Array(25)).map((_, i) => ({id: `id${i + 1}`}))
     }));
     t.equal(state.comments[0].moreRepliesToLoad, false);
     t.equal(state.comments[1].moreRepliesToLoad, false);


### PR DESCRIPTION
### Resolves:

Resolves an issue with a regression introduced by #6311 where older studio comment threads with more than 25 replies did not have a "See more replies" button so users could not fetch more comments in the thread.

### Changes:

This change is a forward fix which introduces an update to project comment threads as well. Project comment threads now also fetch 25 replies at a time to match studio comment threads.

Both types of comments display a "See more replies" button after loading batches of 25 replies at a time.

### Test Coverage:

Updated the comments redux test for when the moreRepliesToLoad flag is true.
