### PR TITLE
Prepare explore page for curated responses

### DIFF
--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -7,7 +7,6 @@ const render = require('../../lib/render.jsx');
 const {connect} = require('react-redux');
 
 const api = require('../../lib/api');
-const intlShape = require('../../lib/intl-shape');
 const PropTypes = require('prop-types');
 const {getLocale} = require('../../lib/locales.js');
 
@@ -15,8 +14,6 @@ const Page = require('../../components/page/www/page.jsx');
 const Tabs = require('../../components/tabs/tabs.jsx');
 const TitleBanner = require('../../components/title-banner/title-banner.jsx');
 const Button = require('../../components/forms/button.jsx');
-const Form = require('../../components/forms/form.jsx');
-const Select = require('../../components/forms/select.jsx');
 const SubNavigation = require('../../components/subnavigation/subnavigation.jsx');
 const Grid = require('../../components/grid/grid.jsx');
 
@@ -28,7 +25,6 @@ class Explore extends React.Component {
         bindAll(this, [
             'getExploreState',
             'handleGetExploreMore',
-            'handleChangeSortMode',
             'handleToggleRemoveButton',
             'handleRemove',
             'getBubble'
@@ -48,12 +44,9 @@ class Explore extends React.Component {
             animations: 'animations',
             art: 'art',
             games: 'games',
-            music: 'music',
-            stories: 'stories',
-            tutorials: 'tutorial'
+            music: 'music'
         };
         const typeOptions = ['projects', 'studios'];
-        const modeOptions = ['trending', 'popular', ''];
 
         let pathname = window.location.pathname.toLowerCase();
         if (pathname[pathname.length - 1] === '/') {
@@ -63,10 +56,9 @@ class Explore extends React.Component {
         const options = pathname.split('/');
         const type = options[2];
         const currentCategory = options[3];
-        const currentMode = options.length > 4 ? options[4] : '';
         if (Object.keys(categoryOptions).indexOf(currentCategory) === -1 ||
-        typeOptions.indexOf(type) === -1 ||
-        modeOptions.indexOf(currentMode) === -1){
+            typeOptions.indexOf(type) === -1 ||
+            currentCategory === categoryOptions.all) {
             window.location = `${window.location.origin}/explore/projects/all/`;
         }
 
@@ -74,18 +66,15 @@ class Explore extends React.Component {
             category: currentCategory,
             acceptableTabs: categoryOptions,
             acceptableTypes: typeOptions,
-            acceptableModes: modeOptions,
             itemType: type,
-            mode: currentMode,
             loadNumber: 16
         };
     }
     handleGetExploreMore () {
         const qText = `&q=${this.state.acceptableTabs[this.state.category]}` || '*';
-        const mode = `&mode=${(this.state.mode ? this.state.mode : 'trending')}`;
         const locale = getLocale();
         const queryString =
-            `limit=${this.state.loadNumber}&offset=${this.state.offset}&language=${locale}${mode}${qText}`;
+            `limit=${this.state.loadNumber}&offset=${this.state.offset}&language=${locale}${qText}`;
 
         api({
             uri: `/explore/${this.state.itemType}?${queryString}`
@@ -98,13 +87,6 @@ class Explore extends React.Component {
                 this.setState({offset: currentOffset});
             }
         });
-    }
-
-    handleChangeSortMode (name, value) {
-        if (this.state.acceptableModes.indexOf(value) !== -1) {
-            window.location =
-                `${window.location.origin}/explore/${this.state.itemType}/${this.state.category}/${value}`;
-        }
     }
 
     handleToggleRemoveButton (e) {
@@ -132,7 +114,7 @@ class Explore extends React.Component {
             active: (this.state.category === type)
         });
         return (
-            <a href={`/explore/${this.state.itemType}/${type}/${this.state.mode}`}>
+            <a href={`/explore/${this.state.itemType}/${type}`}>
                 <li className={classes}>
                     <FormattedMessage id={`general.${type}`} />
                 </li>
@@ -157,7 +139,7 @@ class Explore extends React.Component {
                                 name: 'projects',
                                 onTrigger: () => {
                                     window.location = `${window.location.origin}/explore/projects/` +
-                                        `${this.state.category}/${this.state.mode}`;
+                                        `${this.state.category}/`;
                                 },
                                 getContent: isActive => (
                                     <div>
@@ -182,8 +164,7 @@ class Explore extends React.Component {
                             {
                                 name: 'studios',
                                 onTrigger: () => {
-                                    window.location = `${window.location.origin}/explore/studios/` +
-                                        `${this.state.category}/${this.state.mode}`;
+                                    window.location = `${window.location.origin}/explore/studios/all`;
                                 },
                                 getContent: isActive => (
                                     <div>
@@ -208,35 +189,16 @@ class Explore extends React.Component {
                         ]}
                         activeTabName={this.state.itemType}
                     />
-                    <div className="sort-controls">
-                        <SubNavigation className="categories">
-                            {this.getBubble('all')}
-                            {this.getBubble('animations')}
-                            {this.getBubble('art')}
-                            {this.getBubble('games')}
-                            {this.getBubble('music')}
-                            {this.getBubble('stories')}
-                            {this.getBubble('tutorials')}
-                        </SubNavigation>
-                        <Form className="sort-mode">
-                            <Select
-                                aria-label={this.props.intl.formatMessage({id: 'general.status'})}
-                                name="sort"
-                                options={[
-                                    {
-                                        value: 'trending',
-                                        label: this.props.intl.formatMessage({id: 'explore.trending'})
-                                    },
-                                    {
-                                        value: 'popular',
-                                        label: this.props.intl.formatMessage({id: 'explore.popular'})
-                                    }
-                                ]}
-                                value={this.state.mode}
-                                onChange={this.handleChangeSortMode}
-                            />
-                        </Form>
-                    </div>
+                    {this.state.itemType === 'projects' && (
+                        <div className="sort-controls">
+                            <SubNavigation className="categories">
+                                {this.getBubble('all')}
+                                {this.getBubble('animations')}
+                                {this.getBubble('art')}
+                                {this.getBubble('games')}
+                                {this.getBubble('music')}
+                            </SubNavigation>
+                        </div>)}
                     {this.props.session?.session?.permissions?.admin && (
                         <div className="sort-controls">
                             <label>
@@ -278,7 +240,6 @@ class Explore extends React.Component {
 }
 
 Explore.propTypes = {
-    intl: intlShape,
     session: PropTypes.object
 };
 


### PR DESCRIPTION
Remove trending/popular selector for explore. Remove stories and tutorials as categories. No more categories on studios explore. See POD-353


### Resolves:

POD-353

### Changes:

Changes layout and options on explore page.

### Test Coverage:

Existing tests cover lint only, maybe we should add tests to check for the expected categories/no dropdown?