### PR TITLE
[UEPR-572] Track thumbnail updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.4",
+        "@scratch/scratch-gui": "13.6.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -143,9 +143,9 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.9.tgz",
-      "integrity": "sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
         {
@@ -2285,9 +2285,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
         {
@@ -2302,7 +2302,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
         {
@@ -4480,18 +4480,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.4.tgz",
-      "integrity": "sha512-4LbTMxfXgr8t30FIiSmBIP9ivg0VKmNsuP5gDrBALdjTPROuhcXKucAk+c0IlF/A6PCSzvlWY7nO7WvTPBSbVw==",
+      "version": "13.6.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.5.tgz",
+      "integrity": "sha512-VTgT3/vXaKfe+9dYuQqIE74HbgPfI37NHuXBpBMztUsupOSPaWYxHhF6MnvvQVXOld0se/l60fR0hO+NR3K0TA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.4",
-        "@scratch/scratch-svg-renderer": "13.6.4",
-        "@scratch/scratch-vm": "13.6.4",
+        "@scratch/scratch-render": "13.6.5",
+        "@scratch/scratch-svg-renderer": "13.6.5",
+        "@scratch/scratch-vm": "13.6.5",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -4519,7 +4519,7 @@
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",
         "lodash.defaultsdeep": "4.6.1",
-        "lodash.omit": "4.5.0",
+        "lodash.omit": "4.18.0",
         "lodash.throttle": "4.1.1",
         "omggif": "1.0.10",
         "papaparse": "5.5.3",
@@ -4534,7 +4534,7 @@
         "react-intl": "6.8.9",
         "react-modal": "3.16.3",
         "react-popover": "0.5.10",
-        "react-redux": "8.1.3",
+        "react-redux": "^8.0.0",
         "react-responsive": "9.0.2",
         "react-style-proptype": "3.2.2",
         "react-tabs": "5.2.0",
@@ -4629,10 +4629,9 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4714,13 +4713,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.4.tgz",
-      "integrity": "sha512-5NGd9cqDHKueRhs7793NPOGH8IbknWeyUW7ih4XKk0ZC7iufJDChUa6lqv9ND0NV2zgoIVcECOxqkP0OPLFYrA==",
+      "version": "13.6.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.5.tgz",
+      "integrity": "sha512-OilOmyuQLPC1bWaaIt3tft5DryIu7q8e/7j6hmF14ROVGelagmmliXjHPiOm9O1Sa8eTXaBqbdFZ/ltrh8y1Ow==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.4",
+        "@scratch/scratch-svg-renderer": "13.6.5",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -4740,15 +4739,15 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.4.tgz",
-      "integrity": "sha512-4MyeDyHGZiaUBuOzNR6/Hlde1pmCuQ26gYwGpYsu9JSiJ8grc9ijRVXLOj/6PwLpdfDeG6hoZjZrrNQPYdAbOQ==",
+      "version": "13.6.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.5.tgz",
+      "integrity": "sha512-wYJD7j9tA2LwzYdP6Hqeh5IXKWOsWobomyXRlcQbV9tNSU4pA1gynmRdI4rTPRA5JBbIRqBls1wT+aYl5qVO3A==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "base64-js": "1.5.1",
         "base64-loader": "1.0.0",
-        "css-tree": "1.1.3",
+        "css-tree": "3.2.1",
         "fastestsmallesttextencoderdecoder": "1.0.22",
         "isomorphic-dompurify": "2.36.0",
         "transformation-matrix": "1.15.3",
@@ -4758,15 +4757,36 @@
         "scratch-render-fonts": "^1.0.0"
       }
     },
+    "node_modules/@scratch/scratch-svg-renderer/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-svg-renderer/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.4.tgz",
-      "integrity": "sha512-IlUwp+ilF+V9rNHJj1DJSAdMCFLQPu1LzaClDHedEpaWiWzowQ8vNfZFSiD5nLeuk610mcfIDsKyK8bUBjv9aA==",
+      "version": "13.6.5",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.5.tgz",
+      "integrity": "sha512-1eBKsKJxbSBquq3QBZfAT5+OIthS59uv1XxFArTIEfUGWbCxfVj3YpSv4UrZjWUD+88xSLUs4xHw0WnANflYWw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.4",
-        "@scratch/scratch-svg-renderer": "13.6.4",
+        "@scratch/scratch-render": "13.6.5",
+        "@scratch/scratch-svg-renderer": "13.6.5",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -9290,9 +9310,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10250,9 +10270,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.2",
+        "@scratch/scratch-gui": "14.0.0-accessibility-improvements.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -143,9 +143,9 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.6.tgz",
-      "integrity": "sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.8.tgz",
+      "integrity": "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4480,18 +4480,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.2.tgz",
-      "integrity": "sha512-M1Ae4V1bhrSFoV58UcyH1rbwt5vgtzK7jObSo9BsJMNJiBvFdb49LoSRNywhR/3pGj84yqlWdxAc/9UJfODMHw==",
+      "version": "14.0.0-accessibility-improvements.1",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-14.0.0-accessibility-improvements.1.tgz",
+      "integrity": "sha512-X/Nf2pnawxWr1Tqkon+VDGzkEHUwi1yZNIvRtOggwV3z2KifjyiGRL+RGltFRoHXdG1NWiFkAB7EgL1pOwxPrA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.2",
-        "@scratch/scratch-svg-renderer": "13.6.2",
-        "@scratch/scratch-vm": "13.6.2",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.1",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.1",
+        "@scratch/scratch-vm": "14.0.0-accessibility-improvements.1",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -4519,7 +4519,7 @@
         "lodash.bindall": "4.4.0",
         "lodash.debounce": "4.0.8",
         "lodash.defaultsdeep": "4.6.1",
-        "lodash.omit": "4.18.0",
+        "lodash.omit": "4.5.0",
         "lodash.throttle": "4.1.1",
         "omggif": "1.0.10",
         "papaparse": "5.5.3",
@@ -4534,7 +4534,7 @@
         "react-intl": "6.8.9",
         "react-modal": "3.16.3",
         "react-popover": "0.5.10",
-        "react-redux": "^8.0.0",
+        "react-redux": "8.1.3",
         "react-responsive": "9.0.2",
         "react-style-proptype": "3.2.2",
         "react-tabs": "5.2.0",
@@ -4543,8 +4543,8 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.9",
-        "scratch-l10n": "6.1.66",
+        "scratch-blocks": "2.1.8",
+        "scratch-l10n": "6.1.64",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.0",
@@ -4629,9 +4629,10 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/lodash.omit": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
-      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
       "dev": true,
       "license": "MIT"
     },
@@ -4692,9 +4693,9 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.66",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.66.tgz",
-      "integrity": "sha512-1a6UrYkUI9IZMY17YGfQY5p6nqLC7SQKmWVAMwHfs+57my9essZUr9QEQXSax4+OrZ2zO5VzKLqSlKv6wzM1tQ==",
+      "version": "6.1.64",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.64.tgz",
+      "integrity": "sha512-FzkzU3RbLQHSUdWeB4TQqY6YMvboJN8u245GZmry/uwipK46RsX2RW5HDUcWmKfww7htPhpX1DEdK/gK0U7m/g==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -4713,13 +4714,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.2.tgz",
-      "integrity": "sha512-RdszVBZP41ivDbv+I4W5wNLpbxckyBQYycZ4BXG2y/02HB/YPFEEeAid2HwgGRyXHnwcOAydduI0x4DaPdXl5w==",
+      "version": "14.0.0-accessibility-improvements.1",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-14.0.0-accessibility-improvements.1.tgz",
+      "integrity": "sha512-dLlUdDTSc/O175H65JAiAWagLrb2vkK2y9qGBRemIByn9/I7mocxeaUPxRpDR4tbleQV46IjpsQYLudYZdKIQQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.2",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.1",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -4739,15 +4740,15 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.2.tgz",
-      "integrity": "sha512-k41MOVH1hsmyWYrPlUjgFqziWOhhFIB3KZI7L3IRFNNUGLl+laC/Ib9mXjQHjE3Eof6E0KWYa6fxzhXa647L1w==",
+      "version": "14.0.0-accessibility-improvements.1",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-14.0.0-accessibility-improvements.1.tgz",
+      "integrity": "sha512-XCrRxhqoU2oFaqJ3h8mrYlRCVV9T4QvFNeRXnQstlsgIf8OzLA/86DMHyZjTmH4v6nX98suOz7w7R4luTH0jNw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "base64-js": "1.5.1",
         "base64-loader": "1.0.0",
-        "css-tree": "3.2.1",
+        "css-tree": "1.1.3",
         "fastestsmallesttextencoderdecoder": "1.0.22",
         "isomorphic-dompurify": "2.36.0",
         "transformation-matrix": "1.15.3",
@@ -4757,36 +4758,15 @@
         "scratch-render-fonts": "^1.0.0"
       }
     },
-    "node_modules/@scratch/scratch-svg-renderer/node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@scratch/scratch-svg-renderer/node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.2.tgz",
-      "integrity": "sha512-NPjd1Rn2G8i4H1HANvnBUgBl+gQioyplkZIuDO+oRqUX2JSmELiWw+MFWYXaK6E8nuiQblQ/9S0dMnHLhAA3mA==",
+      "version": "14.0.0-accessibility-improvements.1",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-14.0.0-accessibility-improvements.1.tgz",
+      "integrity": "sha512-e0C9AtxIV2eqrk12Oa93pf5urhEQI6Jwq8ZJKZ4494YpnrwsTKWhdgjxSwR4kNU2NebbDhEmSI4JhGZnkaMxnQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.2",
-        "@scratch/scratch-svg-renderer": "13.6.2",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.1",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.1",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -9310,9 +9290,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -22673,9 +22653,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.9.tgz",
-      "integrity": "sha512-6FapPzDGQCDc549sT82Kv8YaVP6qz13dplVpSKZkLEtJWN9PVmDbTEk1vnAnL7iLeNmhLA8GRpcmWvzzZZVFfw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.8.tgz",
+      "integrity": "sha512-Ox3AxPQmM94RfNLO+3IWIWM9ShMZg9g4wboFSORgzVY3XUQwKnzmpxgO/Gdl0M1ENFSEFR++1inFTgF/GNch0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.2",
+    "@scratch/scratch-gui": "14.0.0-accessibility-improvements.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.4",
+    "@scratch/scratch-gui": "13.6.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -933,7 +933,6 @@ class Preview extends React.Component {
             this.updateLocalThumbnailFromBlob(blob);
             if (onSuccess) onSuccess(response);
         };
-        console.log('In handleUpdateProjectThumbnail', id, this.props.user.id?.toString());
         triggerAnalyticsEvent({
             event: 'set-thumbnail',
             // This is a user property - ideally it would be set once on page load,

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -193,6 +193,8 @@ class Preview extends React.Component {
             'handleUpdateProjectId',
             'handleUpdateProjectTitle',
             'handleToggleComments',
+            'handleSetManualThumbnail',
+            'handleSetManualThumbnailButtonClick',
             'showShareModal',
             'hideShareModal',
             'initCounts',
@@ -931,6 +933,7 @@ class Preview extends React.Component {
             this.updateLocalThumbnailFromBlob(blob);
             if (onSuccess) onSuccess(response);
         };
+        console.log('In handleUpdateProjectThumbnail', id, this.props.user.id?.toString());
         triggerAnalyticsEvent({
             event: 'set-thumbnail',
             // This is a user property - ideally it would be set once on page load,
@@ -945,6 +948,20 @@ class Preview extends React.Component {
             updateLocalThumbnailOnSuccess,
             onError
         );
+    }
+    handleSetManualThumbnail (projectId) {
+        triggerAnalyticsEvent({
+            event: 'set-manual-thumbnail-editor',
+            user_id: this.props.user.id?.toString(),
+            project_id: projectId
+        });
+    }
+    handleSetManualThumbnailButtonClick (projectId) {
+        triggerAnalyticsEvent({
+            event: 'set-manual-thumbnail-editor-button-click',
+            user_id: this.props.user.id?.toString(),
+            project_id: projectId
+        });
     }
     showShareModal () {
         this.setState({
@@ -1214,6 +1231,8 @@ class Preview extends React.Component {
                                     feedback={this.props.feedback}
                                     onUpdateProjectThumbnail={this.handleUpdateProjectThumbnail}
                                     manuallySaveThumbnails={process.env.MANUALLY_SAVE_THUMBNAILS === 'true'}
+                                    onSetManualThumbnail={this.handleSetManualThumbnail}
+                                    onSetManualThumbnailButtonClick={this.handleSetManualThumbnailButtonClick}
                                 />
                             </>
                         )}

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -932,7 +932,7 @@ class Preview extends React.Component {
             if (onSuccess) onSuccess(response);
         };
         triggerAnalyticsEvent({
-            event: 'set-thumbnail-in-editor-button-click',
+            event: 'set-thumbnail',
             // This is a user property - ideally it would be set once on page load,
             // but since this is the only event that uses it, we can set it here
             // for simplicity for now.


### PR DESCRIPTION
### Resolves:

[UEPR-572](https://scratchfoundation.atlassian.net/browse/UEPR-572) - Fixes an issue where we used to track all thumbnail updates, including on project creation

### Changes:

- Brings back old analytic event, which includes both manual and automatic thumbnail updates 
- Adds two new analytic events `set-manual-thumbnail-editor-button-click` and `set-manual-thumbnail-editor` to be triggered when the Manually set thumbnail button is clicked (before confirming), and when the thumbnail is manually set


[UEPR-572]: https://scratchfoundation.atlassian.net/browse/UEPR-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ