### PR TITLE
fix(deps): update to scratch-gui@13.6.12 / scratch-blocks@2.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.6.10",
+        "@scratch/scratch-gui": "13.6.12",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5168,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.6.10",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.10.tgz",
-      "integrity": "sha512-5SrWwCyGojjdToUQLmMsZaCmWPUVLVJoyq5dquzb+VfZYBIdSa11u6yeMzup3ZHN5lX8l3TCtzznpBhALhkVrg==",
+      "version": "13.6.12",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.6.12.tgz",
+      "integrity": "sha512-uta/b2UMIPd39OveI3ZNfxCUO/+ZJFyMBt+kRcO9wufniQCPqbmGDUmJFmgCsaJGnoWVQoxDwxOJYbnZO8Tr+w==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.6.10",
-        "@scratch/scratch-svg-renderer": "13.6.10",
-        "@scratch/scratch-vm": "13.6.10",
+        "@scratch/scratch-render": "13.6.12",
+        "@scratch/scratch-svg-renderer": "13.6.12",
+        "@scratch/scratch-vm": "13.6.12",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5231,8 +5231,8 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.14",
-        "scratch-l10n": "6.1.69",
+        "scratch-blocks": "2.1.17",
+        "scratch-l10n": "6.1.70",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
@@ -5380,9 +5380,9 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.69",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.69.tgz",
-      "integrity": "sha512-d5i+EH/k0erfnW1ADfv537a7WLP57C3PcTjQtFCW9nxO1e0zl1BFmikWMATVy7z4j/h/6fZj6DnRC0wSaEL07Q==",
+      "version": "6.1.70",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.70.tgz",
+      "integrity": "sha512-3lO5C7XrnSHKP3cjqwFIjYmvufSQAnz0yr5gVwD+ZqaXXiceoFHhyZIT5TNruO3QHiNJOWtJ2TmDA8yS3jECiQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5401,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.6.10",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.10.tgz",
-      "integrity": "sha512-H0WyEqkajAmB2/pKUQO41oqTvYuQIsL+uvqposvPncXnDKkA7xppGz6MN+h1dkBEfhEJ5eAa5VWRDuLZ4DyAdw==",
+      "version": "13.6.12",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.6.12.tgz",
+      "integrity": "sha512-Cf3fDhZ8T+r9caarAPU2qFjyl6DBPPqyywtJpBdAEbOHO9MFXPmf7tO69glDkaUabfYjKL9ewqbNpgszuKPpCw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.6.10",
+        "@scratch/scratch-svg-renderer": "13.6.12",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5427,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.6.10",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.10.tgz",
-      "integrity": "sha512-NL2QoQgVx3ZVmpjVR7lgSfAKejACiAlPqRBw2LQIAHw5hBobpJnedTIg2W0ThbluYXq1zgPOBQrs1ZVXdg43FA==",
+      "version": "13.6.12",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.6.12.tgz",
+      "integrity": "sha512-QUoMSea2D4D/iCB57Q8uKrEBRy80TNHm9DYwsFQUjfYRaELvu6YwkmUCZszx4cWEiIA+Eexx/qakASv8r0cTlQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5467,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.6.10",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.10.tgz",
-      "integrity": "sha512-oKzVRUTlT8Tya+sSFlGvf+megi6dfEkD/udPgNJkrfdIEPFt4THoMhMm3uXeSaHUjggllKxn5pkaRBgwaiz+0w==",
+      "version": "13.6.12",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.6.12.tgz",
+      "integrity": "sha512-JGaercIA2q/WFyuBTtoJ9V6tfOMDAMtiBVJQP6p/02xcbAQNKGDKY8QW7B27IbNrGsbzJz9xT+sjhLbMQNzy6A==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.6.10",
-        "@scratch/scratch-svg-renderer": "13.6.10",
+        "@scratch/scratch-render": "13.6.12",
+        "@scratch/scratch-svg-renderer": "13.6.12",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -10958,9 +10958,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -17501,13 +17501,13 @@
       }
     },
     "node_modules/jsdom/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -17528,13 +17528,13 @@
       }
     },
     "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -23361,9 +23361,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.14.tgz",
-      "integrity": "sha512-J2bO8Ax6Dk2sDiC/TsEY9YNFuffxwPhYtv04arpCQwD+dn0CPJ5cqiE/C8Isu1zgyjI53vxdIviMEMJIje4WyQ==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.17.tgz",
+      "integrity": "sha512-ORmXc6m+qxbHUZeaJbVyQa2EyQmaUFDULhL1qUy14EE0JQQcdXfwUQpuUb25HoVkkjD/k8Fz5yNg8RHIUK0cAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.6.10",
+    "@scratch/scratch-gui": "13.6.12",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Hotfix release including:
- fix(scratch-vm): repair broken shadow references from cursed inputs bug by @cwillisf in https://github.com/scratchfoundation/scratch-editor/pull/536
- fix(scratch-blocks): stop making cursed inputs - https://github.com/scratchfoundation/scratch-blocks/pull/3560
- More cursed inputs fixes: https://github.com/scratchfoundation/scratch-blocks/pull/3563