### PR TITLE
fix(gh-6002): fix cursor for ideas tile images

### DIFF
--- a/src/components/ttt-tile/ttt-tile.scss
+++ b/src/components/ttt-tile/ttt-tile.scss
@@ -24,6 +24,7 @@
     border-radius: 1rem 1rem 0 0;
     background: $ui-blue;
     width: 100%;
+    cursor: pointer;
 }
 
 .ttt-tile-image-img {


### PR DESCRIPTION
### Resolves:
Fixes #6002 

### Changes:
Update styling the TTTTile object to make the cursor a pointer on hover of the TTTTile image.

### Test Coverage:
Tried getting the local environment working, but there were some errors. 

I did test manually adding the css attribute to the `ttt-tile-image` class using inspect element, and everything seemed to be working.
