### PR TITLE
Fix studio comment issues on narrow screens

### DIFF
--- a/src/views/preview/comment/comment.scss
+++ b/src/views/preview/comment/comment.scss
@@ -75,6 +75,7 @@
 .comment {
     position: relative;
     width: 100%;
+    flex-direction: row;
     flex-wrap: nowrap;
     justify-content: space-between;
     align-items: flex-start;
@@ -100,6 +101,7 @@
     .comment-top-row {
         margin-bottom: 8px;
         width: 100%;
+        flex-direction: row;
 
         .username {
             margin-right: auto;
@@ -239,6 +241,7 @@
         .comment-bottom-row {
             padding-top: 1rem;
             font-size: .75rem;
+            flex-direction: row;
             justify-content: space-between;
 
             .comment-time {

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -235,10 +235,6 @@ $stage-width: 480px;
             width: 100%;
         }
 
-        .comment, .comment-top-row, .comment-bottom-row {
-            flex-direction: row;
-        }
-
         .comment-bubble {
             text-align: left;
         }


### PR DESCRIPTION
### Resolves:

Resolves #6037

### Changes:

Moves a few lines of code from `preview.scss` to `comment.scss` to fix the layout of studio comments on narrow screens.

### Test Coverage:

Tested by resizing the browser window and comparing this branch with scratch.mit.edu.