### PR TITLE
Update date and time for conference and padding around 'stay tuned'

### DIFF
--- a/src/views/conference/2022/index/index.jsx
+++ b/src/views/conference/2022/index/index.jsx
@@ -10,6 +10,13 @@ const TitleBanner = require('../../../../components/title-banner/title-banner.js
 require('../../../../components/forms/button.scss');
 require('./index.scss');
 
+const conferenceDate = (<FormattedDate
+    day="2-digit"
+    month="long"
+    value={new Date(2022, 6, 21)}
+    year="numeric"
+/>);
+
 const ConferenceSplash = () => (
     <div className="index mod-2022">
         <TitleBanner className="mod-conference mod-2022">
@@ -20,7 +27,7 @@ const ConferenceSplash = () => (
                 </center>
             </h1>
             <h3 className="title-banner-h3 mod-2022">
-                <FormattedMessage id="conference-2022.dateDesc" />
+                {conferenceDate}
             </h3>
         </TitleBanner>
         <div className="inner">
@@ -44,12 +51,8 @@ const ConferenceSplash = () => (
                             </td>
                             <td><FormattedMessage id="conference-2022.date" /></td>
                             <td>
-                                <FormattedDate
-                                    day="2-digit"
-                                    month="long"
-                                    value={new Date(2022, 6, 22)}
-                                    year="numeric"
-                                />
+                                {conferenceDate}{' '}
+                                <FormattedMessage id="conference-2022.eventTime" />
                             </td>
                         </tr>
                         <tr className="conf2022-panel-row">
@@ -65,6 +68,7 @@ const ConferenceSplash = () => (
                         </tr>
                     </tbody>
                 </table>
+                <br />
                 <center>
                     <FormattedMessage id="conference-2022.register" />
                 </center>

--- a/src/views/conference/2022/index/l10n.json
+++ b/src/views/conference/2022/index/l10n.json
@@ -1,11 +1,10 @@
 {
     "conference-2022.title": "Scratch Conference 2022",
-    "conference-2022.subtitle": "An Online Conference",
-    "conference-2022.dateDesc": "July 21, 2022",
     "conference-2022.locationDetails": "Online",
 
     "conference-2022.date": "When:",
     "conference-2022.location": "Where:",
+    "conference-2022.eventTime": "10 AM - 4 PM ET",
 
     "conference-2022.desc1": "Join us for Scratch Conference 2022, an online gathering for educators interested in creative learning with Scratch! This year's theme will be \"What will you create?\"",
     "conference-2022.desc1a": "Although we are not able to meet in person this year, we are excited to find ways to connect and share with others in the global Scratch educator community.",


### PR DESCRIPTION
- Fixes inconsistent date on 2022 conference page.
- Add conference time.
- Fix padding around "stay tuned" sentence

<img width="940" alt="image" src="https://user-images.githubusercontent.com/1786240/158694440-ae77b531-114b-4dd4-a658-62807ff9de4f.png">

