### PR TITLE
WIP: attempt to use circleci’s browser-tools orb to force chrome version for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.4.0
+
 aliases:
   - &defaults
     docker:
@@ -8,6 +11,11 @@ aliases:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
     working_directory: ~/repo
+  - &check-browsers
+      name: check browser versions
+      command: |
+        google-chrome --version
+        chromedriver --version
   - &setup
     name: "setup"
     command: |
@@ -88,6 +96,10 @@ aliases:
       - checkout
       - run:
           <<: *setup
+      - browser-tools/install-browser-tools:
+        chrome-version: 96.0.0
+      - run:
+          <<: *check-browsers
       - run:
           <<: *integration
       - store_test_results:


### PR DESCRIPTION
DO NOT CHECK THIS IN

it's a work in progress that does NOT work as intended... 

attempting to install the Chrome version gives the error:

<img width="976" alt="image" src="https://user-images.githubusercontent.com/3431616/198906431-04d20b61-f454-4cc0-8ecc-c7b0c9dbcf16.png">
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/3431616/198906434-4ed2386f-33be-4ead-8358-d5589771bccf.png">

independently of the install attempt, attempting to even just check the Chrome version gives:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/3431616/198906335-a5d4d331-b7bc-4ef0-b1a4-bc08bfded973.png">

https://app.circleci.com/pipelines/github/LLK/scratch-www/10340/workflows/a605f150-8e66-4b35-98f1-16d5a619a46b/jobs/12755