### PR TITLE
Change messages badge color

### DIFF
--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -147,11 +147,11 @@
                 top: .5rem;
                 right: .25rem;
                 border-radius: 1rem;
-                background-color: $ui-orange;
+                background-color: $background-color;
                 padding: 0 .25rem;
                 text-indent: 0;
                 line-height: 1rem;
-                color: $type-white;
+                color: $type-dark-gray;
                 font-size: .7rem;
                 font-weight: bold;
             }

--- a/src/views/messages/messages.scss
+++ b/src/views/messages/messages.scss
@@ -51,10 +51,10 @@
 .messages-header-unread {
     margin-left: 1rem;
     border-radius: 1rem;
-    background-color: $ui-orange;
+    background-color: $ui-blue-25percent;
     padding: .25rem .5rem;
     line-height: 1rem;
-    color: $type-white;
+    color: $type-dark-gray;
 }
 
 .admin-message {


### PR DESCRIPTION
### Resolves:

Resolves #7256

### Changes:

To improve the text contrast, I changed the background color of the messages badge from light orange to white for the navigation bar and light blue for the messages list, and also changed the text to dark gray.

### Test Coverage:

I don't have the required software to test - sorry about that. I'm sure it'll work, though!

Here's what it looks like:
![The Messages page with 1 unread message with updated colors for the messages badge both on the navigation bar and the list of messages](https://user-images.githubusercontent.com/106490990/222927625-42f7c94f-d3a1-4ba9-aeb7-05edd593923b.png)

