### PR TITLE
fix(deps): update scratch-gui to v13.6.9 for scratch-blocks fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.8",
+        "@scratch/scratch-gui": "13.6.9",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5168,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.8",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.8.tgz",
-      "integrity": "sha512-w/2tVkuNfLEngAWGsJ2C9mRBK6fB3MZ5z1lR9lje2EZtiTsIs7N7sW+yEUUlman0s+ott0nYGwFcGGBcZ08Mvw==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.9.tgz",
+      "integrity": "sha512-ht0jf3mcAhjGLPycOix1QCz0lEBPKJXJXxA2N3qXkm3j0geOMF2mRUVK7/EU1d/eciVPxBkKATKEivM1EHORlQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.8",
-        "@scratch/scratch-svg-renderer": "13.6.8",
-        "@scratch/scratch-vm": "13.6.8",
+        "@scratch/scratch-render": "13.6.9",
+        "@scratch/scratch-svg-renderer": "13.6.9",
+        "@scratch/scratch-vm": "13.6.9",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5231,8 +5231,8 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.11",
-        "scratch-l10n": "6.1.68",
+        "scratch-blocks": "2.1.13",
+        "scratch-l10n": "6.1.69",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
@@ -5380,9 +5380,9 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.68",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.68.tgz",
-      "integrity": "sha512-mHYV66ARrMvswoNmKnEnhNG5QUPzzXvHLvuwZR4FcbEC8EKY9kg3cNnZjYNGjxiBqJGUYD+DJLSL2m9vSr50gg==",
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.69.tgz",
+      "integrity": "sha512-d5i+EH/k0erfnW1ADfv537a7WLP57C3PcTjQtFCW9nxO1e0zl1BFmikWMATVy7z4j/h/6fZj6DnRC0wSaEL07Q==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5401,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.8",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.8.tgz",
-      "integrity": "sha512-Z2xG3yYUp6+Tvu29oepBMi3OpgQ5oMvUx1ENExnF1YYLa9pswdfXIcg1uMAzx8PbjWjVTucz6HCcFzcuUBkeyQ==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.9.tgz",
+      "integrity": "sha512-zb5etlqKd84QwhPe/693io3YQfPVIr7H7a4MqiQfZ5yR8WX76pw6xN1YeXkFP6rarA20wAcLZmvwB6fxmNYBOQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.8",
+        "@scratch/scratch-svg-renderer": "13.6.9",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5427,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.8",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.8.tgz",
-      "integrity": "sha512-1qfzqk7bOGKaextPN/h0scu/dY5x35xMIp4VExA0LNk7kqP7b15trtpykMKRcHJX6GAFi+szREgiWdGvRnvSng==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.9.tgz",
+      "integrity": "sha512-yxg5XVegbPR4HVLzVg2wOY6MPqV4N2r7m4/S0hrBzabvLFCUG991OiHmEY0/i2hrjZmJEFNAkN0Y2lTjhHzgew==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5467,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.8",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.8.tgz",
-      "integrity": "sha512-Y6uBLsaG0FwEqcKsZdEy3YQRgCRh/Q4f1rTV9EBcbObWgVz53L1SpmW/eGHOVgK/D59Lftah/FY8iCEuYhMdFA==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.9.tgz",
+      "integrity": "sha512-0YYpVdiqOwYVtaO8GiONxy2to8fHyTZdfrveS89EE5+nH/ZbnoyBGWCRRyWQrq3ts7+Q/yMWAMSHCq5l+b+Phg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.8",
-        "@scratch/scratch-svg-renderer": "13.6.8",
+        "@scratch/scratch-render": "13.6.9",
+        "@scratch/scratch-svg-renderer": "13.6.9",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -23361,9 +23361,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.11.tgz",
-      "integrity": "sha512-zgfC5q1DXVEPsYzQ/U4Rs0xwVNfGdgnlS7i+9GEyU5DIOKHTx06yPwYuYzI+om82J0paUtd+YlAt3ygoozHEpA==",
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.13.tgz",
+      "integrity": "sha512-T7g84D6xNksW0UXu6fiMs/NFPVlQuvZgrO3XNj3JrNRbCQ4gzMKlrNdQRDX0+LWmaF7WrF8t74FHyZ6PetW5FA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.8",
+    "@scratch/scratch-gui": "13.6.9",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
### Resolves:

- Resolves scratchfoundation/scratch-editor#532
- Resolves https://scratch.mit.edu/discuss/topic/878311/
- May resolve several other issues (See https://github.com/scratchfoundation/scratch-editor/issues/533 )

### Changes:

Update to scratchfoundation/scratch-gui@13.6.9, which updates to scratchfoundation/scratch-blocks@2.1.13

