### PR TITLE
Make extension landing page title icon class constant

### DIFF
--- a/src/components/extension-landing/extension-landing.scss
+++ b/src/components/extension-landing/extension-landing.scss
@@ -39,7 +39,7 @@
     .headline-icon {
         height: 40px;
         width: 40px;
-        margin: auto;
+        margin: auto 0;
     }
 
     .download {

--- a/src/views/boost/boost.jsx
+++ b/src/views/boost/boost.jsx
@@ -34,7 +34,7 @@ class Boost extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="extension-copy">
                             <h1><img
-                                alt=""
+                                alt="Boost"
                                 className="headline-icon"
                                 src="/images/boost/boost.svg"
                             />LEGO BOOST</h1>

--- a/src/views/download/scratch-link/download.jsx
+++ b/src/views/download/scratch-link/download.jsx
@@ -31,7 +31,7 @@ const ScratchLink = ({intl}) => {
                         <FlexRow className="column extension-copy">
                             <h1><img
                                 alt={intl.formatMessage({id: 'scratchLink.linkLogo'})}
-                                width="40px"
+                                className="headline-icon"
                                 src="/images/scratchlink/scratch-link-logo.svg"
                             />{intl.formatMessage({id: 'scratchLink.headerTitle'})}</h1>
                             <FormattedMessage id="scratchLink.headerText" />

--- a/src/views/ev3/ev3.jsx
+++ b/src/views/ev3/ev3.jsx
@@ -39,7 +39,8 @@ class EV3 extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="column extension-copy">
                             <h1><img
-                                alt="ev3.svg"
+                                alt="EV3"
+                                className="headline-icon"
                                 src="/images/ev3/ev3.svg"
                             />LEGO MINDSTORMS EV3</h1>
                             <FormattedMessage

--- a/src/views/ev3/ev3.scss
+++ b/src/views/ev3/ev3.scss
@@ -5,6 +5,10 @@
         background-color: $ui-orange;
         background-image: url("/images/ev3/ev3-pattern.svg");
     }
+    .headline-icon {
+        width: 32px;
+        height: 36px;
+    }
     .step-image.tall {
         height: 16rem;
     }

--- a/src/views/gdxfor/gdxfor.jsx
+++ b/src/views/gdxfor/gdxfor.jsx
@@ -34,7 +34,8 @@ class GdxFor extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="extension-copy">
                             <h1><img
-                                alt=""
+                                alt="Vernier Force & Acceleration"
+                                className="headline-icon"
                                 src="/images/gdxfor/gdxfor.svg"
                             />Vernier Force & Acceleration</h1>
                             <FormattedMessage

--- a/src/views/microbit/microbit.jsx
+++ b/src/views/microbit/microbit.jsx
@@ -38,7 +38,8 @@ class MicroBit extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="extension-copy">
                             <h1><img
-                                alt=""
+                                alt="Microbit"
+                                className="headline-icon"
                                 src="/images/microbit/microbit.svg"
                             />micro:bit</h1>
                             <FormattedMessage

--- a/src/views/microbit/microbit.scss
+++ b/src/views/microbit/microbit.scss
@@ -7,6 +7,11 @@
         background-image: url("/images/microbit/mbit-pattern.svg");
     }
 
+    .headline-icon {
+        width: 34px;
+        height: 28px;
+    }
+
     .things-to-try {
         .display-hello {
             .step-image {

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -35,7 +35,8 @@ class Wedo2 extends ExtensionLanding {
                     renderCopy={
                         <FlexRow className="extension-copy">
                             <h1><img
-                                alt=""
+                                alt="Wedo"
+                                className="headline-icon"
                                 src="/images/wedo2/wedo2.svg"
                             />LEGO Education WeDo 2.0</h1>
                             <FormattedMessage


### PR DESCRIPTION
### Resolves:

Follow on to https://github.com/LLK/scratch-www/pull/7291

Maintains #7291's original fix: here is production now on firefox,

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/3431616/216229945-02c4e6b8-cc26-4ed5-bee3-d33c32f00dd3.png">

and here is the page with this fix:

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/3431616/216229978-7dd705d6-6abe-4e63-bf99-465ba0a8452b.png">

But this change additionally addresses a problem that #7291 did not address, which left this page:

<img width="977" alt="image" src="https://user-images.githubusercontent.com/3431616/216230041-473f2241-871e-4216-bd98-a08565163146.png">

WIth this change, that page looks like:

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/3431616/216230059-82057548-543d-4b87-b292-6f5f3604e973.png">


### Changes:

* ensures the classname "headline-icon" is present on all headline icon images on the pages:
  * /boost
  * /download/scratch-link
  * /ev3
  * /microbit
  * /vernier
  * /wedo

### Test Coverage:

To test manually, open each of the above pages in both local (or staging) and in production. They should appear the same in Chrome and Safari. In Firefox, you should see improvement on the /ev3 page, and everything else should appear the same.

_styling issue, not directly testable with automated tests_