### PR TITLE
Fix gh-7173: The select element in the footer needs proper aria labeling

### DIFF
--- a/src/components/languagechooser/languagechooser.jsx
+++ b/src/components/languagechooser/languagechooser.jsx
@@ -1,5 +1,7 @@
 const bindAll = require('lodash.bindall');
 const classNames = require('classnames');
+const injectIntl = require('react-intl').injectIntl;
+const intlShape = require('react-intl').intlShape;
 const PropTypes = require('prop-types');
 const React = require('react');
 
@@ -37,6 +39,7 @@ class LanguageChooser extends React.Component {
             <Form className={classNames('language-chooser', this.props.className)}>
                 <Select
                     required
+                    aria-label={this.props.intl.formatMessage({id: 'general.languageChooser'})}
                     name="language"
                     options={languageOptions}
                     value={this.props.locale}
@@ -50,7 +53,8 @@ class LanguageChooser extends React.Component {
 LanguageChooser.propTypes = {
     className: PropTypes.string,
     languages: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    intl: intlShape
 };
 
 LanguageChooser.defaultProps = {
@@ -58,4 +62,4 @@ LanguageChooser.defaultProps = {
     locale: 'en'
 };
 
-module.exports = LanguageChooser;
+module.exports = injectIntl(LanguageChooser);

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -1,4 +1,5 @@
 {
+    "general.languageChooser": "Select Language",
     "general.accountSettings": "Account settings",
     "general.about": "About",
     "general.aboutScratch": "About Scratch",


### PR DESCRIPTION
### Description:

AT users will have a difficult time figuring out what the select element in the footer is for because there is no proper aria label for it. Resolves #7173.

### Test Cases:
I added an arial-label attribute to the element that gives context for what the element is for to AT users. The screen reader announces the aria-label attribute.