### PR TITLE
Switch /annual-report to 2021 report!

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -10,9 +10,9 @@
         "name": "annual-report",
         "pattern": "^/annual-report/?(\\?.*)?$",
         "routeAlias": "/annual-report/?$",
-        "view": "annual-report/2020/annual-report",
-        "title": "Annual Report 2020",
-        "intlName": "annual-report-2020",
+        "view": "annual-report/2021/annual-report",
+        "title": "Annual Report 2021",
+        "intlName": "annual-report-2021",
         "viewportWidth": "device-width"
     },
     {


### PR DESCRIPTION
This changes /annual-report to use the 2021 view and intl file instead of the 2020 ones. 

We are planning to launch the Annual Report in the regular deploy cycle this week. If we have decide to not launch it (because of a blocking bug, for example) we will need to revert the merge of this PR.

In bughunt, we should test:
- /annual-report shows the 2021 report
- /annual-report/2021 shows the 2021 report
- /annual-report/2020 shows the 2020 report
- /annual-report/2021 and /annual-report are equally translated