### PR TITLE
Fix gh-7176: Fix empty h5 elements in the homepage

### DIFF
--- a/src/components/box/box.jsx
+++ b/src/components/box/box.jsx
@@ -8,7 +8,7 @@ const Box = props => (
     <div className={classNames('box', props.className)}>
         <div className="box-header">
             <h4>{props.title}</h4>
-            <h5>{props.subtitle}</h5>
+            {props.subtitle ? <h5>{props.subtitle}</h5> : null}
             <p>
                 <a
                     href={props.moreHref}
@@ -19,9 +19,7 @@ const Box = props => (
             </p>
         </div>
 
-        <div className="box-content">
-            {props.children}
-        </div>
+        <div className="box-content">{props.children}</div>
     </div>
 );
 


### PR DESCRIPTION
### Description:

Unlabeled and unfocusable header elements should not be present. The box component accepts a prop for the text inside of the h5 element. However, no attribute is passed to the box component for the h5 element in the source code. I added a conditional that checks for the prop and renders the h5 element if a prop exists but does not render the h5 element if the prop does not exist. Resolves #7176.

### Test Cases:
I passed a prop to the box component for the h5 element and the h5 element rendered with the text from the prop.
I did not pass a prop to the box component for the h5 element and the h5 element did not render
After making the changes, I ran `npm test` and found that nothing was broken