### PR TITLE
webpack config make limit TerserPlugin to parallel: 4

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 // PostCss
 const autoprefixer = require('autoprefixer');
@@ -141,7 +142,14 @@ module.exports = {
                     minChunks: pageRoutes.length // Extract only chunks common to all html pages
                 }
             }
-        }
+        },
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                parallel: 4
+            })
+        ]
+
     },
     plugins: [
         new MiniCssExtractPlugin(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,13 +143,11 @@ module.exports = {
                 }
             }
         },
-        minimize: true,
         minimizer: [
             new TerserPlugin({
                 parallel: 4
             })
         ]
-
     },
     plugins: [
         new MiniCssExtractPlugin(),


### PR DESCRIPTION
### Resolves:

We were running out of memory on Circle CI builds which caused the build to fail.

### Changes:

This PR decreases the parallelism used for running the minifiers to 4 rather than the default. Webpack default uses TerserPlugin, which is what we will continue to do, but in order to not use the default setting we have to add it specifically.
