### PR TITLE
fix: revert scratch-storage to fix fetch worker errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-twitter-embed": "4.0.4",
         "react-use": "17.6.0",
         "scratch-parser": "6.0.0",
-        "scratch-storage": "^6.1.6"
+        "scratch-storage": "6.1.3"
       },
       "devDependencies": {
         "@babel/cli": "7.28.6",
@@ -4539,23 +4539,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@scratch/scratch-gui/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/@scratch/scratch-gui/node_modules/picocolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
@@ -4594,23 +4577,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/scratch-storage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.3.tgz",
-      "integrity": "sha512-xoUIB7/MNF2864lz6mfwGxKwlp7LdpvM4k+amzp3RwtYlQIjca9t/U8dngKKS0zEz4Fc1fuykYRqRPchVnE+Fg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@scratch/task-herder": "12.6.0",
-        "arraybuffer-loader": "^1.0.3",
-        "base64-js": "^1.3.0",
-        "buffer": "6.0.3",
-        "fastestsmallesttextencoderdecoder": "^1.0.7",
-        "js-md5": "^0.7.3",
-        "minilog": "^3.1.0"
       }
     },
     "node_modules/@scratch/scratch-render": {
@@ -4688,45 +4654,10 @@
         "uuid": "8.3.2"
       }
     },
-    "node_modules/@scratch/scratch-vm/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/@scratch/scratch-vm/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
-    "node_modules/@scratch/scratch-vm/node_modules/scratch-storage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.3.tgz",
-      "integrity": "sha512-xoUIB7/MNF2864lz6mfwGxKwlp7LdpvM4k+amzp3RwtYlQIjca9t/U8dngKKS0zEz4Fc1fuykYRqRPchVnE+Fg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@scratch/task-herder": "12.6.0",
-        "arraybuffer-loader": "^1.0.3",
-        "base64-js": "^1.3.0",
-        "buffer": "6.0.3",
-        "fastestsmallesttextencoderdecoder": "^1.0.7",
-        "js-md5": "^0.7.3",
-        "minilog": "^3.1.0"
-      }
-    },
     "node_modules/@scratch/task-herder": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@scratch/task-herder/-/task-herder-12.6.0.tgz",
       "integrity": "sha512-T5sO3GnNan4ffGpkNSq6NcRGQA5AIED7Oujg9kdGVnbGiHVZu8WwsRgwneTOQ99cfeADnLzWQPJpOsNAZBmMng==",
-      "dev": true,
       "license": "AGPL-3.0-only"
     },
     "node_modules/@sinclair/typebox": {
@@ -23335,13 +23266,13 @@
       }
     },
     "node_modules/scratch-storage": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.7.tgz",
-      "integrity": "sha512-u2Be6Lho/NDAdPNSdOSVxrkxCzv6E4zaE+iffOXR9lizVJKvrt8bCptJu8kUijbYSVzHSdNGYza/v3v4dwpIIg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-6.1.3.tgz",
+      "integrity": "sha512-xoUIB7/MNF2864lz6mfwGxKwlp7LdpvM4k+amzp3RwtYlQIjca9t/U8dngKKS0zEz4Fc1fuykYRqRPchVnE+Fg==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
-        "@scratch/task-herder": "12.6.2",
+        "@scratch/task-herder": "12.6.0",
         "arraybuffer-loader": "^1.0.3",
         "base64-js": "^1.3.0",
         "buffer": "6.0.3",
@@ -23349,12 +23280,6 @@
         "js-md5": "^0.7.3",
         "minilog": "^3.1.0"
       }
-    },
-    "node_modules/scratch-storage/node_modules/@scratch/task-herder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/task-herder/-/task-herder-12.6.2.tgz",
-      "integrity": "sha512-x3R/+ttXOqKCfS25YVkuyhFX5CZ1+wTNDELsYhvmayXcOhuQwZFTnQWt2RtrYzTJnZ6iNVT6KgvQyEIyTKBmUQ==",
-      "license": "AGPL-3.0-only"
     },
     "node_modules/scratch-storage/node_modules/microee": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-twitter-embed": "4.0.4",
     "react-use": "17.6.0",
     "scratch-parser": "6.0.0",
-    "scratch-storage": "^6.1.6"
+    "scratch-storage": "6.1.3"
   },
   "devDependencies": {
     "@babel/cli": "7.28.6",


### PR DESCRIPTION
### Changes:

Reverting to `scratch-storage@6.1.3` to fix an issue causing browsers to attempt to load `fetch-worker.*.js` from the wrong path. This doesn't seem to be causing user-facing trouble, but it's causing extra noise in our server logs.

We previously applied the same temporary fix to the editor, where the issue _was_ causing user-facing trouble. Another way to view this change is that it updates the `scratch-www` dependency on `scratch-storage` to match the version in this release of `scratch-editor`.

An upcoming release will include a new, fixed version of `scratch-storage`. The issue was present from `scratch-storage@6.1.4` through `scratch-storage@6.1.7` and was fixed in `scratch-storage@6.1.8`. I would have used 6.1.8 for this hotfix, but it hasn't been through QA yet, so I'd rather stick with this known quantity.
