### PR TITLE
updates aqua and gray colors

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -27,8 +27,8 @@ $motion-blue-3: hsla(215, 60%, 50%, 1);//#3373CC
 /* UI Secondary Colors */
 /* 3.0 colors */
 /* Using www naming convention for now, should be consistent with gui */
-$ui-aqua: hsla(163, 85%, 40%, 1); // #0FBD8C Extension Primary
-$ui-aqua-dark: hsla(163, 85%, 30%, 1); // #0B8E69 Extension Aqua 3
+$ui-aqua: #338554; 
+$ui-aqua-dark: darken($ui-aqua, 10%);
 $ui-purple: hsla(260, 100%, 70%, 1); // #9966FF Looks Primary
 $ui-purple-dark: hsla(260, 60%, 60%, 1); // #774DCB Looks Secondary
 $ui-magenta: hsla(300, 53%, 60%, 1); /* #CF63CF Sounds Primary */
@@ -59,6 +59,7 @@ $transparent-light-blue: rgba(229, 240, 254, 0);
 /* Typography Colors */
 $header-gray: hsla(225, 15%, 40%, 1); //#575E75
 $type-gray: hsla(225, 15%, 40%, 1); //#575E75
+$type-dark-gray: #3B3B3B;
 $type-gray-75percent: hsla(225, 15%, 40%, .75);
 $type-gray-60percent: hsla(225, 15%, 40%, .6);
 $type-white: hsla(0, 100%, 100%, 1); //#FFF

--- a/src/views/explore/explore.scss
+++ b/src/views/explore/explore.scss
@@ -84,15 +84,14 @@ $base-bg: $ui-white;
         justify-content: flex-start;
 
         li {
-            border: 0;
+            border: 1px solid $type-dark-gray;
             background-color: $active-gray;
-            color: $ui-white;
+            color: $header-gray;
 
             &.active {
                 opacity: 1;
                 background-color: $ui-aqua;
                 color: $ui-white;
-
             }
 
             &:active {
@@ -101,6 +100,7 @@ $base-bg: $ui-white;
 
             &:hover {
                 background-color: $active-dark-gray;
+                color: $type-dark-gray;
             }
         }
     }


### PR DESCRIPTION
### Resolves:

Partially addresses #7182. Scratch product & design are currently thinking through further changes to the color palette to reach compliance.  

### Changes:

These changes affect the splash section on the `/splash` page and the tabs on the `/explore` to make them WCAG 2.1 AA compliant. Specifically, the aqua colors are darkened and darker text with outlines are used around grey button-like UI elements. See screenshots for previews of the changes:
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/58723/208171107-d224f69e-fc1a-46d5-80ce-b03523f1b91d.png">

<img width="982" alt="image" src="https://user-images.githubusercontent.com/58723/208171147-473bec02-1655-4057-8176-fb36bc37a633.png">


### Test Coverage:

No tests changes and all automated tests currently pass.
