### PR TITLE
Update donate banner for Scratch celebration.

### DIFF
--- a/src/views/splash/donate/donate-banner.jsx
+++ b/src/views/splash/donate/donate-banner.jsx
@@ -14,8 +14,6 @@ const navigateToDonatePage = () => {
     window.location = donateURL;
 };
 
-// For Scratch week
-const SCRATCH_CELBRATION_BANNER_START_TIME = new Date(2022, 4, 16).getTime(); // May 16 2022 (months are zero indexed)
 const SCRATCH_CELBRATION_BANNER_END_TIME = new Date(2022, 4, 21).getTime(); // May 21 2022 (months are zero indexed)
 
 // Following the example in the Google Analytics doc here to track
@@ -41,8 +39,7 @@ const DonateTopBanner = ({
                 src="/images/ideas/try-it-icon.svg"
             />
             <div className="donate-central-items">
-                {(Date.now() >= SCRATCH_CELBRATION_BANNER_START_TIME &&
-                    Date.now() < SCRATCH_CELBRATION_BANNER_END_TIME) ?
+                {(Date.now() < SCRATCH_CELBRATION_BANNER_END_TIME) ?
                     (
                         <p className="donate-text">
                             <FormattedMessage

--- a/src/views/splash/donate/donate-banner.jsx
+++ b/src/views/splash/donate/donate-banner.jsx
@@ -14,6 +14,10 @@ const navigateToDonatePage = () => {
     window.location = donateURL;
 };
 
+// For Scratch week
+const SCRATCH_CELBRATION_BANNER_START_TIME = new Date(2022, 4, 16).getTime(); // May 16 2022 (months are zero indexed)
+const SCRATCH_CELBRATION_BANNER_END_TIME = new Date(2022, 4, 21).getTime(); // May 21 2022 (months are zero indexed)
+
 // Following the example in the Google Analytics doc here to track
 // clicks going out to the donate page from this banner:
 // https://support.google.com/analytics/answer/1136920?hl=en
@@ -37,9 +41,26 @@ const DonateTopBanner = ({
                 src="/images/ideas/try-it-icon.svg"
             />
             <div className="donate-central-items">
-                <p className="donate-text">
-                    <FormattedMessage id="donatebanner.askSupport" />
-                </p>
+                {(Date.now() >= SCRATCH_CELBRATION_BANNER_START_TIME &&
+                    Date.now() < SCRATCH_CELBRATION_BANNER_END_TIME) ?
+                    (
+                        <p className="donate-text">
+                            <FormattedMessage
+                                id="donatebanner.scratchWeek"
+                                values={{
+                                    celebrationLink: (
+                                        <a href="https://sip.scratch.mit.edu/scratch-celebration/">
+                                            <FormattedMessage id="donatebanner.learnMore" />
+                                        </a>
+                                    )
+                                }}
+                            />
+                        </p>
+                    ) : (
+                        <p className="donate-text">
+                            <FormattedMessage id="donatebanner.askSupport" />
+                        </p>
+                    )}
                 <Button
                     className="donate-button"
                     key="add-to-studio-button"

--- a/src/views/splash/donate/donate-banner.scss
+++ b/src/views/splash/donate/donate-banner.scss
@@ -59,6 +59,10 @@ $tile-height: 244px;
         right: 1rem;
         top: auto;
     }
+    a {
+        color: $ui-white;
+        text-decoration: underline;
+    }
 }
 
 @media only screen and (max-width: $mobileIntermediate) {

--- a/test/unit/components/donate-banner.test.jsx
+++ b/test/unit/components/donate-banner.test.jsx
@@ -11,9 +11,20 @@ describe('DonateBannerTest', () => {
     afterEach(() => {
         global.Date.now = realDateNow;
     });
-    test('Testing regular banner message', () => {
-        // Date outside of scratch week
-        global.Date.now = () => new Date(2021, 4, 19).getTime();
+    test('Testing Scratch week banner message', () => {
+        const component = mountWithIntl(
+            <DonateTopBanner />
+        );
+
+        expect(component.find('div.donate-banner').exists()).toEqual(true);
+        expect(component.find('p.donate-text').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.scratchWeek"]').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(false);
+
+    });
+    test('testing default message comes back after May 21 ', () => {
+        // Date after Scratch week
+        global.Date.now = () => new Date(2022, 4, 22).getTime();
         const component = mountWithIntl(
             <DonateTopBanner />
         );
@@ -21,16 +32,5 @@ describe('DonateBannerTest', () => {
         expect(component.find('p.donate-text').exists()).toEqual(true);
         expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(true);
         expect(component.find('FormattedMessage[id="donatebanner.scratchWeek"]').exists()).toEqual(false);
-    });
-    test('testing time sensitive scratch week banner message ', () => {
-        // Date within Scratch week 2022
-        global.Date.now = () => new Date(2022, 4, 19).getTime();
-        const component = mountWithIntl(
-            <DonateTopBanner />
-        );
-        expect(component.find('div.donate-banner').exists()).toEqual(true);
-        expect(component.find('p.donate-text').exists()).toEqual(true);
-        expect(component.find('FormattedMessage[id="donatebanner.scratchWeek"]').exists()).toEqual(true);
-        expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(false);
     });
 });

--- a/test/unit/components/donate-banner.test.jsx
+++ b/test/unit/components/donate-banner.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {mountWithIntl} from '../../helpers/intl-helpers.jsx';
+import DonateTopBanner from '../../../src/views/splash/donate/donate-banner';
+
+describe('DonateBannerTest', () => {
+    let realDateNow;
+
+    beforeEach(() => {
+        realDateNow = Date.now.bind(global.Date);
+    });
+    afterEach(() => {
+        global.Date.now = realDateNow;
+    });
+    test('Testing regular banner message', () => {
+        // Date outside of scratch week
+        global.Date.now = () => new Date(2021, 4, 19).getTime();
+        const component = mountWithIntl(
+            <DonateTopBanner />
+        );
+        expect(component.find('div.donate-banner').exists()).toEqual(true);
+        expect(component.find('p.donate-text').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.scratchWeek"]').exists()).toEqual(false);
+    });
+    test('testing time sensitive scratch week banner message ', () => {
+        // Date within Scratch week 2022
+        global.Date.now = () => new Date(2022, 4, 19).getTime();
+        const component = mountWithIntl(
+            <DonateTopBanner />
+        );
+        expect(component.find('div.donate-banner').exists()).toEqual(true);
+        expect(component.find('p.donate-text').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.scratchWeek"]').exists()).toEqual(true);
+        expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(false);
+    });
+});


### PR DESCRIPTION
Switches the banner text to mention Scratch celebration and puts back the regular one after Scratch week is over
![image (29)](https://user-images.githubusercontent.com/15675877/165846776-60e6558d-fc91-474b-b495-03ecc08c4b02.png)
.