### PR TITLE
fix(gh-6316): make links open in new tabs

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -17,7 +17,7 @@ const About = () => (
                 <p><FormattedMessage
                     id="about.introOne"
                     values={{foundationLink: (
-                        <a 
+                        <a
                             href="https://www.scratchfoundation.org/"
                             rel="noreferrer noopener"
                             target="_blank"
@@ -116,7 +116,7 @@ const About = () => (
                         id="about.quotesDescription"
                         values={{
                             quotesLink: (
-                                <a 
+                                <a
                                     href="/info/quotes/"
                                     rel="noreferrer noopener"
                                     target="_blank"
@@ -143,7 +143,7 @@ const About = () => (
                                 </a>
                             ),
                             lifelongKindergartenGroupLink: (
-                                <a 
+                                <a
                                     href="https://www.media.mit.edu/groups/lifelong-kindergarten/overview/"
                                     rel="noreferrer noopener"
                                     target="_blank"
@@ -170,7 +170,7 @@ const About = () => (
                                 </a>
                             ),
                             statisticsLink: (
-                                <a 
+                                <a
                                     href="/statistics"
                                     rel="noreferrer noopener"
                                     target="_blank"
@@ -179,7 +179,7 @@ const About = () => (
                                 </a>
                             ),
                             annualReportLink: (
-                                <a 
+                                <a
                                     href="/annual-report"
                                     rel="noreferrer noopener"
                                     target="_blank"
@@ -234,7 +234,7 @@ const About = () => (
                             )
                         }}
                     /></p>
-                    <a 
+                    <a
                         href="//secure.donationpay.org/scratchfoundation/"
                         rel="noreferrer noopener"
                         target="_blank"

--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -118,8 +118,6 @@ const About = () => (
                             quotesLink: (
                                 <a
                                     href="/info/quotes/"
-                                    rel="noreferrer noopener"
-                                    target="_blank"
                                 >
                                     <FormattedMessage id="about.quotesLinkText" />
                                 </a>
@@ -172,8 +170,6 @@ const About = () => (
                             statisticsLink: (
                                 <a
                                     href="/statistics"
-                                    rel="noreferrer noopener"
-                                    target="_blank"
                                 >
                                     <FormattedMessage id="about.statisticsLinkText" />
                                 </a>
@@ -181,8 +177,6 @@ const About = () => (
                             annualReportLink: (
                                 <a
                                     href="/annual-report"
-                                    rel="noreferrer noopener"
-                                    target="_blank"
                                 >
                                     <FormattedMessage id="about.annualReportLinkText" />
                                 </a>

--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -17,7 +17,11 @@ const About = () => (
                 <p><FormattedMessage
                     id="about.introOne"
                     values={{foundationLink: (
-                        <a href="https://www.scratchfoundation.org/">
+                        <a 
+                            href="https://www.scratchfoundation.org/"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                        >
                             <FormattedMessage id="about.foundationText" />
                         </a>
                     )}}
@@ -112,7 +116,11 @@ const About = () => (
                         id="about.quotesDescription"
                         values={{
                             quotesLink: (
-                                <a href="/info/quotes/">
+                                <a 
+                                    href="/info/quotes/"
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                >
                                     <FormattedMessage id="about.quotesLinkText" />
                                 </a>
                             )
@@ -135,7 +143,11 @@ const About = () => (
                                 </a>
                             ),
                             lifelongKindergartenGroupLink: (
-                                <a href="https://www.media.mit.edu/groups/lifelong-kindergarten/overview/">
+                                <a 
+                                    href="https://www.media.mit.edu/groups/lifelong-kindergarten/overview/"
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                >
                                     <FormattedMessage id="about.lifelongKindergartenGroupLinkText" />
                                 </a>
                             ),
@@ -158,12 +170,20 @@ const About = () => (
                                 </a>
                             ),
                             statisticsLink: (
-                                <a href="/statistics">
+                                <a 
+                                    href="/statistics"
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                >
                                     <FormattedMessage id="about.statisticsLinkText" />
                                 </a>
                             ),
                             annualReportLink: (
-                                <a href="/annual-report">
+                                <a 
+                                    href="/annual-report"
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                >
                                     <FormattedMessage id="about.annualReportLinkText" />
                                 </a>
                             )
@@ -214,7 +234,11 @@ const About = () => (
                             )
                         }}
                     /></p>
-                    <a href="//secure.donationpay.org/scratchfoundation/">
+                    <a 
+                        href="//secure.donationpay.org/scratchfoundation/"
+                        rel="noreferrer noopener"
+                        target="_blank"
+                    >
                         <Button className="about-button">
                             <FormattedMessage id="about.donateButton" />
                         </Button>


### PR DESCRIPTION
### Resolves:
Fixes #6316 

### Changes:
- if a link is a) external, or b) embedded within a paragraph, make the link open in a new tab

### Test Coverage:
Tested on local build, Chrome on MacOS.
