### PR TITLE
fix: avoid crash due to missing author profile

### DIFF
--- a/src/components/carousel/carousel.jsx
+++ b/src/components/carousel/carousel.jsx
@@ -3,9 +3,10 @@ const defaults = require('lodash.defaults');
 const PropTypes = require('prop-types');
 const React = require('react');
 const Slider = require('react-slick').default;
-const Thumbnail = require('../thumbnail/thumbnail.jsx');
 
+const Thumbnail = require('../thumbnail/thumbnail.jsx');
 const {frameless} = require('../../lib/frameless.js');
+const {LABEL_TYPE} = require('../membership-label/membership-label.jsx');
 
 require('slick-carousel/slick/slick.scss');
 require('slick-carousel/slick/slick-theme.scss');
@@ -80,7 +81,8 @@ const Carousel = ({
                 return (
                     <Thumbnail
                         creator={item.author.username}
-                        creatorMembershipLabel={item.author.profile.membership_label}
+                        // On the starter projects page, the author `scratchteam` doesn't have a valid profile
+                        creatorMembershipLabel={item.author.profile?.membership_label ?? LABEL_TYPE.NONE}
                         href={href}
                         key={`${type}.${item.id}`}
                         loves={item.stats.loves}


### PR DESCRIPTION
### Resolves:

- Resolves "Oops!" page on https://scratch.mit.edu/starter-projects

### Changes:

Allow for the possibility that `item.author` has no valid `profile` by using `??` to supply `NONE` as the default label.

### Test Coverage:

Tested manually in staging.