### PR TITLE
fixed test for conference link; changed footer link to not involve redirect

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -195,7 +195,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="/conference">
+                        <a href="https://www.scratchfoundation.org/scratch-conference">
                             <FormattedMessage id="general.scratchConference" />
                         </a>
                     </dd>

--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -136,7 +136,7 @@ describe('www-integration footer links', () => {
         await clickText('Scratch Conference');
         let url = await driver.getCurrentUrl();
         let pathname = (new URL(url)).pathname;
-        expect(pathname).toMatch(/^\/conference\/2022\/?$/);
+        expect(pathname).toMatch(/^\/scratch-conference\/?$/);
     });
 
 });


### PR DESCRIPTION
Follow-on to https://github.com/LLK/scratch-www/pull/6876 to fix integration test involving footer link to conference page