### PR TITLE
fix(gh-4969): add missing period to l10n string

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -399,7 +399,7 @@
     "comment.pii.content3": "This is a serious safety issue.",
     "comment.type.unconstructive": "It appears that your most recent comment was saying something that might have been hurtful.",
     "comment.type.unconstructive.past": "It appears that one of your recent comments was saying something that might have been hurtful.",
-    "comment.unconstructive.header": "We encourage you to be supportive when commenting on other people’s projects",
+    "comment.unconstructive.header": "We encourage you to be supportive when commenting on other people’s projects.",
     "comment.unconstructive.content1": "It appears that your comment was saying something that might have been hurtful.",
     "comment.unconstructive.content2": "If you think something could be better, you can say something you like about the project, and make a suggestion about how to improve it.",
     "comment.type.vulgarity": "Your most recent comment appeared to include a bad word.",


### PR DESCRIPTION
### Resolves:

Fixes #4969

### Changes:

Adds missing period to the end of the `comment.unconstructive.header` string.

### Test Coverage:

No tests changed or performed, since it's just a l10n string edit.
