### PR TITLE
build: Updated scratch-gui version for www release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "regenerator-runtime": "0.13.9",
         "sass": "1.49.7",
         "sass-loader": "10.2.1",
-        "scratch-gui": "0.1.0-prerelease.20220914153251",
+        "scratch-gui": "0.1.0-prerelease.20220914163646",
         "scratch-l10n": "3.15.20220913031617",
         "selenium-webdriver": "4.1.0",
         "slick-carousel": "1.6.0",
@@ -22457,9 +22457,9 @@
       }
     },
     "node_modules/scratch-gui": {
-      "version": "0.1.0-prerelease.20220914153251",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220914153251.tgz",
-      "integrity": "sha512-tVqMfY5x+/Tkjzqu7ZmpyQRpLMO2+KR8Sm9jtbHcMlaRU6TGAY1YyFXUjAFrpTFQSMeWZVaZXCvmY1SJSaRH9g==",
+      "version": "0.1.0-prerelease.20220914163646",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220914163646.tgz",
+      "integrity": "sha512-dTdujvFM3Oe13sBFa62kkhwmsaE5ADqrqT+qZ4j9vhOda1MdQImQz2zVVsqBtmAZCKsIFJTE7ZZlVX9W14qY2Q==",
       "dev": true,
       "dependencies": {
         "arraybuffer-loader": "^1.0.6",
@@ -22517,7 +22517,7 @@
         "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
         "scratch-storage": "2.0.2",
         "scratch-svg-renderer": "0.2.0-prerelease.20220817124220",
-        "scratch-vm": "1.1.6",
+        "scratch-vm": "1.2.4",
         "startaudiocontext": "1.2.1",
         "style-loader": "^0.23.0",
         "text-encoding": "0.7.0",
@@ -23106,9 +23106,9 @@
       "dev": true
     },
     "node_modules/scratch-vm": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.1.6.tgz",
-      "integrity": "sha512-A5szfXN/+IY1WU5laMWixxExBaOSmULh5i4OCIiJH5XPQglJsXyhnFkbww4fX+SS0FCmCo9+fYRuI+aNXDJ8vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.2.4.tgz",
+      "integrity": "sha512-gBF8g99M1i0uRqwhoPvjwHrt5+po2mEHBoYd5W7osFYKlVrSRgF5WpNnU4KOOkq5CpXvPgGjdst25Qh2Rk0qOw==",
       "dev": true,
       "dependencies": {
         "@vernier/godirect": "1.5.0",
@@ -49789,9 +49789,9 @@
       }
     },
     "scratch-gui": {
-      "version": "0.1.0-prerelease.20220914153251",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220914153251.tgz",
-      "integrity": "sha512-tVqMfY5x+/Tkjzqu7ZmpyQRpLMO2+KR8Sm9jtbHcMlaRU6TGAY1YyFXUjAFrpTFQSMeWZVaZXCvmY1SJSaRH9g==",
+      "version": "0.1.0-prerelease.20220914163646",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-0.1.0-prerelease.20220914163646.tgz",
+      "integrity": "sha512-dTdujvFM3Oe13sBFa62kkhwmsaE5ADqrqT+qZ4j9vhOda1MdQImQz2zVVsqBtmAZCKsIFJTE7ZZlVX9W14qY2Q==",
       "dev": true,
       "requires": {
         "arraybuffer-loader": "^1.0.6",
@@ -49849,7 +49849,7 @@
         "scratch-render-fonts": "1.0.0-prerelease.20210401210003",
         "scratch-storage": "2.0.2",
         "scratch-svg-renderer": "0.2.0-prerelease.20220817124220",
-        "scratch-vm": "1.1.6",
+        "scratch-vm": "1.2.4",
         "startaudiocontext": "1.2.1",
         "style-loader": "^0.23.0",
         "text-encoding": "0.7.0",
@@ -50356,9 +50356,9 @@
       "dev": true
     },
     "scratch-vm": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.1.6.tgz",
-      "integrity": "sha512-A5szfXN/+IY1WU5laMWixxExBaOSmULh5i4OCIiJH5XPQglJsXyhnFkbww4fX+SS0FCmCo9+fYRuI+aNXDJ8vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-1.2.4.tgz",
+      "integrity": "sha512-gBF8g99M1i0uRqwhoPvjwHrt5+po2mEHBoYd5W7osFYKlVrSRgF5WpNnU4KOOkq5CpXvPgGjdst25Qh2Rk0qOw==",
       "dev": true,
       "requires": {
         "@vernier/godirect": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "regenerator-runtime": "0.13.9",
     "sass": "1.49.7",
     "sass-loader": "10.2.1",
-    "scratch-gui": "0.1.0-prerelease.20220914153251",
+    "scratch-gui": "0.1.0-prerelease.20220914163646",
     "scratch-l10n": "3.15.20220913031617",
     "selenium-webdriver": "4.1.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
### Changes:

Updated scratch-gui version for www release to `0.1.0-prerelease.20220914163646`.

### Test Coverage:

N/A
