### PR TITLE
Remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # scratch-www
 #### Standalone web client for Scratch
 
-[![Build Status](https://travis-ci.org/LLK/scratch-www.svg)](https://travis-ci.org/LLK/scratch-www)
-[![Coverage Status](https://coveralls.io/repos/github/LLK/scratch-www/badge.svg?branch=develop)](https://coveralls.io/github/LLK/scratch-www?branch=develop)
-[![Greenkeeper badge](https://badges.greenkeeper.io/LLK/scratch-www.svg)](https://greenkeeper.io/)
-
 ## Overview
 
 This is Scratch’s open source web client! This is the code for much of the [Scratch website](https://scratch.mit.edu).


### PR DESCRIPTION
Removed build and coverage badges from README.

### Resolves:

They are outdated.

### Changes:

Removes the badges.

### Test Coverage:

<img width="928" height="608" alt="Screenshot 2025-10-17 6 05 01 PM" src="https://github.com/user-attachments/assets/6903790a-c1f5-4e4f-bf5d-e06465a94dcf" />
