### PR TITLE
fix(gh-6377): fix typos in alt text

### DIFF
--- a/src/views/annual-report/2020/l10n.json
+++ b/src/views/annual-report/2020/l10n.json
@@ -348,7 +348,7 @@
 
     "annualReport.2020.altTutorial": "A Scratch tutorial in Spanish",
     "annualReport.2020.altGettingStarted": "A play button sits on top of the Scratch UI.",
-    "annualReport.2020.altEditor": "The Scratch UI along wiht a preview of th progam currently being built showing two people talking to each other.",
+    "annualReport.2020.altEditor": "The Scratch UI along with a preview of the progam currently being built showing two people talking to each other.",
     "annualReport.2020.altHackYourWindow": "A dog in a space helmet, a star, and a donut float outside a window in space.",
     "annualReport.2020.altScratchInteraction": "Two people talk amongst scratch components. One is handing a component to the other one.",
     "annualReport.2020.altImageBubbles": "Images from Scratch projects appear in bubble shapes grouped together.",


### PR DESCRIPTION
### Resolves:

Fixes #6377 

### Changes:

Fixes the typos as per the comments in the issue.
- `wiht` -> `with`
- `th` -> `the`

### Test Coverage:

Didn't conduct any testing, but it's also only a l10n file edit.
