### PR TITLE
Update line 172 to say location, not country

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -169,7 +169,7 @@
     "registration.choosePasswordStepTitle": "Create a password",
     "registration.choosePasswordStepTooltip": "Don't use your name or anything that's easy for someone else to guess.",
     "registration.classroomApiGeneralError": "Sorry, we could not find the registration information for this class",
-    "registration.countryStepTitle": "What country do you live in?",
+    "registration.countryStepTitle": "What is your location?",
     "registration.generalError": "Sorry, an unexpected error occurred.",
     "registration.classroomInviteExistingStudentStepDescription": "you have been invited to join the class:",
     "registration.classroomInviteNewStudentStepDescription": "Your teacher has invited you to join a class:",


### PR DESCRIPTION
Not all locations on that list are countries.

### Resolves:
It says "what country you live in" when not every place is a country. 

### Changes:

Changes line 172 to a more accurate description
