### PR TITLE
CE-177 Change "commenting is off" message for projects

### DIFF
--- a/src/views/preview/l10n.json
+++ b/src/views/preview/l10n.json
@@ -12,7 +12,7 @@
     "project.comments.header": "Comments",
     "project.comments.toggleOff": "Commenting off",
     "project.comments.toggleOn": "Commenting on",
-    "project.comments.turnedOff": "Sorry, comment posting has been turned off for this project.",
+    "project.comments.turnedOff": "Commenting for this project has been turned off.",
     "project.comments.turnedOffGlobally": "Project comments across Scratch are turned off, but don't worry, your comments are saved and will be back soon.",
     "project.share.notShared": "This project is not shared — so only you can see it. Click share to let everyone see it!",
     "project.share.sharedLong": "Congratulations on sharing your project! Other people can now try it out, give comments, and remix it.",


### PR DESCRIPTION
### Resolves:

Resolves #6030

### Changes:

Changes the message shown on projects if comments are disabled to be more similar to the studio page message.

### Test Coverage:

Tested manually by opening a project with comments disabled.
![image](https://user-images.githubusercontent.com/51849865/185594364-b7915d8d-e552-459f-85d2-3037a39336c8.png)