### PR TITLE
CE-310 Fixes title overlap of EV3 for Firefox 

### DIFF
--- a/src/components/extension-landing/extension-landing.scss
+++ b/src/components/extension-landing/extension-landing.scss
@@ -106,6 +106,7 @@
                     display: flex;
                     margin-bottom: 2rem;
                     color: $ui-white;
+                    width: 100%;
 
                     img {
                         padding-right: .5rem;

--- a/src/views/ev3/ev3.jsx
+++ b/src/views/ev3/ev3.jsx
@@ -39,7 +39,7 @@ class EV3 extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="column extension-copy">
                             <h1><img
-                                alt=""
+                                alt="ev3.svg"
                                 src="/images/ev3/ev3.svg"
                             />LEGO MINDSTORMS EV3</h1>
                             <FormattedMessage


### PR DESCRIPTION
Fixed the title's overlapping issue that was happening on Firefox, this fixes issue [#6423.](https://github.com/LLK/scratch-www/issues/6423) 

I tried changing this issue before, but I was working on the wrong branch. I tried to undo those commits, but I wasn't able to delete them from the issue's history. Sorry for all the confusion! 

I also added some text to one of the images, since I've seen a lot of issues regarding accessibility.  


<img width="1137" alt="Screen Shot 2022-12-11 at 4 51 54 PM" src="https://user-images.githubusercontent.com/55937173/206931291-6c7fb299-59d1-4810-b7c9-65f33a6e828f.png">
