### PR TITLE
Chore: update scratch-gui version to v12.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "12.1.3",
+        "@scratch/scratch-gui": "12.3.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2242,448 +2242,6 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -5002,18 +4560,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.1.3.tgz",
-      "integrity": "sha512-3lydsKh3JQhmOHgPy3nEHcyqPSg542lsySA3CqqbbXboPRZz1L9JycM2+2n16GCVrzylportVTCjn1rnILv32A==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.3.0.tgz",
+      "integrity": "sha512-PCs2vvvkLkOMovL3Xuf74DR/0dGGM4X1MXgwIOQVHiiY5NIaukhdaDHhu+SOfDE+99Z1QECRNqMusmpnCF1B2w==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "12.1.3",
-        "@scratch/scratch-svg-renderer": "12.1.3",
-        "@scratch/scratch-vm": "12.1.3",
+        "@scratch/scratch-render": "12.3.0",
+        "@scratch/scratch-svg-renderer": "12.3.0",
+        "@scratch/scratch-vm": "12.3.0",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5043,7 +4601,6 @@
         "lodash.defaultsdeep": "4.6.1",
         "lodash.omit": "4.5.0",
         "lodash.throttle": "4.1.1",
-        "minilog": "3.1.0",
         "omggif": "1.0.10",
         "papaparse": "5.5.3",
         "postcss-import": "12.0.1",
@@ -5067,14 +4624,15 @@
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
         "scratch-blocks": "1.3.0",
-        "scratch-l10n": "6.1.30",
-        "scratch-paint": "4.1.24",
+        "scratch-l10n": "6.1.43",
+        "scratch-paint": "4.1.35",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "5.0.10",
         "startaudiocontext": "1.2.1",
         "style-loader": "4.0.0",
         "text-encoding": "0.7.0",
         "to-style": "1.3.3",
+        "tslog": "4.10.2",
         "wav-encoder": "1.3.0",
         "xhr": "2.6.0"
       },
@@ -5232,9 +4790,9 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.30",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.30.tgz",
-      "integrity": "sha512-lSrk4rAHTHRQoBtpFkf+ZHkMpYQ1FWKsXhzGAQnQDkPmZCeztUxBC1tLHPXNJIc8pItiX6zIbgHw0EIRAcFq1A==",
+      "version": "6.1.43",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.43.tgz",
+      "integrity": "sha512-Phom1BWv4a+cEZ7I3d5USyt8Wxw7qObY3gCHzC/fgOtel1VMcpM+T/eVriw91VSgd6Biw89CJhBaCfNEhCNDxA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5245,7 +4803,7 @@
         "lodash.defaultsdeep": "4.6.1",
         "mkdirp": "3.0.1",
         "transifex": "1.6.6",
-        "tsx": "4.20.6"
+        "tsx": "4.21.0"
       },
       "bin": {
         "build-i18n-src": "scripts/build-i18n-src.mts",
@@ -5269,61 +4827,24 @@
         "minilog": "^3.1.0"
       }
     },
-    "node_modules/@scratch/scratch-gui/node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "node_modules/@scratch/scratch-render": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.1.3.tgz",
-      "integrity": "sha512-PzI3xXvtyC+a6wiemj5yItaGEhyqaQ3Xwrbod0iXKnRgJbLLchrGt/sjTANX86mWRmgHB1RWRtZzzbs58bqm6Q==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.3.0.tgz",
+      "integrity": "sha512-KAN/Pmy4ZfYuLt/I9Rg9V80crct518YRMV8MP5nghGK6nGupx4Fl9XXKcSGZyBC3erIJbzkotsValZ1HxQR/Yw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "12.1.3",
+        "@scratch/scratch-svg-renderer": "12.3.0",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
         "linebreak": "0.3.0",
-        "minilog": "3.1.0",
         "raw-loader": "0.5.1",
+        "tslog": "4.10.2",
         "twgl.js": "4.24.0"
       },
       "peerDependencies": {
         "scratch-render-fonts": "^1.0.0"
-      }
-    },
-    "node_modules/@scratch/scratch-render/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/@scratch/scratch-render/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
       }
     },
     "node_modules/@scratch/scratch-render/node_modules/raw-loader": {
@@ -5333,9 +4854,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.1.3.tgz",
-      "integrity": "sha512-UkYmHm14SJ7aQDd4v8Z4R5Ik1xEgKJ754COp0BMs9Uf+KXYUvQyMHQq0WVKgaEze/A+KJh7VpRA8rb1QnGPE5w==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.3.0.tgz",
+      "integrity": "sha512-8yxaUYzDAy4/pk8NgIM5KVuvwv+Rzfy8Fd2SQ47PhG8DQMfzW9M0JqPW9AnZMAJOfP8lEQkmSMGRSQtOARETlA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5344,39 +4865,22 @@
         "css-tree": "1.1.3",
         "fastestsmallesttextencoderdecoder": "1.0.22",
         "isomorphic-dompurify": "2.26.0",
-        "minilog": "3.1.0",
-        "transformation-matrix": "1.15.3"
+        "transformation-matrix": "1.15.3",
+        "tslog": "4.10.2"
       },
       "peerDependencies": {
         "scratch-render-fonts": "^1.0.0"
       }
     },
-    "node_modules/@scratch/scratch-svg-renderer/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/@scratch/scratch-svg-renderer/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/@scratch/scratch-vm": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.1.3.tgz",
-      "integrity": "sha512-FkUwu/WC5NBlUWFY5IvIoTp92PQAMKuZu49IceUvGHwc2c3KeJSWK6iO5TohUhZTHLE8cGIQNnrwpvvk1uo22w==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.3.0.tgz",
+      "integrity": "sha512-zOqessaWDq77u3rTz30d9OJkQV6goeRV+ZhGDMJlMuolACEMz7qbBsX6Pl+p5+MIkJlVKNAmQ4O7erzc99ZjHg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "12.1.3",
-        "@scratch/scratch-svg-renderer": "12.1.3",
+        "@scratch/scratch-render": "12.3.0",
+        "@scratch/scratch-svg-renderer": "12.3.0",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -5388,13 +4892,13 @@
         "htmlparser2": "3.10.1",
         "immutable": "3.8.2",
         "jszip": "3.10.1",
-        "minilog": "3.1.0",
         "scratch-audio": "2.0.268",
         "scratch-parser": "6.0.0",
         "scratch-sb1-converter": "2.0.279",
         "scratch-storage": "5.0.10",
         "scratch-translate-extension-languages": "1.0.7",
         "text-encoding": "0.7.0",
+        "tslog": "4.10.2",
         "uuid": "8.3.2",
         "web-worker": "1.3.0"
       }
@@ -11671,48 +11175,6 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -23944,9 +23406,9 @@
       }
     },
     "node_modules/scratch-paint": {
-      "version": "4.1.24",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.24.tgz",
-      "integrity": "sha512-BD13LXce8CCpZAiHRWKJZFCPkS4K/aU4ldB0h8SpYW3W5ortuo/D0WiRTkspYzrbVX5swzjY8jcjxQN6amHYXA==",
+      "version": "4.1.35",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.35.tgz",
+      "integrity": "sha512-y0GZUlxQVPJMish0rnvr2W1J1FMv0CUxzhnW8fCPg6yNNlayDv3k4WJ2pjMLbAvqdE8y7bWA5KJ3WGHhAKlUIQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -28592,6 +28054,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tslog": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
+      "integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "12.1.3",
+    "@scratch/scratch-gui": "12.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Updates scratch-gui version to v12.3.0, which includes all most recent changes