### PR TITLE
Fix reply input indentation and alignment

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -267,6 +267,11 @@
 
 .replies {
     width: calc(100% - 4rem);
+
+    .comment-reply-row {
+        margin-left: -3.5rem;
+        width: calc(100% + 3.5rem);
+    }
 }
 
 .replies.collapsed > .comment:last-of-type {
@@ -304,7 +309,7 @@
 .comment-reply-row {
     margin-top: 1.5rem;
     margin-left: .5rem;
-    width: 100%;
+    width: calc(100% - 0.5rem);
 }
 
 .expand-thread {


### PR DESCRIPTION
### Resolves:

Resolves #5951

### Changes:

Removes extra indentation when replying to a reply and aligns the right end of the reply input correctly.

### Test Coverage:

Tested in project and studio comments.
![image](https://user-images.githubusercontent.com/51849865/158380930-5e1f953c-b459-40be-9190-2d4acf2856a7.png)