### PR TITLE
Fix format of url of caret.svg in language selector

### DIFF
--- a/src/components/forms/select.scss
+++ b/src/components/forms/select.scss
@@ -11,7 +11,7 @@
         margin-bottom: .75rem;
         border: 1px solid $active-gray;
         border-radius: 5px;
-        background: $ui-light-gray url("../../../static/svgs/forms/caret.svg") no-repeat right center;
+        background: $ui-light-gray url("/svgs/forms/caret.svg") no-repeat right center;
         padding-right: 4rem;
         padding-left: 1rem;
         width: 100%;
@@ -43,7 +43,7 @@
 
         &:focus,
         &:hover {
-            background: $ui-light-gray url("../../../static/svgs/forms/caret-hover.svg") no-repeat right center;
+            background: $ui-light-gray url("/svgs/forms/caret-hover.svg") no-repeat right center;
         }
 
         > option {


### PR DESCRIPTION
also caret-hover.svg

### Resolves:

The caret on the language selector in the footer was not showing up.  

### Changes:

Updates the urls provided to the url() function in select.scss to the correct format.
Changes it for caret.svg and caret-hover.svg

### Test Coverage:

Checked on Chrome and Safari
