### PR TITLE
Added border radius to "What's happening?" user icons.

### DIFF
--- a/src/views/splash/splash.scss
+++ b/src/views/splash/splash.scss
@@ -114,10 +114,11 @@
 }
 
 .activity-img {
-    padding-right: .825rem;
+    margin-right: .825rem;
     width: 2rem;
     height: 2rem;
     vertical-align: middle;
+    border-radius: 3px;
 }
 
 .social-message-content {


### PR DESCRIPTION
### Resolves:

The "What's happening?" profile pictures of the users do not have a border radius, while the rest of the Scratch website shows profile pictures with a border-radius of 3 pixels.

### Changes:

This pull request is a minor change that just adds the border-radius property of 3px to the icons so they match the same style of other places and also replaces the image padding by margin, because padding was redundant and only causing visual issues.

### Test Coverage:

Tested on 4 browsers and 2 devices (a computer and a phone) - Works fine as expected:

<img width="1598" height="1982" alt="Comparison" src="https://github.com/user-attachments/assets/291dab35-c372-44da-977d-76e8741787ef" />
