### PR TITLE
test: change page load strategy to improve integration tests

### DIFF
--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -4,7 +4,8 @@ const SeleniumHelper = require('./selenium-helpers.js');
 
 const {
     clickText,
-    buildDriver
+    buildDriver,
+    findText
 } = new SeleniumHelper();
 
 let rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
@@ -20,6 +21,7 @@ describe('www-integration footer links', () => {
 
     beforeEach(async () => {
         await driver.get(rootUrl);
+        await findText('Create stories, games, and animations');
     });
 
     afterAll(async () => await driver.quit());

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,4 +1,5 @@
 const webdriver = require('selenium-webdriver');
+const {PageLoadStrategy} = require('selenium-webdriver/lib/capabilities');
 const bindAll = require('lodash.bindall');
 require('chromedriver');
 const chromedriverVersion = require('chromedriver').version;
@@ -60,6 +61,7 @@ class SeleniumHelper {
             args.push('--no-sandbox');
         }
         chromeCapabilities.set('chromeOptions', {args});
+        chromeCapabilities.setPageLoadStrategy(PageLoadStrategy.EAGER);
         let driver = new webdriver.Builder()
             .forBrowser('chrome')
             .withCapabilities(chromeCapabilities)


### PR DESCRIPTION
### Resolves:

- Investigated while working on [ENA-263](https://scratchfoundation.atlassian.net/browse/ENA-263)

### Changes:

- Use a different `selenium-webdriver` page loading strategy so that we don't have to wait for the page to completely load. There are a couple of pages that navigate to the About page. The TED talk iframe is taking a long time to load. (This may be going away soon because of the cookies it uses.) It is then causing some following tests to fail.
- Wait for the landing page to load for the `footer-links.test.js`. Not sure if this is happening in CircleCI, but locally I am seeing periodic failures of these tests. The test attempts to click on a link and nothing (no error) happens. Not completely sure, but my theory is the page is reflowing right when the click is attempted and it misses. Added a wait for some text that appears after the /session request. 

### Test Coverage:

*N/a*


[ENA-263]: https://scratchfoundation.atlassian.net/browse/ENA-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ