### PR TITLE
fix(deps): update scratch-gui to v13.6.10 for scratch-blocks fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.9",
+        "@scratch/scratch-gui": "13.6.10",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5168,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.9.tgz",
-      "integrity": "sha512-ht0jf3mcAhjGLPycOix1QCz0lEBPKJXJXxA2N3qXkm3j0geOMF2mRUVK7/EU1d/eciVPxBkKATKEivM1EHORlQ==",
+      "version": "13.6.10",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.10.tgz",
+      "integrity": "sha512-5SrWwCyGojjdToUQLmMsZaCmWPUVLVJoyq5dquzb+VfZYBIdSa11u6yeMzup3ZHN5lX8l3TCtzznpBhALhkVrg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.9",
-        "@scratch/scratch-svg-renderer": "13.6.9",
-        "@scratch/scratch-vm": "13.6.9",
+        "@scratch/scratch-render": "13.6.10",
+        "@scratch/scratch-svg-renderer": "13.6.10",
+        "@scratch/scratch-vm": "13.6.10",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5231,7 +5231,7 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.13",
+        "scratch-blocks": "2.1.14",
         "scratch-l10n": "6.1.69",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
@@ -5401,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.9.tgz",
-      "integrity": "sha512-zb5etlqKd84QwhPe/693io3YQfPVIr7H7a4MqiQfZ5yR8WX76pw6xN1YeXkFP6rarA20wAcLZmvwB6fxmNYBOQ==",
+      "version": "13.6.10",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.10.tgz",
+      "integrity": "sha512-H0WyEqkajAmB2/pKUQO41oqTvYuQIsL+uvqposvPncXnDKkA7xppGz6MN+h1dkBEfhEJ5eAa5VWRDuLZ4DyAdw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.9",
+        "@scratch/scratch-svg-renderer": "13.6.10",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5427,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.9.tgz",
-      "integrity": "sha512-yxg5XVegbPR4HVLzVg2wOY6MPqV4N2r7m4/S0hrBzabvLFCUG991OiHmEY0/i2hrjZmJEFNAkN0Y2lTjhHzgew==",
+      "version": "13.6.10",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.10.tgz",
+      "integrity": "sha512-NL2QoQgVx3ZVmpjVR7lgSfAKejACiAlPqRBw2LQIAHw5hBobpJnedTIg2W0ThbluYXq1zgPOBQrs1ZVXdg43FA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5467,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.9.tgz",
-      "integrity": "sha512-0YYpVdiqOwYVtaO8GiONxy2to8fHyTZdfrveS89EE5+nH/ZbnoyBGWCRRyWQrq3ts7+Q/yMWAMSHCq5l+b+Phg==",
+      "version": "13.6.10",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.10.tgz",
+      "integrity": "sha512-oKzVRUTlT8Tya+sSFlGvf+megi6dfEkD/udPgNJkrfdIEPFt4THoMhMm3uXeSaHUjggllKxn5pkaRBgwaiz+0w==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.9",
-        "@scratch/scratch-svg-renderer": "13.6.9",
+        "@scratch/scratch-render": "13.6.10",
+        "@scratch/scratch-svg-renderer": "13.6.10",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -23361,9 +23361,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.13.tgz",
-      "integrity": "sha512-T7g84D6xNksW0UXu6fiMs/NFPVlQuvZgrO3XNj3JrNRbCQ4gzMKlrNdQRDX0+LWmaF7WrF8t74FHyZ6PetW5FA==",
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.14.tgz",
+      "integrity": "sha512-J2bO8Ax6Dk2sDiC/TsEY9YNFuffxwPhYtv04arpCQwD+dn0CPJ5cqiE/C8Isu1zgyjI53vxdIviMEMJIje4WyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.9",
+    "@scratch/scratch-gui": "13.6.10",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
### Resolves:

- Resolves https://github.com/scratchfoundation/scratch-editor/issues/532 again, hopefully for real this time

### Changes:

Update to scratchfoundation/scratch-gui@13.6.10, which updates to scratchfoundation/scratch-blocks@2.1.14
See https://github.com/scratchfoundation/scratch-blocks/compare/v2.1.13...v2.1.14

### Test Coverage:

See scratchfoundation/scratch-blocks#3551