### PR TITLE
[UEPR-438] Membership avatar not visible when adding a project to studio

### DIFF
--- a/src/views/studio/lib/studio-project-actions.js
+++ b/src/views/studio/lib/studio-project-actions.js
@@ -64,7 +64,9 @@ const generateProjectListItem = (postBody, infoBody) => ({
     image: infoBody.image,
     creator_id: infoBody.author.id,
     username: infoBody.author.username,
-    avatar: infoBody.author.profile.images
+    avatar: infoBody.author.profile.images,
+    creator_membership_avatar_badge: infoBody.author.profile.membership_avatar_badge,
+    creator_membership_label: infoBody.author.profile.membership_label
 });
 
 const addProject = projectIdOrUrl => ((dispatch, getState) => new Promise((resolve, reject) => {


### PR DESCRIPTION
### Resolves:

- [UEPR-438](https://scratchfoundation.atlassian.net/browse/UEPR-438)

### Changes:

- Add membership info when generating list item after adding a project


[UEPR-438]: https://scratchfoundation.atlassian.net/browse/UEPR-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ