### PR TITLE
Fix “Creative Expression” description copy in annual report

### DIFF
--- a/src/views/annual-report/2021/l10n.json
+++ b/src/views/annual-report/2021/l10n.json
@@ -34,7 +34,7 @@
     "annualReport.2021.progressiveImprovementTitle": "Progressive Improvement",
     "annualReport.2021.EquitableOpportunitiesTitle": "Equitable Opportunities",
     "annualReport.2021.playfulEngagementTitle": "Playful Engagement",
-    "annualReport.2021.creativeExpressionDescription": "We are building an educational movement inclusive of people from diverse backgrounds so we can reach children around the world who have been excluded from creative coding opportunities.",
+    "annualReport.2021.creativeExpressionDescription": " We are committed to providing everyone with tools and opportunities to express their ideas, their interests, and their authentic selves within a supportive community.",
     "annualReport.2021.progressiveImprovementDescription": "We hold ourselves to a high standard and always strive to iterate, improve, and inspire one another to best serve young people around the world and the community that makes our work possible.",
     "annualReport.2021.EquitableOpportunitiesDescription": "We are building an educational movement inclusive of people from diverse backgrounds so we can reach children around the world who have been excluded from creative coding opportunities.",
     "annualReport.2021.playfulEngagementDescription": "At Scratch, play is an approach for making, sharing, learning, and engaging with the world. We encourage joyful exploration, experimentation, and collaboration.",


### PR DESCRIPTION
The copy for the Creative Expression value was a duplicate of the one for Equitable Opportunities. I fixed it to the copy on the content doc.