### PR TITLE
chore: update scratch-gui version to v13.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.7",
+        "@scratch/scratch-gui": "13.6.8",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -143,14 +143,15 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
-      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0"
       },
@@ -202,6 +203,16 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
@@ -5157,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.7",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.7.tgz",
-      "integrity": "sha512-UZkrCXZI41u+qWrfjro97qSqUU9UjTh6AF6G6kn4O2tuase3WW/uoLnkBKGYIwrIoUjP/X1ORGp7gYeNAokjpg==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.8.tgz",
+      "integrity": "sha512-w/2tVkuNfLEngAWGsJ2C9mRBK6fB3MZ5z1lR9lje2EZtiTsIs7N7sW+yEUUlman0s+ott0nYGwFcGGBcZ08Mvw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.7",
-        "@scratch/scratch-svg-renderer": "13.6.7",
-        "@scratch/scratch-vm": "13.6.7",
+        "@scratch/scratch-render": "13.6.8",
+        "@scratch/scratch-svg-renderer": "13.6.8",
+        "@scratch/scratch-vm": "13.6.8",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5390,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.7",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.7.tgz",
-      "integrity": "sha512-LBFDwh4SrAOOy9Wk5TTebliYFJmodsLnkBYL0qL03SjhEAJ2lqA818ODWUxZ6J2LJ6PMauH5mJ8FkaDfKuEWPw==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.8.tgz",
+      "integrity": "sha512-Z2xG3yYUp6+Tvu29oepBMi3OpgQ5oMvUx1ENExnF1YYLa9pswdfXIcg1uMAzx8PbjWjVTucz6HCcFzcuUBkeyQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.7",
+        "@scratch/scratch-svg-renderer": "13.6.8",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5416,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.7",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.7.tgz",
-      "integrity": "sha512-c9vkUH1JpZGOlpfVHxEhCPfPC4EHugGNxnGV+evp43O/Gh1QcnaVhkG61T8jB3Mgeu8SQ3+E4kt85HWEB5caQA==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.8.tgz",
+      "integrity": "sha512-1qfzqk7bOGKaextPN/h0scu/dY5x35xMIp4VExA0LNk7kqP7b15trtpykMKRcHJX6GAFi+szREgiWdGvRnvSng==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5456,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.7",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.7.tgz",
-      "integrity": "sha512-g2ArqkB6Sdj/B3qYegHzGefvEnObdUNMnN4OrFO3u1v4/yINqfz0ycvQS3yvdm1Q5KhB9Irbbk6pffs5HY69uQ==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.8.tgz",
+      "integrity": "sha512-Y6uBLsaG0FwEqcKsZdEy3YQRgCRh/Q4f1rTV9EBcbObWgVz53L1SpmW/eGHOVgK/D59Lftah/FY8iCEuYhMdFA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.7",
-        "@scratch/scratch-svg-renderer": "13.6.7",
+        "@scratch/scratch-render": "13.6.8",
+        "@scratch/scratch-svg-renderer": "13.6.8",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.7",
+    "@scratch/scratch-gui": "13.6.8",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Proposed Changes

- Update scratch-gui version to v13.6.8 - includes https://github.com/scratchfoundation/scratch-editor/pull/531