### PR TITLE
build: add more version info to build output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "formik": "2.4.9",
         "formsy-react": "1.1.6",
         "formsy-react-components": "1.1.0",
-        "git-bundle-sha": "0.0.2",
         "glob": "5.0.15",
         "google-libphonenumber": "3.2.44",
         "html-webpack-plugin": "5.6.0",
@@ -7446,13 +7445,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/bn.js": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
@@ -12696,16 +12688,6 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/git-bundle-sha": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/git-bundle-sha/-/git-bundle-sha-0.0.2.tgz",
-      "integrity": "sha512-3KpoWmE1lyE58CtIoxw+t0mor5bJO5o80ptGQbFSFDi7nL7NP50SBQj3LH6eI6TDT7pMkB7wA5xGvmevA8BB0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^2.3.0"
       }
     },
     "node_modules/gl-axes3d": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "formik": "2.4.9",
     "formsy-react": "1.1.6",
     "formsy-react-components": "1.1.0",
-    "git-bundle-sha": "0.0.2",
     "glob": "5.0.15",
     "google-libphonenumber": "3.2.44",
     "html-webpack-plugin": "5.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
+const {exec} = require('node:child_process');
+const path = require('node:path');
 const defaults = require('lodash.defaults');
-const gitsha = require('git-bundle-sha');
-const path = require('path');
 const webpack = require('webpack');
 
 // Plugins
@@ -27,23 +27,51 @@ routes = routes.filter(route => !process.env.VIEW || process.env.VIEW === route.
 const pageRoutes = routes.filter(route => !route.redirect);
 
 /**
- * Retrieve a version ID string for the current build, to be emitted into `version.txt`.
- * @returns {Promise<string>} A promise that resolves to a version ID string.
+ * Load the package.json for an installed npm package.
+ * Uses {@link require.resolve} to locate the package via Node's module resolution algorithm,
+ * which handles hoisting and workspaces. The resolved value is a file path, so the subsequent
+ * {@link require} call is a direct file access that bypasses the package's `exports` restriction
+ * on `./package.json`.
+ * @param {string} packageName The package name to look up.
+ * @returns {object} The parsed package.json contents.
  */
-const getVersionId = () => {
-    if (process.env.WWW_VERSION) {
-        return Promise.resolve(process.env.WWW_VERSION);
-    }
-    return new Promise((resolve, reject) => {
-        gitsha({length: 5}, (err, sha) => {
+const requirePackageJson = packageName => {
+    let dir = path.dirname(require.resolve(packageName));
+    do {
+        try {
+            const pkg = require(path.join(dir, 'package.json')); // eslint-disable-line global-require
+            if (pkg.name === packageName) return pkg;
+        } catch { /* no package.json here, keep walking up */ }
+        dir = path.dirname(dir);
+    } while (dir !== path.dirname(dir));
+    throw new Error(`Could not find package.json for ${packageName}`);
+};
+
+const guiVersion = requirePackageJson('@scratch/scratch-gui').version;
+
+// Resolved once at module load time so both version files share the same git call.
+// git rev-parse's abbreviated hash uses a dynamic unique-prefix algorithm, matching GitHub's web UI.
+const gitHashesPromise = process.env.WWW_VERSION ?
+    Promise.resolve({fullHash: process.env.WWW_VERSION, shortHash: process.env.WWW_VERSION}) :
+    new Promise((resolve, reject) => {
+        exec('git log -1 --format="%H %h"', (err, stdout) => {
             if (err) {
                 reject(err);
             } else {
-                resolve(sha);
+                const [fullHash, shortHash] = stdout.trim().split(' ');
+                resolve({fullHash, shortHash});
             }
         });
     });
-};
+
+/** @returns {Promise<string>} Abbreviated git hash for display in version.txt. */
+const makeVersionTxt = () => gitHashesPromise.then(({shortHash}) => shortHash);
+
+/** @returns {Promise<string>} JSON string with full git hash and package versions for version.json. */
+const makeVersionJson = () => gitHashesPromise.then(({fullHash}) => JSON.stringify({
+    'scratch-www': fullHash,
+    'scratch-gui': guiVersion
+}, null, 4));
 
 // Prepare all entry points
 const entry = {};
@@ -232,7 +260,11 @@ module.exports = {
         new HtmlWebpackBackwardsCompatibilityPlugin(),
         new EmitFilePlugin({
             filename: 'version.txt',
-            content: getVersionId
+            content: makeVersionTxt
+        }),
+        new EmitFilePlugin({
+            filename: 'version.json',
+            content: makeVersionJson
         }),
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer']


### PR DESCRIPTION
### Changes:

Add editor (`scratch-gui`) version info to the build output in a new `version.json` file. Also, for human viewers' convenience, adjust the SHA in `version.txt` to match what GitHub's UI displays.
