### PR TITLE
Refactor renderHomepageRows to use conditional rendering

### DIFF
--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -211,19 +211,26 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
     renderHomepageRows () {
         const rows = [];
 
-        if (this.props.featuredGlobal.community_featured_projects && 
-            this.props.featuredGlobal.community_featured_projects.length > 0) {
-            rows.push(
-                <Box
-                    key="community_featured_projects"
-                    title={this.props.intl.formatMessage({
-                        id: 'splash.featuredProjects'
-                    })}
-                >
-                    <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
+        if (!this.props.featuredGlobal || 
+            !this.props.featuredGlobal.community_featured_projects || 
+            this.props.featuredGlobal.community_featured_projects.length === 0) {
+            return [
+                <Box key="error" title="Error">
+                    <div className="row-error-message">Whoops! There was a problem loading this section. Please try again later.</div>
                 </Box>
-            );
+            ];
         }
+
+        rows.push(
+            <Box
+                key="community_featured_projects"
+                title={this.props.intl.formatMessage({
+                    id: 'splash.featuredProjects'
+                })}
+            >
+                <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
+            </Box>
+        );
 
         if (this.props.featuredGlobal.community_featured_studios && 
             this.props.featuredGlobal.community_featured_studios.length > 0) {

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -209,31 +209,42 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
         ]);
     }
     renderHomepageRows () {
-        const rows = [
-            <Box
-                key="community_featured_projects"
-                title={this.props.intl.formatMessage({
-                    id: 'splash.featuredProjects'
-                })}
-            >
-                <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
-            </Box>,
-            <Box
-                key="community_featured_studios"
-                title={this.props.intl.formatMessage({
-                    id: 'splash.featuredStudios'
-                })}
-            >
-                <LegacyCarousel
-                    items={this.props.featuredGlobal.community_featured_studios}
-                    settings={{
-                        slidesToShow: 4,
-                        slidesToScroll: 4,
-                        lazyLoad: false
-                    }}
-                />
-            </Box>
-        ];
+        const rows = [];
+
+        if (this.props.featuredGlobal.community_featured_projects && 
+            this.props.featuredGlobal.community_featured_projects.length > 0) {
+            rows.push(
+                <Box
+                    key="community_featured_projects"
+                    title={this.props.intl.formatMessage({
+                        id: 'splash.featuredProjects'
+                    })}
+                >
+                    <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
+                </Box>
+            );
+        }
+
+        if (this.props.featuredGlobal.community_featured_studios && 
+            this.props.featuredGlobal.community_featured_studios.length > 0) {
+            rows.push(
+                <Box
+                    key="community_featured_studios"
+                    title={this.props.intl.formatMessage({
+                        id: 'splash.featuredStudios'
+                    })}
+                >
+                    <LegacyCarousel
+                        items={this.props.featuredGlobal.community_featured_studios}
+                        settings={{
+                            slidesToShow: 4,
+                            slidesToScroll: 4,
+                            lazyLoad: false
+                        }}
+                    />
+                </Box>
+            );
+        }
 
         if (this.props.featuredGlobal.curator_top_projects &&
             this.props.featuredGlobal.curator_top_projects.length > 4) {

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -211,7 +211,6 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
     renderHomepageRows () {
         const rows = [];
 
-        // Featured Projects Row - Only show if not empty
         if (this.props.featuredGlobal.community_featured_projects && 
             this.props.featuredGlobal.community_featured_projects.length > 0) {
             rows.push(
@@ -226,7 +225,6 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
             );
         }
 
-        // Featured Studios Row - Only show if not empty
         if (this.props.featuredGlobal.community_featured_studios && 
             this.props.featuredGlobal.community_featured_studios.length > 0) {
             rows.push(

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -211,27 +211,22 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
     renderHomepageRows () {
         const rows = [];
 
-        if (!this.props.featuredGlobal || 
-            !this.props.featuredGlobal.community_featured_projects || 
-            this.props.featuredGlobal.community_featured_projects.length === 0) {
-            return [
-                <Box key="error" title="Error">
-                    <div className="row-error-message">Whoops! There was a problem loading this section. Please try again later.</div>
+        // Featured Projects Row - Only show if not empty
+        if (this.props.featuredGlobal.community_featured_projects && 
+            this.props.featuredGlobal.community_featured_projects.length > 0) {
+            rows.push(
+                <Box
+                    key="community_featured_projects"
+                    title={this.props.intl.formatMessage({
+                        id: 'splash.featuredProjects'
+                    })}
+                >
+                    <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
                 </Box>
-            ];
+            );
         }
 
-        rows.push(
-            <Box
-                key="community_featured_projects"
-                title={this.props.intl.formatMessage({
-                    id: 'splash.featuredProjects'
-                })}
-            >
-                <LegacyCarousel items={this.props.featuredGlobal.community_featured_projects} />
-            </Box>
-        );
-
+        // Featured Studios Row - Only show if not empty
         if (this.props.featuredGlobal.community_featured_studios && 
             this.props.featuredGlobal.community_featured_studios.length > 0) {
             rows.push(


### PR DESCRIPTION
### Resolves:

They always go down and look ugly on the homepage.

### Changes:

It changes the featured studios & projects row to be on a condition if there's no projects in it, don't show it.
### Test Coverage:

<img width="1360" height="767" alt="Screenshot 2026-03-08 11 15 04 AM" src="https://github.com/user-attachments/assets/cd9b7451-0b96-4be5-95c5-acf246aa52b9" />
