### PR TITLE
[UEPR-442] Fix Avatar Frame missing on Become a Scratcher Invitation card

### DIFF
--- a/src/views/become-a-scratcher/become-a-scratcher.jsx
+++ b/src/views/become-a-scratcher/become-a-scratcher.jsx
@@ -19,6 +19,7 @@ import {
     CommunityGuidelines,
     communityGuidelines
 } from '../../components/community-guidelines/community-guidelines.jsx';
+import Avatar from '../../components/avatar/avatar.jsx';
 
 import './become-a-scratcher.scss';
 
@@ -323,9 +324,10 @@ const BecomeAScratcher = ({user, invitedScratcher, scratcher, sessionStatus}) =>
                                 alt=""
                                 src={`/images/onboarding/left-lines.svg`}
                             />
-                            <img
+                            <Avatar
                                 className="invitation-icon"
                                 src={thumbnailUrl(user.id, 100, 100)}
+                                showAvatarBadge={!!user.membership_avatar_badge}
                             />
                             <img
                                 alt=""
@@ -433,7 +435,8 @@ BecomeAScratcher.propTypes = {
     user: PropTypes.shape({
         id: PropTypes.number,
         thumbnailUrl: PropTypes.string,
-        username: PropTypes.string
+        username: PropTypes.string,
+        membership_avatar_badge: PropTypes.number
     }),
     invitedScratcher: PropTypes.bool,
     scratcher: PropTypes.bool,

--- a/src/views/become-a-scratcher/become-a-scratcher.scss
+++ b/src/views/become-a-scratcher/become-a-scratcher.scss
@@ -187,8 +187,12 @@ html,body{
 
     .invitation-icon{
         border-radius: 3px;
-        width: 50px;
-        margin: 0px 10px;
+    }
+
+    .avatar-wrapper {
+        margin: 0 10px;
+        --frame-size: 13px;
+        --avatar-size: 50px;
     }
 
     button{


### PR DESCRIPTION
### Resolves:

[UEPR-442](https://scratchfoundation.atlassian.net/browse/UEPR-442)

### Changes:

- Add avatar frame to the Become a Scratcher Invitation Card

[UEPR-442]: https://scratchfoundation.atlassian.net/browse/UEPR-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ