### PR TITLE
feat: add new invalid-parent-email info step as part of ToS acceptanc…

### DIFF
--- a/src/components/tos-flow/invalid-parent-email-info-step.jsx
+++ b/src/components/tos-flow/invalid-parent-email-info-step.jsx
@@ -1,0 +1,64 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const {useIntl, FormattedMessage} = require('react-intl');
+
+const TosFlowStep = require('./tos-flow-step.jsx');
+require('./tos-flow-step.scss');
+
+const InvalidParentEmailInfoStep = ({onComplete, user}) => {
+    const intl = useIntl();
+    const description = (
+        <div className="tos-step-description-container">
+            <div className="tos-step-description">
+                <FormattedMessage
+                    id="tos.invalidParentEmailInfoStepDescriptionPart1"
+                    values={{
+                        parentEmail: <b>{user.email}</b>
+                    }}
+                />
+            </div>
+            <div className="tos-step-description">
+                <FormattedMessage
+                    id="tos.invalidParentEmailInfoStepDescriptionPart2"
+                    values={{
+                        b: chunks => <b>{chunks}</b>
+                    }}
+                />
+            </div>
+            <div className="tos-step-description">
+                <FormattedMessage
+                    id="tos.invalidParentEmailInfoStepDescriptionPart3"
+                    values={{
+                        b: chunks => <b>{chunks}</b>
+                    }}
+                />
+            </div>
+            <div className="tos-step-description">
+                <FormattedMessage
+                    id="tos.invalidParentEmailInfoStepDescriptionPart4"
+                    values={{
+                        b: chunks => <b>{chunks}</b>
+                    }}
+                />
+            </div>
+        </div>
+    );
+
+    return (
+        <TosFlowStep
+            title={intl.formatMessage({id: 'tos.invalidParentEmailInfoStepTitle'})}
+            description={description}
+            nextButton={intl.formatMessage({id: 'general.okay'})}
+            onSubmit={onComplete}
+        />
+    );
+};
+
+InvalidParentEmailInfoStep.propTypes = {
+    user: PropTypes.shape({
+        email: PropTypes.string.isRequired
+    }),
+    onComplete: PropTypes.func.isRequired
+};
+
+module.exports = InvalidParentEmailInfoStep;

--- a/src/components/tos-flow/tos-flow-step.jsx
+++ b/src/components/tos-flow/tos-flow-step.jsx
@@ -28,7 +28,11 @@ const TosFlowStep = ({
                         title={title}
                     />}
                     {description && (
-                        <div className="tos-step-description">{description}</div>
+                        typeof description === 'string' ? (
+                            <div className="tos-step-description">{description}</div>
+                        ) : (
+                            description
+                        )
                     )}
                 </div>
                 {children}

--- a/src/components/tos-flow/tos-flow-step.scss
+++ b/src/components/tos-flow/tos-flow-step.scss
@@ -37,6 +37,12 @@
                 line-height: 2rem;
             }
             
+            .tos-step-description-container {
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+            }
+
             .tos-step-description {
                 color: colors.$type-gray;
                 font-size: 1rem;

--- a/src/components/tos-flow/tos-flow.jsx
+++ b/src/components/tos-flow/tos-flow.jsx
@@ -108,6 +108,11 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
             () => refreshSession()
         );
     }, [user, refreshSession]);
+    
+    const handleCompleteFlow = useCallback(() => {
+        refreshSession();
+        onComplete();
+    }, [onComplete, refreshSession]);
 
     const handleOfAgeConfirmation = useCallback(() => {
         setError(false);
@@ -118,11 +123,10 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
             'POST',
             {action: ACTION_TYPES.ACCEPT_TERMS_OF_SERVICE},
             () => {
-                refreshSession();
-                onComplete();
+                handleCompleteFlow();
             }
         );
-    }, [user, onComplete, refreshSession]);
+    }, [user, handleCompleteFlow]);
 
     const handleParentalConfirmation = useCallback(value => {
         // We fallback to the user's email if the user is underage
@@ -137,17 +141,11 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
                 if (body && body.email_confirmation_reset) {
                     setStep(STEPS.INVALID_PARENT_EMAIL_INFO_STEP);
                 } else {
-                    refreshSession();
-                    onComplete();
+                    handleCompleteFlow();
                 }
             }
         );
-    }, [user, onComplete, refreshSession]);
-
-    const handleInvalidParentEmailInfoClose = useCallback(() => {
-        refreshSession();
-        onComplete();
-    }, [onComplete, refreshSession]);
+    }, [user, handleCompleteFlow]);
 
     return (
         <Progression step={step}>
@@ -170,7 +168,7 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
             />
             <InvalidParentEmailInfoStep
                 user={user}
-                onComplete={handleInvalidParentEmailInfoClose}
+                onComplete={handleCompleteFlow}
             />
         </Progression>
     );

--- a/src/components/tos-flow/tos-flow.jsx
+++ b/src/components/tos-flow/tos-flow.jsx
@@ -7,13 +7,15 @@ const Progression = require('../progression/progression.jsx');
 const ProfileCompletionStep = require('./profile-completion-step.jsx');
 const OfAgeConfirmationStep = require('./of-age-confirmation-step.jsx');
 const ParentalConfirmationStep = require('./parental-confirmation-step.jsx');
+const InvalidParentEmailInfoStep = require('./invalid-parent-email-info-step.jsx');
 const sessionActions = require('../../redux/session.js');
 const api = require('../../lib/api.js');
 
 const STEPS = {
     PROFILE_COMPLETION_STEP: 0,
     OF_AGE_CONFIRMATION_STEP: 1,
-    PARENTAL_CONFIRMATION_STEP: 2
+    PARENTAL_CONFIRMATION_STEP: 2,
+    INVALID_PARENT_EMAIL_INFO_STEP: 3
 };
 
 const ACTION_TYPES = {
@@ -61,7 +63,14 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
     useEffect(() => {
         const currentStep = getCurrentTosStep(user);
 
-        setStep(prev => (currentStep === prev ? prev : currentStep));
+        setStep(prev => {
+            if (prev === STEPS.INVALID_PARENT_EMAIL_INFO_STEP) {
+                // If the user was an info step, we want to keep them there (e.g. on a session refresh)
+                return prev;
+            }
+
+            return currentStep === prev ? prev : currentStep;
+        });
     }, [user]);
 
     const handleSubmitStep = (uri, method, data, onSuccess) => {
@@ -84,7 +93,7 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
                     setError(true);
                     return;
                 }
-                onSuccess();
+                onSuccess(body);
             }
         );
     };
@@ -124,11 +133,21 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
             '/accounts/consent/',
             'POST',
             {action: ACTION_TYPES.ACCEPT_TERMS_OF_SERVICE_AND_RECORD_PARENT_EMAIL, parent_email: email},
-            () => {
-                refreshSession();
-                onComplete();
-            });
+            body => {
+                if (body && body.email_confirmation_reset) {
+                    setStep(STEPS.INVALID_PARENT_EMAIL_INFO_STEP);
+                } else {
+                    refreshSession();
+                    onComplete();
+                }
+            }
+        );
     }, [user, onComplete, refreshSession]);
+
+    const handleInvalidParentEmailInfoClose = useCallback(() => {
+        refreshSession();
+        onComplete();
+    }, [onComplete, refreshSession]);
 
     return (
         <Progression step={step}>
@@ -148,6 +167,10 @@ const TosFlow = ({user, onComplete, refreshSession}) => {
                 loading={loading}
                 error={error}
                 onSubmit={handleParentalConfirmation}
+            />
+            <InvalidParentEmailInfoStep
+                user={user}
+                onComplete={handleInvalidParentEmailInfoClose}
             />
         </Progression>
     );

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -593,5 +593,11 @@
     "tos.parentalConsentRequestSentButton": "Email Sent Successfully",
     "tos.parentalConsentRequiredPageRateLimitError": "You have exceeded the maximum number of emails for now. Please try again in {hours, plural, one {1 hour} other {{hours} hours}}.",
     "tos.parentalConsentRequiredPageValidationError": "Email doesn’t look right. Try another?",
-    "tos.parentalConsentRequiredPageError": "Sorry, we couldn't request permission from your parent. Please try again."
+    "tos.parentalConsentRequiredPageError": "Sorry, we couldn't request permission from your parent. Please try again.",
+
+    "tos.invalidParentEmailInfoStepTitle": "Invalid Parent Email",
+    "tos.invalidParentEmailInfoStepDescriptionPart1": "The parent email ({parentEmail}) associated with your account appears to be invalid.",
+    "tos.invalidParentEmailInfoStepDescriptionPart2": "This means your account is currently <b>unconfirmed</b>, and you won’t be able to use the social features on Scratch until your parent’s email is updated and they confirm your account.",
+    "tos.invalidParentEmailInfoStepDescriptionPart3": "You can update your parent’s email in your <b>Settings</b> under the <b>Email</b> tab.",
+    "tos.invalidParentEmailInfoStepDescriptionPart4": "Once your parent confirms the new email, your account will be confirmed, and social features will be available again."
 }


### PR DESCRIPTION
…e flow

### Resolves:

https://scratchfoundation.atlassian.net/browse/UEPR-525

### Changes:

When we detect an invalid email (which was considered valid during registration) during the ToS acceptance flow, allow users to continue with recording consent, but mark the email as unverified to force re-verification (which would probably mean changing their email). Add a new info step to the modal flow.

