### PR TITLE
feat: Show Membership in navigation bar when logged out & in if the user didn't buy membership

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -123,17 +123,15 @@ class Navigation extends React.Component {
                             <FormattedMessage id="general.ideas" />
                         </a>
                     </li>
-                    {
-                        this.props.isLoggedIn === false &&
-                            (
-                                <li className="link membership">
-                                    <a
-                                        href="/membership"
-                                    >
-                                        <FormattedMessage id="general.membership" />
-                                    </a>
-                                </li>
-                            )
+                    { 
+                (this.props.user && this.props.user.membership_status == null) && (
+    
+                <li className="link membership">
+                  <a href="/membership">
+            <FormattedMessage id="general.membership" />
+        </a>
+                   </li>
+)
                     }
 
                     <li className="search">
@@ -275,7 +273,8 @@ Navigation.propTypes = {
         classroomId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         thumbnailUrl: PropTypes.string,
         username: PropTypes.string,
-        membership_avatar_badge: PropTypes.number
+        membership_avatar_badge: PropTypes.number,
+        membership_status: PropTypes.string
     })
 };
 


### PR DESCRIPTION
### Changes:

[This](https://github.com/scratchfoundation/scratch-www/issues/9910#issuecomment-3569570972) comment by @KManolov3 who said that "... because there is already a news item related to Membership that logged in users see on their home page." in November 2025. Now that

<img width="408" height="396" alt="Screenshot 2026-04-15 6 17 33 PM" src="https://github.com/user-attachments/assets/2e215af3-5e90-4bbd-bae8-4ca499a90203" />

It's gone, why don't we add it to the header for everyone BUT members? If members has it, they don't need it. This change adds a prop type where it detects if there "membership_status" in the /session cookie and if it's "null", show it but if its any other value, don't show it.
