### PR TITLE
fix: return logic to deploy when cicd job is run on any release branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,7 @@ jobs:
             (
               (github.ref == 'refs/heads/beta') ||
               startsWith(github.ref, 'refs/heads/hotfix/') ||
-              startsWith(github.ref, 'refs/heads/release/terms-of-use')
+              startsWith(github.ref, 'refs/heads/release/')
             ) && 'staging'
           ) ||
           ''


### PR DESCRIPTION
### Changes:

Return logic to deploy to staging when cicd is run with any release branch. Currently the cicd job is only run manually with release branches; this will ease the process of switching between membership and terms of use changes on staging
