### PR TITLE
Make /annual-report use localization file of 2020 report

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -12,6 +12,7 @@
         "routeAlias": "/annual-report/?$",
         "view": "annual-report/2020/annual-report",
         "title": "Annual Report 2020",
+        "intlName": "annual-report-2020",
         "viewportWidth": "device-width"
     },
     {

--- a/src/template.ejs
+++ b/src/template.ejs
@@ -79,7 +79,7 @@
         <script src="<%= htmlWebpackPlugin.files.chunks.common.entry %>"></script>
 
         <!-- Scripts -->
-        <script src="/js/<%= htmlWebpackPlugin.options.route.name %>.intl.js"></script>
+        <script src="/js/<%= htmlWebpackPlugin.options.route.intlName || htmlWebpackPlugin.options.route.name %>.intl.js"></script>
         <script src="<%= htmlWebpackPlugin.files.chunks[htmlWebpackPlugin.options.route.name].entry %>"></script>
 
         <!-- Translate title element -->


### PR DESCRIPTION
### Resolves:

The /annual-report route uses the same view as the current annual report (so right now, /annual-report/2020) but is not configured to use that intl.js file, so if you visit the page from the /annual-report url it is not translated.

### Changes:

- `src/template.ejs` now looks for an optional `intlName` route attribute
- The annual-report route now has that attribute that points to 'annual-report-2020' (when new report launched, will change it to 'annual-report-2021')

Note: There are other routes that have fixes for similar problems that take place in other parts of the scripts, such as [here](https://github.com/LLK/scratch-www/blob/develop/bin/build-locales#L134). I'm going to make a backlog ticket for standardizing using routes.json as the source of truth for localization file names in www.

### Test Coverage:

In bughunt, we should check that both "annual-report" and "annual-report/2020" use `annual-report-2020.intl.js` and that they are both equally translated.

Since this changes `src/template.ejs` we should spot check that other www pages are still translated as expected
