### PR TITLE
Fix Explore/search tile overflow when avatars don't load

### DIFF
--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -45,6 +45,8 @@
                     height: 32px;
                     display: block;
                     overflow: hidden;
+                    text-indent: 100%;
+                    white-space: nowrap;
                 }
             }
 

--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -43,6 +43,8 @@
                     border-radius: 4px;
                     width: 32px;
                     height: 32px;
+                    display: block;
+                    overflow: hidden;
                 }
             }
 


### PR DESCRIPTION
### Resolves:

Resolves #4822

### Changes:

Adds `overflow: hidden` to avatars on Explore and search.

### Test Coverage:

Tested by manually setting an invalid URL.
![image](https://user-images.githubusercontent.com/51849865/158357949-4265163e-3526-4468-a2e6-33a5a411a254.png)