### PR TITLE
Hide scrollbar in project full screen mode

### DIFF
--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -7,6 +7,7 @@ const MediaQuery = require('react-responsive').default;
 const React = require('react');
 const Formsy = require('formsy-react').default;
 const classNames = require('classnames');
+const Helmet = require('react-helmet').default;
 
 const GUI = require('scratch-gui').default;
 const IntlGUI = injectIntl(GUI);
@@ -217,6 +218,12 @@ const PreviewPresentation = ({
     );
     return (
         <div className="preview">
+            <Helmet
+                bodyAttributes={
+                    // Hide scrollbar in full screen mode
+                    isFullScreen ? {class: 'fullscreen-body'} : {}
+                }
+            />
             {showEmailConfirmationModal && <EmailConfirmationModal
                 isOpen
                 onRequestClose={onCloseEmailConfirmationModal}

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -7,6 +7,10 @@ $player-height: 362px;
 $player-header: 44px;
 $stage-width: 480px;
 
+.fullscreen-body {
+    overflow: hidden;
+}
+
 /* override view padding for share banner */
 #view {
     padding: 0;


### PR DESCRIPTION
### Resolves:

Resolves #4190

### Changes:

Hides the page scrollbar when a project is in full screen mode. This is done using `react-helmet` as discussed in an older PR for the same issue (#5665).

### Test Coverage:

Tested manually.