### PR TITLE
Fix: Remove obsolete ToU path

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -17,8 +17,7 @@ const banGoodListPaths = [
     '/vpn_required',
     '/accounts/banned-response',
     '/accounts/bad-username',
-    '/community_guidelines',
-    '/privacy_policy'
+    '/community_guidelines'
 ];
 
 module.exports.Status = keyMirror({

--- a/src/routes.json
+++ b/src/routes.json
@@ -271,20 +271,6 @@
         "redirect": "/3faq"
     },
     {
-        "name": "privacypolicy",
-        "pattern": "^/privacy_policy/?$",
-        "routeAlias": "/privacy_policy/?$",
-        "view": "privacypolicy/privacypolicy",
-        "title": "Privacy Policy"
-    },
-    {
-        "name": "privacypolicy-apps",
-        "pattern": "^/privacy_policy/apps?$",
-        "routeAlias": "/privacy_policy/apps?$",
-        "view": "privacypolicy-apps/privacypolicy-apps",
-        "title": "Privacy Policy"
-    },
-    {
         "name": "research",
         "pattern": "^/research/?$",
         "routeAlias": "/research",


### PR DESCRIPTION
### Resolves

[UEPR-478](https://scratchfoundation.atlassian.net/browse/UEPR-478)

### Changes:

- Remove access to obsolete `terms_of_use` page, which is no longer used

[UEPR-478]: https://scratchfoundation.atlassian.net/browse/UEPR-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ