### PR TITLE
fix: update integration tests for react-intl

### DIFF
--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -162,7 +162,7 @@ describe('comment tests', async () => {
 
         test('project message links you to project page', async () => {
             let projectLinkXpath = '//p[@class="emoji-text mod-comment" ' +
-            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/span/a[2]`;
+            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/a[2]`;
 
             await driver.get(rootUrl + '/messages');
             await clickXpath(projectLinkXpath);
@@ -174,7 +174,7 @@ describe('comment tests', async () => {
 
         test('project comment is on project page', async () => {
             let projectLinkXpath = '//p[@class="emoji-text mod-comment" ' +
-            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/span/a[2]`;
+            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/a[2]`;
 
             await driver.get(rootUrl + '/messages');
             await clickXpath(projectLinkXpath);
@@ -187,7 +187,7 @@ describe('comment tests', async () => {
 
         test('project comment is highlighted', async () => {
             let projectLinkXpath = '//p[@class="emoji-text mod-comment" ' +
-            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/span/a[2]`;
+            `and contains(text(), "${projectComment}")]/../../../p[@class = "comment-message-info"]/a[2]`;
             let containerXpath = `//span[contains(text(), "${projectComment}")]/../../../..`;
 
             await driver.get(rootUrl + '/messages');
@@ -201,7 +201,7 @@ describe('comment tests', async () => {
         test('profile message links you to profile page', async () => {
             let profileLinkXpath = await '//p[@class="emoji-text mod-comment" ' +
                 `and contains(text(), "${profileComment}")]/../../../` +
-                `p[@class = "comment-message-info"]/span/a[2]`;
+                `p[@class = "comment-message-info"]/a[2]`;
             await driver.get(rootUrl + '/messages');
             await clickXpath(profileLinkXpath);
 
@@ -218,7 +218,7 @@ describe('comment tests', async () => {
         test('profile comment is on profile page', async () => {
             let profileLinkXpath = await '//p[@class="emoji-text mod-comment" ' +
                 `and contains(text(), "${profileComment}")]/../../../` +
-                `p[@class = "comment-message-info"]/span/a[2]`;
+                `p[@class = "comment-message-info"]/a[2]`;
             await driver.get(rootUrl + '/messages');
             await clickXpath(profileLinkXpath);
 
@@ -233,7 +233,7 @@ describe('comment tests', async () => {
         test('profile comment is highlighted', async () => {
             let profileLinkXpath = await '//p[@class="emoji-text mod-comment" ' +
                 `and contains(text(), "${profileComment}")]/../../../` +
-                `p[@class = "comment-message-info"]/span/a[2]`;
+                `p[@class = "comment-message-info"]/a[2]`;
             await driver.get(rootUrl + '/messages');
             await clickXpath(profileLinkXpath);
 

--- a/test/integration/sign-in-and-out.test.js
+++ b/test/integration/sign-in-and-out.test.js
@@ -80,7 +80,7 @@ describe('www-integration sign-in-and-out', () => {
         test('sign out on www', async () => {
             await clickXpath('//a[contains(@class, "user-info")]');
             await clickText('Sign out');
-            let element = await findByXpath('//li[@class="link right login-item"]/a/span');
+            let element = await findByXpath('//li[@class="link right login-item"]/a');
             let text = await element.getText();
             await expect(text.toLowerCase()).toEqual('Sign In'.toLowerCase());
         });
@@ -89,7 +89,7 @@ describe('www-integration sign-in-and-out', () => {
             await driver.get(scratchr2url);
             await clickXpath('//span[@class="user-name dropdown-toggle"]');
             await clickXpath('//li[@id="logout"]');
-            let element = await findByXpath('//li[@class="link right login-item"]/a/span');
+            let element = await findByXpath('//li[@class="link right login-item"]/a');
             let text = await element.getText();
             await expect(text.toLowerCase()).toEqual('Sign In'.toLowerCase());
         });

--- a/test/integration/studios-page.test.js
+++ b/test/integration/studios-page.test.js
@@ -135,10 +135,10 @@ describe('studio management', () => {
         await clickXpath(kebabMenuXpath + '/button[@class="overflow-menu-trigger"]');
         // click promote
         // await clickXpath('//button[@class="promote-menu-button"]'); //<-- I think this will do it
-        await clickXpath(kebabMenuXpath + '/ul/li/button/span[contains(text(), "Promote")]/..');
+        await clickXpath(kebabMenuXpath + '/ul/li/button[contains(text(), "Promote")]');
         await findByXpath('//div[@class="promote-content"]');
         // await clickXpath(//button[contains(@class="promote-button")]) <-- add this selector to the button
-        await clickXpath('//div[@class="promote-button-row"]/button/span[contains(text(),"Promote")]/..');
+        await clickXpath('//div[@class="promote-button-row"]/button[contains(text(),"Promote")]');
         let promoteSuccess = await findByXpath('//div[contains(@class, "alert-success")]');
         let promoteSuccessVisible = await promoteSuccess.isDisplayed();
         await expect(promoteSuccessVisible).toBe(true);
@@ -181,7 +181,7 @@ describe('studio management', () => {
 
         // click confirm
         // await clickXpath('//button[contains(@class, "confirm-transfer-button")]')
-        await clickXpath('//span[contains(text(), "Confirm")]/..');
+        await clickXpath('//button[contains(text(), "Confirm")]');
         let transferSuccess = await findByXpath('//div[contains(@class, "alert-success")]');
         let successVisible = await transferSuccess.isDisplayed();
         await expect(successVisible).toBe(true);


### PR DESCRIPTION
### Resolves:

- Fixes [ENA-205](https://scratchfoundation.atlassian.net/browse/ENA-205)

### Changes:

Part of the `react-intl` upgrade includes the following:

> Change default textComponent in IntlProvider to React.Fragment. In order to keep the old behavior, you can explicitly set textComponent to span.

This broke some integration tests that were specifically targeting the `<span>`. Fixed the integration tests that were [failing](https://app.circleci.com/pipelines/github/LLK/scratch-www/10855/workflows/7f6b8f52-d6b4-474c-b749-00bfdc494e67/jobs/13439).

### Test Coverage:

I ran the `sign-in-and-out`, `studios-page`, and `comments` tests pointed at scratch.ly with the TesterRobot* accounts. They pass with these changes.


[ENA-205]: https://scratchfoundation.atlassian.net/browse/ENA-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ