### PR TITLE
chore: update scratch-gui to v12.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "12.1.4",
+        "@scratch/scratch-gui": "12.1.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5002,18 +5002,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.1.4.tgz",
-      "integrity": "sha512-wjhETx3zt2e9XrLAfUglp2XYrFrwGDRKl8aVm+tmHHnMzzW/C7f4fScUBlwsHgh5UnisN5CkZiJh6jHZ4FUtaA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.1.5.tgz",
+      "integrity": "sha512-YvdZQhFPaOA2T0c22HjNH7BgFrZm5SUz/8vs8JooxFDV61eYM+TgNwuqGxbLLEGP/SV++C+OZ/k8Hyw8zDbiyQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "12.1.4",
-        "@scratch/scratch-svg-renderer": "12.1.4",
-        "@scratch/scratch-vm": "12.1.4",
+        "@scratch/scratch-render": "12.1.5",
+        "@scratch/scratch-svg-renderer": "12.1.5",
+        "@scratch/scratch-vm": "12.1.5",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5290,13 +5290,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.1.4.tgz",
-      "integrity": "sha512-fXk/mHJZGvQIhjVkTCRjZ3IuJuR0t0QRv0RAqhkmRom7ebEuTFe7sNVWyTMc4e8lgGhLgpGEHFasrWq4nUkqdQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.1.5.tgz",
+      "integrity": "sha512-ExlITATgFHAFyIJZBI5K0ZDCi7AHS3OQeTJ69eNEKqxXscfiokK/yeu91ZPguHj9/z/1JREHAkOC6r79cLmdsA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "12.1.4",
+        "@scratch/scratch-svg-renderer": "12.1.5",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5333,9 +5333,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.1.4.tgz",
-      "integrity": "sha512-qcida6rQ83aqb6V0pANOXro+lSANyd1ZdQ6eCbImQ+6xki11SveZwQxHI8Wn0MrkQ0iJPyLYoqQKHnJFBE6aYQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.1.5.tgz",
+      "integrity": "sha512-nBldq3GKzc7K+KHUo/V+nb5sfND987rKBGyLvQYrrmWxy25+DFM5WSwc3kVS2KImtp4XJM5bwW4o6mWcc5R04A==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5369,14 +5369,14 @@
       }
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.1.4.tgz",
-      "integrity": "sha512-Qd7j1+vLvwQC7vxMA2GJUpYGlApZ/NntJQPB1h9bMwlL8pajkCPrV4FB0AIHOolPcpzXW7J87Sl7lHEfQj0BTQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.1.5.tgz",
+      "integrity": "sha512-fhtq6ssuRcRfrnCQClVO1Lp3Fi1Ay+71Atcv7Rns/GFL0McY/CIjAs0FoZV27r+6YsOrj0OzzxebPJ2zda0zig==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "12.1.4",
-        "@scratch/scratch-svg-renderer": "12.1.4",
+        "@scratch/scratch-render": "12.1.5",
+        "@scratch/scratch-svg-renderer": "12.1.5",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "12.1.4",
+    "@scratch/scratch-gui": "12.1.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Update `scratch-gui` version to `v12.1.5`