### PR TITLE
Change username test to something actually rejected

### DIFF
--- a/test/integration/join.test.js
+++ b/test/integration/join.test.js
@@ -79,7 +79,8 @@ describe('www-integration join flow', () => {
     test('username validation: bad word', async () => {
         let textInput = await findByXpath('//input[contains(@name, "username")]');
         await textInput.click();
-        await textInput.sendKeys('qnb02mclepghwic9');
+        // Should be caught by the filter
+        await textInput.sendKeys('xxxxxxxxx');
         await clickXpath('//div[@class = "join-flow-outer-content"]');
         let message = await findByXpath('//div[contains(@class, "validation-error")]');
         let messageText = await message.getText();


### PR DESCRIPTION
### Resolves:

IBE-401

### Changes:

Fixes a failing integration test that was formerly dependent on Cleanspeak bad word list

### Test Coverage:

Ran all the join flow integration tests locally.
