### PR TITLE
Refactor renderHomepageRows to use dynamic rows

### DIFF
--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -589,7 +589,7 @@ SplashPresentation.defaultProps = {
     sharedByFollowing: [], // "Projects by Scratchers I'm Following"
     shouldShowCommunityRows: false,
     shouldShowFeaturedProjectRow: true,
-    shouldShowFeaturedStudioRow: true
+    shouldShowFeaturedStudioRow: false
 };
 
 module.exports = injectIntl(SplashPresentation);


### PR DESCRIPTION
toggle Featured Rows due to server issues

### Resolves:

It resolves things not loading on the homepage completely .

### Changes:

Uses rows.push like WTCIL and WTCIF and to toggle it.

### Test Coverage:

Before:

<img width="1206" height="421" alt="Screenshot 2025-11-02 10 30 51 AM" src="https://github.com/user-attachments/assets/e178ad2d-48ba-46ff-8dd5-ac34d6638860" />

After:

<img width="1156" height="742" alt="Screenshot 2025-11-02 10 31 43 AM" src="https://github.com/user-attachments/assets/d722572a-a541-46fc-8e15-8b37787d28c3" />