### PR TITLE
fix: use correct CleanSpeak product url

### DIFF
--- a/src/views/parents/parents.jsx
+++ b/src/views/parents/parents.jsx
@@ -222,7 +222,7 @@ const Landing = () => (
                                             </a>
                                         ),
                                         CleanSpeak: (
-                                            <a href="http://www.inversoft.com/features/profanity-filter/">CleanSpeak</a>
+                                            <a href="https://cleanspeak.com/products/profanity-filter/">CleanSpeak</a>
                                         )
                                     }}
                                 />

--- a/src/views/parents/parents.jsx
+++ b/src/views/parents/parents.jsx
@@ -222,7 +222,7 @@ const Landing = () => (
                                             </a>
                                         ),
                                         CleanSpeak: (
-                                            <a href="https://cleanspeak.com/products/profanity-filter/">CleanSpeak</a>
+                                            <a href="https://cleanspeak.com/products/profanity-filter">CleanSpeak</a>
                                         )
                                     }}
                                 />


### PR DESCRIPTION
### Resolves:

Resolves #6933 

### Changes:

* Replaces outdated CleanSpeak url with a link to https://cleanspeak.com/products/profanity-filter

