### PR TITLE
Make integration tests sequential

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,8 @@ workflows:
                 - /^hotfix\/.*/
                 - /^release\/.*/
       - integration-tests:
+          requires:
+            - build-and-deploy-staging
           context:
             - scratch-www-all
             - scratch-www-staging
@@ -151,6 +153,8 @@ workflows:
               only:
                 - master
       - integration-tests:
+          requires:
+            - build-and-deploy-production
           context:
             - scratch-www-all
             - scratch-www-production


### PR DESCRIPTION
Changes circleci configuration to make integration test jobs wait for deploy jobs before running.

Follow-up to https://github.com/LLK/scratch-www/pull/7088 , which left the integration test jobs running in parallel with deploy jobs, which defeats the purpose!