### PR TITLE
chore: Update scratch-gui version to v12.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "12.6.2",
+        "@scratch/scratch-gui": "12.6.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -144,23 +144,23 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
-      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.4",
-        "@csstools/css-color-parser": "^3.1.0",
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4",
-        "lru-cache": "^11.2.4"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.7.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
-      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -178,7 +178,7 @@
         "bidi-js": "^1.0.3",
         "css-tree": "^3.1.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.4"
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2174,9 +2174,9 @@
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
       "dev": true,
       "funding": [
         {
@@ -2190,13 +2190,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
       "dev": true,
       "funding": [
         {
@@ -2210,17 +2210,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
       "dev": true,
       "funding": [
         {
@@ -2234,21 +2234,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
         {
@@ -2262,16 +2262,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
-      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
       "dev": true,
       "funding": [
         {
@@ -2283,15 +2283,12 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -2305,7 +2302,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2402,9 +2399,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.9.0.tgz",
-      "integrity": "sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4408,18 +4405,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.6.2.tgz",
-      "integrity": "sha512-J7ijzj9eVAt+XKJrVHd286pTppfxhmA2PGkz0BB1fY7xTVANE6i2JBI2TpjeLPaw9Q9sitoJFlQKVYnIwWXe3A==",
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.6.3.tgz",
+      "integrity": "sha512-UtSCCVPvbZrenoI1uonaf6eDvqiPx/+kr18UZ/blc8zo0St4oUH6szuDUa4yDWfW7DHMjEWgDmshucowFmq8BQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "12.6.2",
-        "@scratch/scratch-svg-renderer": "12.6.2",
-        "@scratch/scratch-vm": "12.6.2",
+        "@scratch/scratch-render": "12.6.3",
+        "@scratch/scratch-svg-renderer": "12.6.3",
+        "@scratch/scratch-vm": "12.6.3",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -4475,7 +4472,7 @@
         "scratch-l10n": "6.1.60",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
-        "scratch-storage": "6.1.5",
+        "scratch-storage": "6.1.3",
         "startaudiocontext": "1.2.1",
         "style-loader": "4.0.0",
         "text-encoding": "0.7.0",
@@ -4542,6 +4539,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scratch/scratch-gui/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
     "node_modules/@scratch/scratch-gui/node_modules/picocolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
@@ -4582,14 +4596,31 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@scratch/scratch-render": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.6.2.tgz",
-      "integrity": "sha512-mYKSevUv+bRzHk5/ga6j96cR4ZkT7Fw1Ld5KcUrcLI9bUiHHy99btwp8kahhpNB5rfjJ9m2ZH1PIm5cE8It4HA==",
+    "node_modules/@scratch/scratch-gui/node_modules/scratch-storage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.3.tgz",
+      "integrity": "sha512-xoUIB7/MNF2864lz6mfwGxKwlp7LdpvM4k+amzp3RwtYlQIjca9t/U8dngKKS0zEz4Fc1fuykYRqRPchVnE+Fg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "12.6.2",
+        "@babel/runtime": "^7.21.0",
+        "@scratch/task-herder": "12.6.0",
+        "arraybuffer-loader": "^1.0.3",
+        "base64-js": "^1.3.0",
+        "buffer": "6.0.3",
+        "fastestsmallesttextencoderdecoder": "^1.0.7",
+        "js-md5": "^0.7.3",
+        "minilog": "^3.1.0"
+      }
+    },
+    "node_modules/@scratch/scratch-render": {
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.6.3.tgz",
+      "integrity": "sha512-RWieUCEesYTh8dolHNtkIjircCQhERoDeYkep8nQY8SnYcKJLVfeqX/iikjj0Hh2SFEGnN7y9XlXEXg/weXkEA==",
+      "dev": true,
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@scratch/scratch-svg-renderer": "12.6.3",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -4609,9 +4640,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.6.2.tgz",
-      "integrity": "sha512-kxVC8hQang/luxwdBR0HWjR0yKfWdBZFQVBMNx+G8menCMcjpdzbfpY2yfOKtj7Za2uGgP2p7OHAKxJ+cgg1eA==",
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.6.3.tgz",
+      "integrity": "sha512-Iw3xr9az5hdqaQbrX0N8XiE+6h/obyN90I5CcdeR3QpB5lc1iYaIXWTN9kZw62g0z43cnmL33vmrJU/fHRuaqw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -4628,14 +4659,14 @@
       }
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.6.2.tgz",
-      "integrity": "sha512-1Ol8ddRUi8HzhjAAFD0NVFzOitvTwpJqthAM5fDmyl/2PiV5bjLH/+ldsNUqnp5RPN4j12T/u9qc/HxZZSlMjw==",
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.6.3.tgz",
+      "integrity": "sha512-yaUjl9LTxr5Oc5q+c43lthwz/hmdPHyYskpEgVLN/jfjaXWhUwfdSd5V1AWQ61emTAKMGlmr+OhXE+JtxiXZoQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "12.6.2",
-        "@scratch/scratch-svg-renderer": "12.6.2",
+        "@scratch/scratch-render": "12.6.3",
+        "@scratch/scratch-svg-renderer": "12.6.3",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -4650,11 +4681,45 @@
         "scratch-audio": "2.0.268",
         "scratch-parser": "6.0.0",
         "scratch-sb1-converter": "2.0.279",
-        "scratch-storage": "6.1.5",
+        "scratch-storage": "6.1.3",
         "scratch-translate-extension-languages": "1.0.7",
         "text-encoding": "0.7.0",
         "tslog": "4.10.2",
         "uuid": "8.3.2"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/scratch-storage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.3.tgz",
+      "integrity": "sha512-xoUIB7/MNF2864lz6mfwGxKwlp7LdpvM4k+amzp3RwtYlQIjca9t/U8dngKKS0zEz4Fc1fuykYRqRPchVnE+Fg==",
+      "dev": true,
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@scratch/task-herder": "12.6.0",
+        "arraybuffer-loader": "^1.0.3",
+        "base64-js": "^1.3.0",
+        "buffer": "6.0.3",
+        "fastestsmallesttextencoderdecoder": "^1.0.7",
+        "js-md5": "^0.7.3",
+        "minilog": "^3.1.0"
       }
     },
     "node_modules/@scratch/task-herder": {
@@ -8993,9 +9058,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -21821,7 +21886,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -27465,22 +27530,22 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.19"
+        "tldts-core": "^7.0.22"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "12.6.2",
+    "@scratch/scratch-gui": "12.6.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Update `scratch-gui` version to `v12.6.3`, which switches back to using scratch-storage `v6.1.3`, instead of `v6.1.5`