### PR TITLE
fix: Fix Community Guidelines off-screen navigation bug

### DIFF
--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -46,7 +46,9 @@
         flex-direction: column;
         justify-content: center;
         gap: 4.5rem;
-        margin: 6rem 15% 0 0;
+        margin: 6rem 0 0 0;
+        padding: 0 15%;
+        box-sizing: border-box;
         padding-bottom: 6rem;
 
         border-bottom: 1px solid colors.$active-gray;

--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -48,7 +48,7 @@
         gap: 4.5rem;
         margin: 6rem 15% 0 15%;
         padding-bottom: 6rem;
-        max-width: 70%
+        max-width: 70%;
 
         border-bottom: 1px solid colors.$active-gray;
         

--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -46,9 +46,8 @@
         flex-direction: column;
         justify-content: center;
         gap: 4.5rem;
-        margin: 6rem 15% 0 15%;
+        margin: 6rem 15% 0 0;
         padding-bottom: 6rem;
-        max-width: 70%;
 
         border-bottom: 1px solid colors.$active-gray;
         

--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -48,7 +48,7 @@
         gap: 4.5rem;
         margin: 6rem 15% 0 15%;
         padding-bottom: 6rem;
-        margin-inline: auto;
+        max-width: 70%
 
         border-bottom: 1px solid colors.$active-gray;
         

--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -48,6 +48,7 @@
         gap: 4.5rem;
         margin: 6rem 15% 0 15%;
         padding-bottom: 6rem;
+        margin-inline: auto;
 
         border-bottom: 1px solid colors.$active-gray;
         


### PR DESCRIPTION
### Resolves:

The community guidelines page has been broken for months

### Changes:

Adds margin-inline (auto value) CSS property to hoepfully fix it

### Test Coverage:

Without margin-inline: auto;
<img width="1303" height="602" alt="Screenshot 2026-04-12 11 02 00 AM" src="https://github.com/user-attachments/assets/631bbfb4-9170-441e-82e0-7ca9d8131676" />

With margin-inline: auto;
<img width="1361" height="522" alt="Screenshot 2026-04-12 11 02 43 AM" src="https://github.com/user-attachments/assets/6199ca82-bd74-49cb-b904-646d262b26be" />
