### PR TITLE
[UEPR-486] Add DC to the state options

### DIFF
--- a/src/components/join-flow/country-step.jsx
+++ b/src/components/join-flow/country-step.jsx
@@ -43,7 +43,7 @@ class CountryStep extends React.Component {
         if (this.stateOptions.length === 0) {
             const allSubdivisions = countryData.subdivisionOptions.us ?? [];
             
-            this.stateOptions = allSubdivisions.filter(subdivision => subdivision.type === 'State');
+            this.stateOptions = allSubdivisions.filter(subdivision => subdivision.type !== 'Outlying area');
             
             this.stateOptions.unshift({
                 disabled: true,

--- a/src/components/tos-flow/profile-completion-step.jsx
+++ b/src/components/tos-flow/profile-completion-step.jsx
@@ -29,7 +29,7 @@ const ProfileCompletionStep = ({user, onSubmit, loading, error}) => {
 
     const allSubdivisions = countryInfo ? countryData.subdivisionOptions[countryInfo.code] : [];
     const stateOptions = useMemo(() =>
-        allSubdivisions.filter(subdivision => subdivision.type === 'State'),
+        allSubdivisions.filter(subdivision => subdivision.type !== 'Outlying area'),
     [allSubdivisions]);
 
     const countryOptions = countryData.registrationCountryNameOptions;


### PR DESCRIPTION
### Resolves:

- [UEPR-486](https://scratchfoundation.atlassian.net/browse/UEPR-486)

### Changes:

- Add "District of Columbia" to the state options during sign up and when collecting the state for existing users
- Only exclude outlying areas when filtering the US subdivisions

[UEPR-486]: https://scratchfoundation.atlassian.net/browse/UEPR-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ