### PR TITLE
Chore: Update scratch-gui version to v12.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "12.6.3",
+        "@scratch/scratch-gui": "12.6.4",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
-      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
       "dev": true,
       "funding": [
         {
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
-      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.12.0.tgz",
+      "integrity": "sha512-BuCOHA/EJdPN0qQ5MdgAiJSt9fYDHbghlgrj33gRdy/Yp1/FMCDhU6vJfcKrLC0TPWGSrfH3vYXBQWmFHxlddw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4405,18 +4405,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.6.3.tgz",
-      "integrity": "sha512-UtSCCVPvbZrenoI1uonaf6eDvqiPx/+kr18UZ/blc8zo0St4oUH6szuDUa4yDWfW7DHMjEWgDmshucowFmq8BQ==",
+      "version": "12.6.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-12.6.4.tgz",
+      "integrity": "sha512-zM9odE9Y6WgS+FmY36xTh48wXrhcQ1bbBEfne6NCggUDJbt+4mVJix670h2CxRQ+dlPm/N0CX6mcYPY4016opQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "12.6.3",
-        "@scratch/scratch-svg-renderer": "12.6.3",
-        "@scratch/scratch-vm": "12.6.3",
+        "@scratch/scratch-render": "12.6.4",
+        "@scratch/scratch-svg-renderer": "12.6.4",
+        "@scratch/scratch-vm": "12.6.4",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -4614,13 +4614,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.6.3.tgz",
-      "integrity": "sha512-RWieUCEesYTh8dolHNtkIjircCQhERoDeYkep8nQY8SnYcKJLVfeqX/iikjj0Hh2SFEGnN7y9XlXEXg/weXkEA==",
+      "version": "12.6.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-12.6.4.tgz",
+      "integrity": "sha512-K1+/gWH+uO28HZPKUuZk40Eu+hLte2voHJXbS/zJefe7NpEzrxLNU0r4hTknsWy7JDKSnjo2jZNp9LTQW6SvdQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "12.6.3",
+        "@scratch/scratch-svg-renderer": "12.6.4",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -4640,9 +4640,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.6.3.tgz",
-      "integrity": "sha512-Iw3xr9az5hdqaQbrX0N8XiE+6h/obyN90I5CcdeR3QpB5lc1iYaIXWTN9kZw62g0z43cnmL33vmrJU/fHRuaqw==",
+      "version": "12.6.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-12.6.4.tgz",
+      "integrity": "sha512-Kodkf6NsPMWpsyRG01Kc5+oXSUiUlpD/XPtThEKcTZM44+1q3tbK4fD738hMMMEPRBZflKdpFY/RXVo75HxH6A==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -4659,14 +4659,14 @@
       }
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.6.3.tgz",
-      "integrity": "sha512-yaUjl9LTxr5Oc5q+c43lthwz/hmdPHyYskpEgVLN/jfjaXWhUwfdSd5V1AWQ61emTAKMGlmr+OhXE+JtxiXZoQ==",
+      "version": "12.6.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-12.6.4.tgz",
+      "integrity": "sha512-LVXbSOOfEnO7bcEy7wy+kvkiEuVJlWNVXM38kmmR/K2uFkmwy4IrFoZXa8VfQ6dvBeRFfHygseRew+UXp0WYog==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "12.6.3",
-        "@scratch/scratch-svg-renderer": "12.6.3",
+        "@scratch/scratch-render": "12.6.4",
+        "@scratch/scratch-svg-renderer": "12.6.4",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -27537,22 +27537,22 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
-      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.22"
+        "tldts-core": "^7.0.23"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
-      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "12.6.3",
+    "@scratch/scratch-gui": "12.6.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Update scratch-gui version to v12.6.4, which includes a minor fix for the Surprise button