### PR TITLE
[UEPR-388] Fix 1Password autofill issue

### DIFF
--- a/src/components/forms/input.jsx
+++ b/src/components/forms/input.jsx
@@ -3,6 +3,7 @@ const FRCInput = require('formsy-react-components').Input;
 const omit = require('lodash.omit');
 const PropTypes = require('prop-types');
 const React = require('react');
+const withFormsy = require('formsy-react').withFormsy;
 
 const defaultValidationHOC = require('./validations.jsx').defaultValidationHOC;
 const inputHOC = require('./input-hoc.jsx');
@@ -13,22 +14,29 @@ require('./row.scss');
 const Input = ({
     className,
     label,
+    setValue,
     ...props
-}) => (
-    <FRCInput
+}) => {
+    const handleChange = React.useCallback((_name, value) => {
+        setValue(value);
+    }, [setValue]);
+
+    return (<FRCInput
         className="input"
         label={label}
         rowClassName={classNames(
             className,
             {'no-label': (typeof label === 'undefined')}
         )}
+        onChange={handleChange}
         {...omit(props, ['className'])}
-    />
-);
+    />);
+};
 
 Input.propTypes = {
     className: PropTypes.string,
-    label: PropTypes.string
+    label: PropTypes.string,
+    setValue: PropTypes.func
 };
 
-module.exports = inputHOC(defaultValidationHOC(Input));
+module.exports = withFormsy(inputHOC(defaultValidationHOC(Input)));


### PR DESCRIPTION
### Resolves:

[UEPR-388](https://scratchfoundation.atlassian.net/browse/UEPR-388)

### Changes:

Add custom change handler that explicitly calls Formsy’s `setValue` whenever the field value changes. This fixes an issue where autofilled credentials (1Password) weren’t propagating, causing login failures.


[UEPR-388]: https://scratchfoundation.atlassian.net/browse/UEPR-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ