### PR TITLE
CE-178 Use correct username prefix in 2020 Annual Report

### DIFF
--- a/src/views/annual-report/2020/annual-report.jsx
+++ b/src/views/annual-report/2020/annual-report.jsx
@@ -1716,7 +1716,7 @@ class AnnualReport extends React.Component {
                                         />
                                     </MediaQuery>
                                     <p>
-                                        <FormattedMessage id="annualReport.2020.projectBy" /> u/STORMPRIMEX
+                                        <FormattedMessage id="annualReport.2020.projectBy" /> @STORMPRIMEX
                                     </p>
                                 </div>
                                 <a
@@ -1904,7 +1904,7 @@ class AnnualReport extends React.Component {
                                     projectBy={this.props.intl.formatMessage(
                                         {id: 'annualReport.2020.projectBy'}
                                     )}
-                                    attribution="u/lukiepie2011"
+                                    attribution="@lukiepie2011"
                                 />
                                 <img
                                     className="connector left"
@@ -2002,7 +2002,7 @@ class AnnualReport extends React.Component {
                                     projectBy={this.props.intl.formatMessage(
                                         {id: 'annualReport.2020.projectBy'}
                                     )}
-                                    attribution="u/cellie"
+                                    attribution="@cellie"
                                 />
                                 <TimelineCard
                                     className="left"
@@ -2041,7 +2041,7 @@ class AnnualReport extends React.Component {
                                     projectBy={this.props.intl.formatMessage(
                                         {id: 'annualReport.2020.projectBy'}
                                     )}
-                                    attribution="u/LGMammoth"
+                                    attribution="@LGMammoth"
                                 />
                                 <img
                                     className="connector right"
@@ -2067,7 +2067,7 @@ class AnnualReport extends React.Component {
                                     projectBy={this.props.intl.formatMessage(
                                         {id: 'annualReport.2020.projectBy'}
                                     )}
-                                    attribution="u/IDK_HAVE_SOME_NUMBER"
+                                    attribution="@IDK_HAVE_SOME_NUMBER"
                                 />
                                 <div className="illustrations">
                                     <img


### PR DESCRIPTION
### Resolves:

Resolves #6305

### Changes:

Replaces `u/` prefixes with `@` in the 2020 Annual Report to be consistent with the rest of the website.

### Test Coverage:

Tested manually.
![image](https://user-images.githubusercontent.com/51849865/185591034-22dae07a-f38b-4100-a5ca-7802548c27fa.png)