### PR TITLE
Update credits page

### DIFF
--- a/src/views/annual-report/2020/people.json
+++ b/src/views/annual-report/2020/people.json
@@ -225,7 +225,7 @@
         "userId": 974363
     },
     {
-        "name": "Zoe",
+        "name": "Zo\u00eb",
         "userName": "Zinnea",
         "userId": 35911243
     }

--- a/src/views/credits/people.json
+++ b/src/views/credits/people.json
@@ -1,257 +1,332 @@
 [
-	{
-		"userName": "cosmosaura",
-		"userId": 61436283,
-		"name": "Achal"
-	},
-	{
-		"userName": "themorningsun",
-		"userId": 79849553,
-		"name": "Addae"
-	},
-	{
-		"userName": "LeopardFlash",
-		"userId": 71683519,
-		"name": "Aishat"
-	},
-	{
-		"userName": "originalwow",
-		"userId": 56182496,
-		"name": "Amielle"
-	},
-	{
-		"userName": "amylaser",
-		"userId": 17462181,
-		"name": "Amy"
-	},
-	{
-		"userName": "achouse",
-		"userId": 4747093,
-		"name": "Annie"
-	},
-	{
-		"userName": "wheelsonfire",
-		"userId": 10001044,
-		"name": "Ben"
-	},
-	{
-		"userName": "beezy333",
-		"userId": 79626299,
-		"name": "Breanna"
-	},
-	{
-		"userName": "BrycedTea",
-		"userId": 2029640,
-		"name": "Bryce"
-	},
-	{
-		"userName": "designerd",
-		"userId": 3581881,
-		"name": "Carl"
-	},
-	{
-		"userName": "chrisg",
-		"userId": 1494,
-		"name": "Chris"
-	},
-	{
-		"userName": "cwillisf",
-		"userId": 3532363,
-		"name": "Chris"
-	},
-	{
-		"userName": "ceebee",
-		"userId": 2755634,
-		"name": "Christan"
-	},
-	{
-		"userName": "floralsunset",
-		"userId": 64635632,
-		"name": "Cindy"
-	},
-	{
-		"userName": "codubee",
-		"userId": 10866958,
-		"name": "Colby"
-	},
-	{
-		"userName": "spectre_specs",
-		"userId": 79615865,
-		"name": "Courtney"
-	},
-	{
-		"userName": "noncanonical",
-		"userId": 55851826,
-		"name": "Craig"
-	},
-	{
-		"userName": "Harakou",
-		"userId": 373646,
-		"name": "Dalton"
-	},
-	{
-		"userName": "SunnyDay4aBlueJay",
-		"userId": 24164779,
-		"name": "Ellen"
-	},
-	{
-		"userName": "ericr",
-		"userId": 159,
-		"name": "Eric"
-	},
-	{
-		"userName": "speakvisually",
-		"userId": 3484484,
-		"name": "Eric"
-	},
-	{
-		"userName": "cheddargirl",
-		"userId": 159139,
-		"name": "Franchette"
-	},
-	{
-		"userName": "starry_sky7",
-		"userId": 61374093,
-		"name": "Iuliia"
-	},
-	{
-		"userName": "bluecrazie",
-		"userId": 50257624,
-		"name": "JT"
-	},
-	{
-		"userName": "pixelmoth",
-		"userId": 2408962,
-		"name": "Jacy"
-	},
-	{
-		"userName": "FredDog",
-		"userId": 2496866,
-		"name": "Jolie"
-	},
-	{
-		"userName": "Class12321",
-		"userId": 2871308,
-		"name": "Joshua"
-	},
-	{
-		"userName": "MunchtheCat",
-		"userId": 59383434,
-		"name": "Kait"
-	},
-	{
-		"userName": "kittyloaf",
-		"userId": 27383273,
-		"name": "Karishma"
-	},
-	{
-		"userName": "dinopickles",
-		"userId": 34607790,
-		"name": "Katelyn"
-	},
-	{
-		"userName": "pondermake",
-		"userId": 26779669,
-		"name": "Kathy"
-	},
-	{
-		"userName": "Lamatchalattei",
-		"userId": 61415372,
-		"name": "Lamar"
-	},
-	{
-		"userName": "JumpingRabbits",
-		"userId": 3948118,
-		"name": "Linda"
-	},
-	{
-		"userName": "itzlinz",
-		"userId": 80082947,
-		"name": "Lindsay"
-	},
-	{
-		"userName": "algorithmar",
-		"userId": 43013126,
-		"name": "Maren"
-	},
-	{
-		"userName": "dietbacon",
-		"userId": 24137617,
-		"name": "Mark"
-	},
-	{
-		"userName": "Paddle2See",
-		"userId": 49156,
-		"name": "Mark"
-	},
-	{
-		"userName": "deism902",
-		"userId": 78735197,
-		"name": "Melodie"
-	},
-	{
-		"userName": "pamimus",
-		"userId": 74474548,
-		"name": "Mimi"
-	},
-	{
-		"userName": "raimondious",
-		"userId": 2584924,
-		"name": "Ray"
-	},
-	{
-		"userName": "rtrvmwe",
-		"userId": 61342326,
-		"name": "Retrouvailles"
-	},
-	{
-		"userName": "binnieb",
-		"userId": 53715539,
-		"name": "Robyn"
-	},
-	{
-		"userName": "rupalax",
-		"userId": 58005604,
-		"name": "Rupa"
-	},
-	{
-		"userName": "Rhyolyte",
-		"userId": 80776012,
-		"name": "Ryan"
-	},
-	{
-		"userName": "scmb1",
-		"userId": 246290,
-		"name": "Sarah"
-	},
-	{
-		"userName": "Onyx45",
-		"userId": 63526043,
-		"name": "Shawna"
-	},
-	{
-		"userName": "sgste735",
-		"userId": 69368419,
-		"name": "Stephanie"
-	},
-	{
-		"userName": "LT7845",
-		"userId": 68837085,
-		"name": "Tasha"
-	},
-	{
-		"userName": "Pandatt",
-		"userId": 18417774,
-		"name": "Tracy"
-	},
-	{
-		"userName": "Za-Chary",
-		"userId": 974363,
-		"name": "Zachary"
-	},
-	{
-		"userName": "Zinnea",
-		"userId": 35911243,
-		"name": "Zoë"
-	}
+    {
+        "userName": "cosmosaura",
+        "userId": 61436283,
+        "name": "Achal"
+    },
+    {
+        "userName": "themorningsun",
+        "userId": 79849553,
+        "name": "Addae"
+    },
+    {
+        "userName": "LeopardFlash",
+        "userId": 71683519,
+        "name": "Aishat"
+    },
+    {
+        "userName": "RulerOfTheQueendom",
+        "userId": 82775985,
+        "name": "Alexis"
+    },
+    {
+        "userName": "originalwow",
+        "userId": 56182496,
+        "name": "Amielle"
+    },
+    {
+        "userName": "amylaser",
+        "userId": 17462181,
+        "name": "Amy"
+    },
+    {
+        "userName": "achouse",
+        "userId": 4747093,
+        "name": "Annie"
+    },
+    {
+        "userName": "mogibear",
+        "userId": 5808866,
+        "name": "Ariam"
+    },
+    {
+        "userName": "carpeediem",
+        "userId": 85830206,
+        "name": "Ashlee"
+    },
+    {
+        "userName": "wheelsonfire",
+        "userId": 10001044,
+        "name": "Ben"
+    },
+    {
+        "userName": "digital-gig",
+        "userId": 79596311,
+        "name": "Bob"
+    },
+    {
+        "userName": "beezy333",
+        "userId": 79626299,
+        "name": "Breanna"
+    },
+    {
+        "userName": "BrycedTea",
+        "userId": 2029640,
+        "name": "Bryce"
+    },
+    {
+        "userName": "designerd",
+        "userId": 3581881,
+        "name": "Carl"
+    },
+    {
+        "userName": "chrisg",
+        "userId": 1494,
+        "name": "Chris"
+    },
+    {
+        "userName": "cwillisf",
+        "userId": 3532363,
+        "name": "Chris"
+    },
+    {
+        "userName": "ceebee",
+        "userId": 2755634,
+        "name": "Christan"
+    },
+    {
+        "userName": "floralsunset",
+        "userId": 64635632,
+        "name": "Cindy"
+    },
+    {
+        "userName": "codubee",
+        "userId": 10866958,
+        "name": "Colby"
+    },
+    {
+        "userName": "spectre_specs",
+        "userId": 79615865,
+        "name": "Courtney"
+    },
+    {
+        "userName": "noncanonical",
+        "userId": 55851826,
+        "name": "Craig"
+    },
+    {
+        "userName": "Ohsohpy",
+        "userId": 85652763,
+        "name": "Crystal"
+    },
+    {
+        "userName": "BlueWillow78",
+        "userId": 86427896,
+        "name": "Deborah"
+    },
+    {
+        "userName": "deeplikethesea",
+        "userId": 87998393,
+        "name": "Deep"
+    },
+    {
+        "userName": "epa85",
+        "userId": 83956975,
+        "name": "Elaine"
+    },
+    {
+        "userName": "ericr",
+        "userId": 159,
+        "name": "Eric"
+    },
+    {
+        "userName": "speakvisually",
+        "userId": 3484484,
+        "name": "Eric"
+    },
+    {
+        "userName": "scratcher-erik",
+        "userId": 82778056,
+        "name": "Erik"
+    },
+    {
+        "userName": "cheddargirl",
+        "userId": 159139,
+        "name": "Fran"
+    },
+    {
+        "userName": "fcoCCT",
+        "userId": 721727,
+        "name": "Francisco"
+    },
+    {
+        "userName": "pixelmoth",
+        "userId": 2408962,
+        "name": "Jacy"
+    },
+    {
+        "userName": "GourdVibesOnly",
+        "userId": 83196398,
+        "name": "Jo"
+    },
+    {
+        "userName": "MunchtheCat",
+        "userId": 59383434,
+        "name": "Kaitlyn"
+    },
+    {
+        "userName": "kittyloaf",
+        "userId": 27383273,
+        "name": "Karishma"
+    },
+    {
+        "userName": "dinopickles",
+        "userId": 34607790,
+        "name": "Katelyn"
+    },
+    {
+        "userName": "Roxie916",
+        "userId": 86101613,
+        "name": "Kathryn"
+    },
+    {
+        "userName": "lashaunan",
+        "userId": 91118517,
+        "name": "La Shauna"
+    },
+    {
+        "userName": "lamatchalattei",
+        "userId": 61415372,
+        "name": "Lamar"
+    },
+    {
+        "userName": "shinyvase275",
+        "userId": 88789309,
+        "name": "Laura"
+    },
+    {
+        "userName": "JumpingRabbits",
+        "userId": 3948118,
+        "name": "Linda"
+    },
+    {
+        "userName": "ItzLinz",
+        "userId": 80082947,
+        "name": "Lindsay"
+    },
+    {
+        "userName": "algorithmar",
+        "userId": 43013126,
+        "name": "Maren"
+    },
+    {
+        "userName": "TheNuttyKnitter",
+        "userId": 88343200,
+        "name": "Maria"
+    },
+    {
+        "userName": "soutoam",
+        "userId": 79824929,
+        "name": "Mariana"
+    },
+    {
+        "userName": "dietbacon",
+        "userId": 24137617,
+        "name": "Mark"
+    },
+    {
+        "userName": "Paddle2See",
+        "userId": 49156,
+        "name": "Mark"
+    },
+    {
+        "userName": "deism902",
+        "userId": 78735197,
+        "name": "Melodie"
+    },
+    {
+        "userName": "pamimus",
+        "userId": 74474548,
+        "name": "Mimi"
+    },
+    {
+        "userName": "raimondious",
+        "userId": 2584924,
+        "name": "Ray"
+    },
+    {
+        "userName": "rtrvmwe",
+        "userId": 61342326,
+        "name": "Retro"
+    },
+    {
+        "userName": "binnieb",
+        "userId": 53715539,
+        "name": "Robyn"
+    },
+    {
+        "userName": "delasare",
+        "userId": 88383612,
+        "name": "Ron"
+    },
+    {
+        "userName": "RupaLax",
+        "userId": 58005604,
+        "name": "Rupa"
+    },
+    {
+        "userName": "Rhyolyte",
+        "userId": 80776012,
+        "name": "Ryan"
+    },
+    {
+        "userName": "scmb1",
+        "userId": 246290,
+        "name": "Sarah"
+    },
+    {
+        "userName": "Onyx45",
+        "userId": 63526043,
+        "name": "Shawna"
+    },
+    {
+        "userName": "RagingAvocado",
+        "userId": 79263979,
+        "name": "Shen"
+    },
+    {
+        "userName": "sgste735",
+        "userId": 69368419,
+        "name": "Stephanie"
+    },
+    {
+        "userName": "LT7845",
+        "userId": 68837085,
+        "name": "Tasha"
+    },
+    {
+        "userName": "cardboardbee",
+        "userId": 83142859,
+        "name": "Tom"
+    },
+    {
+        "userName": "pandatt",
+        "userId": 18417774,
+        "name": "Tracy"
+    },
+    {
+        "userName": "passiflora296",
+        "userId": 84104816,
+        "name": "Valerie"
+    },
+    {
+        "userName": "ninja11013",
+        "userId": 85158705,
+        "name": "Vicki"
+    },
+    {
+        "userName": "starry_sky7",
+        "userId": 61374093,
+        "name": "Yulia"
+    },
+    {
+        "userName": "YPhilip2006",
+        "userId": 80892866,
+        "name": "Yvette"
+    },
+    {
+        "userName": "Zinnea",
+        "userId": 35911243,
+        "name": "Zo\u00eb"
+    }
 ]


### PR DESCRIPTION
### Changes:

- Update the team members on the credits page. There should be 66 people in total.
- I also fixed a typo I noticed in a team member's name on the 2020 annual report page.

### Test Coverage:

Tested locally that the some of the links open up to the correct profiles.
