### PR TITLE
Made the Membership link appear on navbar when logged in

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -123,19 +123,11 @@ class Navigation extends React.Component {
                             <FormattedMessage id="general.ideas" />
                         </a>
                     </li>
-                    {
-                        this.props.isLoggedIn === false &&
-                            (
-                                <li className="link membership">
-                                    <a
-                                        href="/membership"
-                                    >
-                                        <FormattedMessage id="general.membership" />
-                                    </a>
-                                </li>
-                            )
-                    }
-
+                    <li className="link membership">
+                        <a href="/membership">
+                            <FormattedMessage id="general.membership" />
+                        </a>
+                    </li>
                     <li className="search">
                         <Form onSubmit={this.handleSearchSubmit}>
                             <Button


### PR DESCRIPTION
### Resolves:

- https://github.com/scratchfoundation/scratch-www/issues/9910

### Changes:

When you log into Scratch, you cannot see the membership link on the nav bar. I’ve made so that it is now visible.

### Test Coverage:
[sorry, don’t have image yet.]