### PR TITLE
Fit thumbnail instead of stretching it

### DIFF
--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -167,6 +167,7 @@ $radius: 8px;
         background: white;
         box-sizing: border-box;
         border: 2px solid $box-shadow-light-gray;
+        object-fit: cover;
     }
 
     .studio-follow-button {


### PR DESCRIPTION
This one-line update would change the way studio images display - it tries to contain most of the image instead of just stretching it so that it fits. For example, when an uploaded thumbnail is wider than the ratio of the default studio thumbnail, the image won't stretch its width and make it look distorted, instead, it will just crop the edges so that the center of the image can be viewed.