### PR TITLE
fix: membership tab flashing for logged in users

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -291,7 +291,7 @@ const mapStateToProps = state => ({
     searchTerm: state.navigation.searchTerm,
     unreadMessageCount: state.messageCount.messageCount,
     user: state.session && state.session.session && state.session.session.user,
-    isLoggedIn: state.session.status === sessionActions.Status.FETCHED ?
+    isLoggedIn: state.session && state.session.status === sessionActions.Status.FETCHED ?
         !!(state.session.session && state.session.session.user) :
         null,
     useScratch3Registration: state.navigation.useScratch3Registration


### PR DESCRIPTION
### Resolves:

https://scratchfoundation.atlassian.net/browse/UEPR-419

### Changes:

Make the check for whether to show membership tab in navigation default to false; introduce a `isLoggedIn` which is assigned a boolean only after session fetch.

