### PR TITLE
CE-211 separate integration tests into separate job within deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,6 @@ aliases:
           <<: *setup_python
       - run:
           <<: *deploy
-      - run:
-          <<: *integration
       - store_test_results:
           path: test/results
       - run:
@@ -83,6 +81,17 @@ aliases:
           command: tar -cvzf build.tar build
       - store_artifacts:
           path: build.tar
+  - &integration_tests_and_store
+    <<: *defaults
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          <<: *setup
+      - run:
+          <<: *integration
+      - store_test_results:
+          path: test/results
   - &update-translations
     <<: *defaults
     steps:
@@ -98,8 +107,12 @@ aliases:
 jobs:
   build-and-deploy-staging:
     <<: *build_and_deploy
+  integration-tests-staging:
+    <<: *integration_tests_and_store
   build-and-deploy-production:
     <<: *build_and_deploy
+  integration-tests-production:
+    <<: *integration_tests_and_store
   update-translations:
     <<: *update-translations
   build-no-deploy:
@@ -119,7 +132,27 @@ workflows:
                 - develop
                 - /^hotfix\/.*/
                 - /^release\/.*/
+      - integration-tests-staging:
+          context:
+            - scratch-www-all
+            - scratch-www-staging
+            - dockerhub-credentials
+          filters:
+            branches:
+              only:
+                - develop
+                - /^hotfix\/.*/
+                - /^release\/.*/
       - build-and-deploy-production:
+          context:
+            - scratch-www-all
+            - scratch-www-production
+            - dockerhub-credentials
+          filters:
+            branches:
+              only:
+                - master
+      - integration-tests-production:
           context:
             - scratch-www-all
             - scratch-www-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,11 +107,9 @@ aliases:
 jobs:
   build-and-deploy-staging:
     <<: *build_and_deploy
-  integration-tests-staging:
-    <<: *integration_tests_and_store
   build-and-deploy-production:
     <<: *build_and_deploy
-  integration-tests-production:
+  integration-tests:
     <<: *integration_tests_and_store
   update-translations:
     <<: *update-translations
@@ -132,7 +130,7 @@ workflows:
                 - develop
                 - /^hotfix\/.*/
                 - /^release\/.*/
-      - integration-tests-staging:
+      - integration-tests:
           context:
             - scratch-www-all
             - scratch-www-staging
@@ -152,7 +150,7 @@ workflows:
             branches:
               only:
                 - master
-      - integration-tests-production:
+      - integration-tests:
           context:
             - scratch-www-all
             - scratch-www-production


### PR DESCRIPTION
### Resolves:

private Jira ticket: https://scratchfoundation.atlassian.net/browse/CE-211

### Changes:

separates integration tests into a separate job within deploy workflow.

as of the initial version of this change, I'm not sure of a few things:
* this code will currently not automatically run integration tests as part of the deploy steps. But we probably want to put those back in, so that integration tests run as part of the deploy. What I'm wondering is, is it better to have separate build/deploy and integration test jobs, which run in sequence? Or is it better to just put the integration tests back into the deploy jobs?
* I'm not totally clear on when to store test results, and when not to. In the deploy steps, we have linting and unit tests; should we attempt to store test results at the end of the deploy steps, as we did previously? Or are they really only useful for integration tests?

### Test Coverage:

n/a, this deals with tests themselves.