### PR TITLE
[UEPR-423] Red Tooltip Not On Email Input

### DIFF
--- a/src/components/join-flow/email-step.jsx
+++ b/src/components/join-flow/email-step.jsx
@@ -230,8 +230,6 @@ class EmailStep extends React.Component {
                                 className={classNames(
                                     'join-flow-input',
                                     'join-flow-input-tall',
-                                    'join-flow-email-input',
-                                    {'join-flow-email-input-padding-sm': this.props.requiresExternalVerification},
                                     {fail: errors.email}
                                 )}
                                 error={errors.email}
@@ -240,11 +238,11 @@ class EmailStep extends React.Component {
                                 placeholder={this.props.intl.formatMessage({id: 'general.emailAddress'})}
                                 type="email"
                                 validate={this.validateEmail}
-                                validationClassName={classNames(
-                                    'validation-full-width-input',
+                                wrapperClassName={classNames(
                                     'join-flow-email-input',
                                     {'join-flow-email-input-padding-sm': this.props.requiresExternalVerification}
                                 )}
+                                validationClassName="validation-full-width-input"
                                 /* eslint-disable react/jsx-no-bind */
                                 onBlur={() => validateField('email')}
                                 onChange={e => {

--- a/src/components/join-flow/join-flow-steps.scss
+++ b/src/components/join-flow/join-flow-steps.scss
@@ -41,6 +41,7 @@
 
 .validation-full-width-input {
     transform: translate(21.8125rem, 0);
+    margin-top: 0;
 }
 
 .validation-birthdate-month {


### PR DESCRIPTION
### Resolves:

(https://scratchfoundation.atlassian.net/browse/UEPR-423)

### Changes:

Added the classes that add some margin top to the email field to the validation tooltip as well.

### Thoughts:

It is a little suspicious whether we really want that to be margin top of the email field or bottom of the previous component.

