### PR TITLE
fix: use span for localized messages

### DIFF
--- a/src/lib/render.jsx
+++ b/src/lib/render.jsx
@@ -39,6 +39,7 @@ const render = (jsx, element, reducers, initialState, enhancer) => {
                 <IntlProvider
                     locale={intlLocale}
                     messages={messages}
+                    textComponent="span"
                 >
                     {jsx}
                 </IntlProvider>

--- a/test/helpers/intl-helpers.jsx
+++ b/test/helpers/intl-helpers.jsx
@@ -39,7 +39,12 @@ const mountWithIntl = (node, {context, childContextTypes} = {}) => {
 
 // react-test-renderer component for use with snapshot testing
 const componentWithIntl = (children, props = {locale: 'en'}) => renderer.create(
-    <IntlProvider {...props}>{children}</IntlProvider>
+    <IntlProvider
+        textComponent="span"
+        {...props}
+    >
+        {children}
+    </IntlProvider>
 );
 
 export {


### PR DESCRIPTION
### Resolves:

- Fixes [ENA-205](https://scratchfoundation.atlassian.net/browse/ENA-205)

### Changes:

Part of the `react-intl` upgrade includes the following:

> Change default textComponent in IntlProvider to React.Fragment. In order to keep the old behavior, you can explicitly set textComponent to span.

This broke some [integration tests](https://app.circleci.com/pipelines/github/LLK/scratch-www/10855/workflows/7f6b8f52-d6b4-474c-b749-00bfdc494e67/jobs/13439) that were specifically targeting the `<span>`. Used the `textComponent` property to restore original behavior. This should also ensure any css that was depending on the spans also works.

### Test Coverage:

Unit tests still pass.

[ENA-205]: https://scratchfoundation.atlassian.net/browse/ENA-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ