### PR TITLE
add path matching for subdirectories under /help/

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -498,8 +498,8 @@
     },
     {
         "name": "help-redirect",
-        "pattern": "^/help/?(\\?.*)?$",
-        "routeAlias": "/help/?(\\?.*)?$",
+        "pattern": "^/help/?(.*\/)?(\\?.*)?$",
+        "routeAlias": "/help/?(.*\/)?(\\?.*)?$",
         "redirect": "/ideas"
     },
     {


### PR DESCRIPTION
### Resolves:

(need to file!)

### Changes:

Adds optional subdirectories for the path under /help/ , to mask outdated content in scratchr2 

