### PR TITLE
Add check on password complexity by using a backend call

### DIFF
--- a/src/components/join-flow/username-step.jsx
+++ b/src/components/join-flow/username-step.jsx
@@ -114,11 +114,12 @@ class UsernameStep extends React.Component {
         if (!password) return null; // skip validation if password is blank; null indicates valid
         // if password is not blank, run both local and remote validations
         const localResult = validate.validatePasswordLocally(password, username);
+        if (localResult.valid === false) { // defer to local check first
+            return this.props.intl.formatMessage({id: localResult.errMsgId});
+        }
         return this.validatePasswordRemotelyWithCache(password).then(
             remoteResult => {
-                if (localResult.valid === false) { // defer to local check first
-                    return this.props.intl.formatMessage({id: localResult.errMsgId});
-                } else if (remoteResult.valid === false) {
+                if (remoteResult.valid === false) {
                     return this.props.intl.formatMessage({id: remoteResult.errMsgId});
                 }
                 return null;

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -107,7 +107,7 @@ module.exports.validatePasswordRemotely = password => (
                     valid: false,
                     errMsgId: 'registration.validationPasswordNotEquals'
                 });
-            }; // switch
+            } // switch
         }); // api
     }) // promise
 );

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -100,7 +100,7 @@ module.exports.validatePasswordRemotely = password => (
                     requestSucceeded: true,
                     valid: true
                 });
-            case 'valid password':
+            case 'invalid password':
             default:
                 return resolve({
                     requestSucceeded: true,

--- a/test/unit/lib/validate.test.js
+++ b/test/unit/lib/validate.test.js
@@ -2,6 +2,10 @@ const validate = require('../../../src/lib/validate');
 
 describe('unit test lib/validate.js', () => {
 
+    test('validate username remote existence', () => {
+        expect(typeof validate.validateUsernameRemotely).toBe('function');
+    });
+
     test('validate username exists locally', () => {
         let response;
         expect(typeof validate.validateUsernameLocally).toBe('function');
@@ -52,9 +56,13 @@ describe('unit test lib/validate.js', () => {
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationUsernameRegexp'});
     });
 
+    test('validate password remote existence', () => {
+        expect(typeof validate.validatePasswordRemotely).toBe('function');
+    });
+
     test('validate password existence', () => {
         let response;
-        expect(typeof validate.validatePassword).toBe('function');
+        expect(typeof validate.validatePasswordLocally).toBe('function');
         response = validate.validatePasswordLocally('abcdef');
         expect(response).toEqual({valid: true});
         response = validate.validatePasswordLocally('');

--- a/test/unit/lib/validate.test.js
+++ b/test/unit/lib/validate.test.js
@@ -55,38 +55,38 @@ describe('unit test lib/validate.js', () => {
     test('validate password existence', () => {
         let response;
         expect(typeof validate.validatePassword).toBe('function');
-        response = validate.validatePassword('abcdef');
+        response = validate.validatePasswordLocally('abcdef');
         expect(response).toEqual({valid: true});
-        response = validate.validatePassword('');
+        response = validate.validatePasswordLocally('');
         expect(response).toEqual({valid: false, errMsgId: 'general.required'});
     });
 
     test('validate password length', () => {
         let response;
-        response = validate.validatePassword('abcdefghijklmnopqrst');
+        response = validate.validatePasswordLocally('abcdefghijklmnopqrst');
         expect(response).toEqual({valid: true});
-        response = validate.validatePassword('abcde');
+        response = validate.validatePasswordLocally('abcde');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordLength'});
-        response = validate.validatePassword('😺');
+        response = validate.validatePasswordLocally('😺');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordLength'});
-        response = validate.validatePassword('😺🦆🐝');
+        response = validate.validatePasswordLocally('😺🦆🐝');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordLength'});
-        response = validate.validatePassword('😺🦆🐝🐮🐠');
+        response = validate.validatePasswordLocally('😺🦆🐝🐮🐠');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordLength'});
-        response = validate.validatePassword('😺🦆🐝🐮🐠🐻');
+        response = validate.validatePasswordLocally('😺🦆🐝🐮🐠🐻');
         expect(response).toEqual({valid: true});
     });
 
     test('validate password cannot be "password"', () => {
-        const response = validate.validatePassword('password');
+        const response = validate.validatePasswordLocally('password');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordNotEquals'});
     });
 
     test('validate password cannot be same as username', () => {
         let response;
-        response = validate.validatePassword('abcdefg', 'abcdefg');
+        response = validate.validatePasswordLocally('abcdefg', 'abcdefg');
         expect(response).toEqual({valid: false, errMsgId: 'registration.validationPasswordNotUsername'});
-        response = validate.validatePassword('abcdefg', 'abcdefG');
+        response = validate.validatePasswordLocally('abcdefg', 'abcdefG');
         expect(response).toEqual({valid: true});
     });
 


### PR DESCRIPTION

Compliments the ability of the frontend check on username validity with a check on password weakness. This requires the deployment of changes to scratch-api before this change is deployed.
