### PR TITLE
chore(deps):update dependency scratch-gui to 0.1.0-prerelease.20220706173215

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "regenerator-runtime": "0.13.9",
         "sass": "1.49.7",
         "sass-loader": "10.2.1",
-        "scratch-gui": "0.1.0-prerelease.20220620170924",
+        "scratch-gui": "0.1.0-prerelease.20220706173215",
         "scratch-l10n": "3.14.20220703031542",
         "selenium-webdriver": "4.1.0",
         "slick-carousel": "1.6.0",
@@ -4824,7 +4824,7 @@
     "node_modules/canvas-toBlob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/canvas-toBlob/-/canvas-toBlob-1.0.0.tgz",
-      "integrity": "sha1-m/MrKGu04SUhiyCO7MgyH9Az5sM=",
+      "integrity": "sha512-oU5bawygt/Nef9F+C49eTFmzXzz6yKdGqn6J1wn/LZQF5ulnnZVm0KIZzik85I6tjCbZFH6aa47j4bU2tkHxRw==",
       "dev": true
     },
     "node_modules/capture-exit": {
@@ -6933,7 +6933,7 @@
     "node_modules/decode-html": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/decode-html/-/decode-html-2.0.0.tgz",
-      "integrity": "sha1-fQqIfORCgOYJeKcH67f4CB/WHqo=",
+      "integrity": "sha512-lVJ+EBozhAXA2nSQG+xAgcD0P5K3uejnIIvM09uoQfS8AALkQ+HhHcEUvKovXi0EIpIZWjm0y8X7ULjaJpgY9w==",
       "dev": true
     },
     "node_modules/decode-uri-component": {
@@ -22878,9 +22878,9 @@
       }
     },
     "node_modules/scratch-gui": {
-      "version": "0.1.0-prerelease.20220620170924",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220620170924.tgz",
-      "integrity": "sha512-773Xu60nco3nbltMRrpvYmjUi2kCGM5xTXTIacs0nMThjli9Xoy/tMhFqjfdTgngNatE7I2Huq5rSNIWr6qKmg==",
+      "version": "0.1.0-prerelease.20220706173215",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220706173215.tgz",
+      "integrity": "sha512-pLraYbImVh+LFH4gkFzv+CAEL8akIPwQMtT5YLDD3fJfQ2QU2uT96IHVdHxIY7DLQ1fgupYK0Z+Fa5Ys20mZHA==",
       "dev": true,
       "dependencies": {
         "arraybuffer-loader": "^1.0.6",
@@ -22938,7 +22938,7 @@
         "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
         "scratch-storage": "2.0.2",
         "scratch-svg-renderer": "0.2.0-prerelease.20210727023023",
-        "scratch-vm": "0.2.0-prerelease.20220602121716",
+        "scratch-vm": "1.0.1",
         "startaudiocontext": "1.2.1",
         "style-loader": "^0.23.0",
         "text-encoding": "0.7.0",
@@ -23474,13 +23474,13 @@
     "node_modules/scratch-sb1-converter/node_modules/microee": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha1-oSvbAQNoHosSapsHHrpMRnx4//4=",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
       "dev": true
     },
     "node_modules/scratch-sb1-converter/node_modules/minilog": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
       "dev": true,
       "dependencies": {
         "microee": "0.0.6"
@@ -23544,9 +23544,9 @@
       "dev": true
     },
     "node_modules/scratch-vm": {
-      "version": "0.2.0-prerelease.20220602121716",
-      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-0.2.0-prerelease.20220602121716.tgz",
-      "integrity": "sha512-N7hY2OeMJMybH1GdYwxaj+zu8BUBsiDUCmA0o3UsrVVsKCxcPgHQxJYksWalH1zV3GsWlkXwX6qBarviRmVfbg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.0.1.tgz",
+      "integrity": "sha512-Ua9Y7G8vwjmUZkifxQDfrGmGHDJ4Wry13zRy5Gozy6jTWk/GdMVjkFuk7/qTDz6UU5Xqgyq/92FdD9S8f16TDQ==",
       "dev": true,
       "dependencies": {
         "@vernier/godirect": "1.5.0",
@@ -23588,7 +23588,7 @@
     "node_modules/scratch-vm/node_modules/immutable": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
+      "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -23597,13 +23597,13 @@
     "node_modules/scratch-vm/node_modules/microee": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha1-oSvbAQNoHosSapsHHrpMRnx4//4=",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
       "dev": true
     },
     "node_modules/scratch-vm/node_modules/minilog": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
       "dev": true,
       "dependencies": {
         "microee": "0.0.6"
@@ -35648,7 +35648,7 @@
     "canvas-toBlob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/canvas-toBlob/-/canvas-toBlob-1.0.0.tgz",
-      "integrity": "sha1-m/MrKGu04SUhiyCO7MgyH9Az5sM=",
+      "integrity": "sha512-oU5bawygt/Nef9F+C49eTFmzXzz6yKdGqn6J1wn/LZQF5ulnnZVm0KIZzik85I6tjCbZFH6aa47j4bU2tkHxRw==",
       "dev": true
     },
     "capture-exit": {
@@ -37417,7 +37417,7 @@
     "decode-html": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/decode-html/-/decode-html-2.0.0.tgz",
-      "integrity": "sha1-fQqIfORCgOYJeKcH67f4CB/WHqo=",
+      "integrity": "sha512-lVJ+EBozhAXA2nSQG+xAgcD0P5K3uejnIIvM09uoQfS8AALkQ+HhHcEUvKovXi0EIpIZWjm0y8X7ULjaJpgY9w==",
       "dev": true
     },
     "decode-uri-component": {
@@ -50785,9 +50785,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20220620170924",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220620170924.tgz",
-      "integrity": "sha512-773Xu60nco3nbltMRrpvYmjUi2kCGM5xTXTIacs0nMThjli9Xoy/tMhFqjfdTgngNatE7I2Huq5rSNIWr6qKmg==",
+      "version": "0.1.0-prerelease.20220706173215",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220706173215.tgz",
+      "integrity": "sha512-pLraYbImVh+LFH4gkFzv+CAEL8akIPwQMtT5YLDD3fJfQ2QU2uT96IHVdHxIY7DLQ1fgupYK0Z+Fa5Ys20mZHA==",
       "dev": true,
       "requires": {
         "arraybuffer-loader": "^1.0.6",
@@ -50845,7 +50845,7 @@
         "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
         "scratch-storage": "2.0.2",
         "scratch-svg-renderer": "0.2.0-prerelease.20210727023023",
-        "scratch-vm": "0.2.0-prerelease.20220602121716",
+        "scratch-vm": "1.0.1",
         "startaudiocontext": "1.2.1",
         "style-loader": "^0.23.0",
         "text-encoding": "0.7.0",
@@ -51298,13 +51298,13 @@
         "microee": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-          "integrity": "sha1-oSvbAQNoHosSapsHHrpMRnx4//4=",
+          "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
           "dev": true
         },
         "minilog": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-          "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
+          "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
           "dev": true,
           "requires": {
             "microee": "0.0.6"
@@ -51368,9 +51368,9 @@
       "dev": true
     },
     "scratch-vm": {
-      "version": "0.2.0-prerelease.20220602121716",
-      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-0.2.0-prerelease.20220602121716.tgz",
-      "integrity": "sha512-N7hY2OeMJMybH1GdYwxaj+zu8BUBsiDUCmA0o3UsrVVsKCxcPgHQxJYksWalH1zV3GsWlkXwX6qBarviRmVfbg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.0.1.tgz",
+      "integrity": "sha512-Ua9Y7G8vwjmUZkifxQDfrGmGHDJ4Wry13zRy5Gozy6jTWk/GdMVjkFuk7/qTDz6UU5Xqgyq/92FdD9S8f16TDQ==",
       "dev": true,
       "requires": {
         "@vernier/godirect": "1.5.0",
@@ -51409,19 +51409,19 @@
         "immutable": {
           "version": "3.8.1",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-          "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
+          "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==",
           "dev": true
         },
         "microee": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-          "integrity": "sha1-oSvbAQNoHosSapsHHrpMRnx4//4=",
+          "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
           "dev": true
         },
         "minilog": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-          "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
+          "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
           "dev": true,
           "requires": {
             "microee": "0.0.6"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "regenerator-runtime": "0.13.9",
     "sass": "1.49.7",
     "sass-loader": "10.2.1",
-    "scratch-gui": "0.1.0-prerelease.20220620170924",
+    "scratch-gui": "0.1.0-prerelease.20220706173215",
     "scratch-l10n": "3.14.20220703031542",
     "selenium-webdriver": "4.1.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
Update `scratch-gui` directly instead of waiting for Renovate.