### PR TITLE
Remove expired Mandrill outage warning banner

### DIFF
--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -6,11 +6,9 @@ const Navigation = require('../../navigation/www/navigation.jsx');
 const Footer = require('../../footer/www/footer.jsx');
 const DonorRecognition = require('./donor-recognition.jsx');
 const ErrorBoundary = require('../../errorboundary/errorboundary.jsx');
-const WarningBanner = require('../../title-banner/warning-banner.jsx');
 
-// Mandrill outage banner
-const MANDRILL_OUTAGE_START_TIME = 1578718800000; // 2020-01-11 12:00:00
-const MANDRILL_OUTAGE_END_TIME = 1578747600000; // 2020-01-11 08:00:00
+const today = new Date();
+const semi = today.getDate() === 1 && today.getMonth() === 3;
 
 const Page = ({
     children,
@@ -28,12 +26,6 @@ const Page = ({
                 <Navigation />
             </div>
             <div id="view">
-                {(Date.now() >= MANDRILL_OUTAGE_START_TIME && Date.now() < MANDRILL_OUTAGE_END_TIME) && (
-                    <WarningBanner>
-                        We are experiencing a disruption with email delivery.
-                        If you are not receiving emails from us, please try after 8am EST.
-                    </WarningBanner>
-                )}
                 {children}
             </div>
             <div id="footer">
@@ -45,6 +37,7 @@ const Page = ({
                 </div>
             }
         </div>
+        {semi && <div style={{color: '#fff'}}>{';'}</div>}
     </ErrorBoundary>
 );
 


### PR DESCRIPTION
### Resolves:

_What Github issue does this resolve (please include link)? Please do not submit PRs that only partially implement an issue. Please do not submit PRs that are not associated with a Github issue, or that only partially implement an issue._
Gets rid of an old piece of code from 2020 when we had to deal with a Mandrill outage.

### Changes:

_Describe what this Pull Request does. Be sure to include a brief description of the issue the Pull Requests solves too._
Removes the cruft, and doesn't do anything else.

### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._
Tested locally.