### PR TITLE
Fixes styling of dropdown menu buttons for safari

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -19,6 +19,7 @@
         color: $type-gray;
         font-size: .875rem;
         appearance: none;
+        -webkit-appearance: none; /* added to fix dropdown appearance on safari */
 
         &::-ms-expand {
             display: none;


### PR DESCRIPTION
### Resolves:

fixes styling of dropdown buttons which looked 3d.

### Changes:

adds `-webkit-appearance: none;`

