### PR TITLE
Fix gh-7260: The select element on the `/explore` page needs proper aria labeling

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -1,4 +1,5 @@
 {
+    "general.status": "Filter Projects",
     "general.accountSettings": "Account settings",
     "general.about": "About",
     "general.aboutScratch": "About Scratch",

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -175,6 +175,7 @@ class Explore extends React.Component {
                         </SubNavigation>
                         <Form className="sort-mode">
                             <Select
+                                aria-label={this.props.intl.formatMessage({id: 'general.status'})}
                                 name="sort"
                                 options={[
                                     {


### PR DESCRIPTION
### Description:

AT users will have a difficult time figuring out what the select element on the `/explore` page is for because there is no proper aria label for it.

### Test Cases:
I added an arial-label attribute to the element that gives context for what the element is for to AT users. The screen reader announces the aria-label attribute.
