### PR TITLE
Make project stats icons always opaque

### DIFF
--- a/src/views/preview/stats.scss
+++ b/src/views/preview/stats.scss
@@ -55,8 +55,6 @@
     cursor: pointer;
 
     &:before {
-        
-        opacity: .5;
         background-image: url("/svgs/project/love-gray.svg");
     }
 }
@@ -64,7 +62,6 @@
 .project-loves.loved {
 
     &:before {
-        opacity: 1;
         background-image: url("/svgs/project/love-red.svg");
     }
 }
@@ -74,7 +71,6 @@
     cursor: pointer;
 
     &:before {
-        opacity: .5;
         background-image: url("/svgs/project/fav-gray.svg");
     }
 }
@@ -82,7 +78,6 @@
 .project-favorites.favorited {
 
     &:before {
-        opacity: 1;
         background-image: url("/svgs/project/fav-yellow.svg");
     }
 }
@@ -90,7 +85,6 @@
 .project-remixes {
 
     &:before {
-        opacity: .5;
         background-image: url("/svgs/project/remix-gray.svg");
     }
 }
@@ -98,7 +92,6 @@
 .project-views {
 
     &:before {
-        opacity: .5;
         background-image: url("/svgs/project/views-gray.svg");
     }
 }


### PR DESCRIPTION
### Resolves:

follow-on to https://github.com/LLK/scratch-www/pull/7264

### Changes:

sets opacity of the new project page stats icons to default of 100% (instead of 50%), to match the intention behind their design.

