### PR TITLE
chore: Bring back automatic deploy from develop

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,6 +35,7 @@ jobs:
           ) ||
           (
             (
+              (github.ref == 'refs/heads/develop') ||
               (github.ref == 'refs/heads/beta') ||
               startsWith(github.ref, 'refs/heads/hotfix/') ||
               startsWith(github.ref, 'refs/heads/release/')


### PR DESCRIPTION
Bring back automatic deploys from the `develop` branch