### PR TITLE
Correct comment compose spacing

### DIFF
--- a/src/components/commenting-status/commenting-status.scss
+++ b/src/components/commenting-status/commenting-status.scss
@@ -4,7 +4,7 @@
     border: 1px solid $ui-blue-10percent;
     border-radius: 8px;
     padding: 1.75rem 3rem 2rem;
-    margin: .5rem 0 2.25rem;
+    margin: .5rem 0 2rem;
     background-color: $ui-blue-10percent;
     text-align: center;
     box-sizing: border-box;

--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -1,10 +1,5 @@
 @import "../../../colors";
 
-.compose-row, .compose-disabled {
-    margin-top: 30px;
-    margin-bottom: 32px;
-}
-
 .compose-comment {
     margin-left: .5rem;
     width: 100%;
@@ -42,6 +37,7 @@
 
     .compose-bottom-row {
         width: 100%;
+        margin-top: 0.4rem;
         justify-content: space-between;
         flex-direction: row;
 
@@ -61,6 +57,8 @@
 
         .button {
             margin-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
             border-radius: .25rem;
         }
     }
@@ -298,11 +296,12 @@
 }
 
 .comments-root-reply {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
 }
 
 .comment-reply-row {
-    margin-top: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: .5rem;
     margin-left: .5rem;
     width: 100%;
 }

--- a/src/views/studio/studio-comments.jsx
+++ b/src/views/studio/studio-comments.jsx
@@ -110,10 +110,12 @@ const StudioComments = ({
                 <div>
                     {shouldShowCommentComposer ?
                         (commentsAllowed ?
-                            <ComposeComment
-                                postURI={postURI}
-                                onAddComment={handleNewComment}
-                            /> :
+                            <div className="comments-root-reply">
+                                <ComposeComment
+                                    postURI={postURI}
+                                    onAddComment={handleNewComment}
+                                />
+                            </div> :
                             <StudioCommentsNotAllowed />
                         ) : null
                     }

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -509,6 +509,10 @@ $radius: 8px;
 .studio-compose-container {
     padding-top: 8px;
 
+    .comments-root-reply {
+        margin-top: 20px;
+    }
+
     .load-more-button {
         width: 100%;
     }


### PR DESCRIPTION
### Resolves:

Resolves #5889

### Changes:

Makes changes to CSS to make the padding above and below the comment compose box always exactly 32px.

### Test Coverage:

Tested on project and studio pages by checking the padding values using Inspect.