### PR TITLE
fix: guard fetchCommunityData in componentDidMount for new projects

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ locales/*
 **/*.min.js
 **/node_modules/*
 scratch-gui/*
+/test/generated/

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -255,10 +255,11 @@ class Preview extends React.Component {
         }
         this.addEventListeners();
 
-        // It's possible that the session was fetched before this constructor
-        // In that case, we need to run some of componentDidUpdate here
-        // TODO: Exactly how much of componentDidUpdate should be here? Do we need a common helper method?
-        if (this.props.sessionStatus === sessionActions.Status.FETCHED) {
+        // With React 18's createRoot, the session response can arrive before
+        // componentDidMount runs. Guard on projectId like componentDidUpdate does,
+        // otherwise projectId '0' hits the API → 404 → "not available" page.
+        if (this.props.sessionStatus === sessionActions.Status.FETCHED &&
+            this.state.projectId > 0) {
             this.fetchCommunityData();
         }
     }
@@ -1612,6 +1613,9 @@ module.exports.View = injectIntl(
         mapDispatchToProps
     )(Preview)
 );
+if (process.env.NODE_ENV !== 'production') {
+    module.exports._Preview = Preview;
+}
 
 // replace old Scratch 2.0-style hashtag URLs with updated format
 if (window.location.hash) {

--- a/test/unit/views/preview-project-view.test.js
+++ b/test/unit/views/preview-project-view.test.js
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-env browser */
+/* eslint-disable global-require, react/display-name, react/prop-types */
+
+// Mock heavy dependencies so the module can load without scratch-gui, Blockly, etc.
+jest.mock('query-string', () => ({
+    default: {parse: () => ({}), stringify: () => ''},
+    parse: () => ({}),
+    stringify: () => ''
+}));
+jest.mock('@scratch/scratch-gui', () => {
+    const React = require('react');
+    const MockGUI = () => React.createElement('div');
+    MockGUI.guiReducers = {};
+    MockGUI.guiInitialState = {};
+    MockGUI.guiMiddleware = f => f;
+    MockGUI.initLocale = s => s;
+    MockGUI.localesInitialState = {};
+    MockGUI.setAppElement = () => {};
+    MockGUI.initPlayer = s => s;
+    MockGUI.initFullScreen = s => s;
+    MockGUI.default = MockGUI;
+    return MockGUI;
+});
+jest.mock('scratch-parser', () => () => {});
+jest.mock('../../../src/lib/storage.js', () => ({
+    default: {setProjectToken: () => {}, load: () => ({then: () => ({catch: () => {}})})},
+    __esModule: true
+}));
+jest.mock('../../../src/lib/api', () => jest.fn());
+jest.mock('xhr', () => jest.fn());
+jest.mock('../../../src/components/page/www/page.jsx', () => {
+    const React = require('react');
+    return props => React.createElement('div', null, props.children);
+});
+jest.mock('../../../src/views/preview/presentation.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/not-available/not-available.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div', null, 'NotAvailable');
+});
+jest.mock('../../../src/components/registration/registration.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/registration/scratch3-registration.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/login/connected-login.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/login/canceled-deletion-modal.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/views/preview/meta.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/modal/share/modal.jsx', () => ({
+    ShareModal: () => null
+}));
+jest.mock('../../../src/components/modal/tos/modal.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/journeys/editor-journey/editor-journey.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+jest.mock('../../../src/components/journeys/tutorials-highlight/tutorials-highlight.jsx', () => {
+    const React = require('react');
+    return () => React.createElement('div');
+});
+
+const sessionActions = require('../../../src/redux/session.js');
+
+describe('Preview componentDidMount', () => {
+    let Preview;
+
+    beforeAll(() => {
+        // Preview reads window.location.pathname in its constructor to derive
+        // projectId. Use window.history.pushState to set the URL without
+        // replacing the Location object.
+        window.history.pushState({}, '', '/projects/editor/?tutorial=getStarted');
+        Preview = require('../../../src/views/preview/project-view.jsx')._Preview;
+    });
+
+    afterAll(() => {
+        // Restore original URL
+        window.history.pushState({}, '', '/');
+    });
+
+    const buildProps = overrides => ({
+        hasActiveMembership: false,
+        sessionStatus: sessionActions.Status.NOT_FETCHED,
+        user: {},
+        userPresent: false,
+        projectInfo: {},
+        projectHost: 'https://projects.scratch.mit.edu',
+        isAdmin: false,
+        fullScreen: false,
+        playerMode: false,
+        permissions: {},
+        // dispatch-mapped functions
+        getProjectInfo: jest.fn(),
+        getRemixes: jest.fn(),
+        getCuratedStudios: jest.fn(),
+        getFavedStatus: jest.fn(),
+        getLovedStatus: jest.fn(),
+        refreshSession: jest.fn(),
+        setPlayer: jest.fn(),
+        setFullScreen: jest.fn(),
+        ...overrides
+    });
+
+    test('does not fetch community data for new projects (projectId 0) when session is already FETCHED', () => {
+        const props = buildProps({
+            sessionStatus: sessionActions.Status.FETCHED
+        });
+        const instance = new Preview(props);
+        instance.fetchCommunityData = jest.fn();
+        // Stub out DOM side effects
+        instance.addEventListeners = jest.fn();
+
+        instance.componentDidMount();
+
+        expect(instance.fetchCommunityData).not.toHaveBeenCalled();
+    });
+
+    test('fetches community data for existing projects when session is already FETCHED', () => {
+        window.history.pushState({}, '', '/projects/12345/');
+
+        try {
+            const props = buildProps({
+                sessionStatus: sessionActions.Status.FETCHED
+            });
+            const instance = new Preview(props);
+            instance.fetchCommunityData = jest.fn();
+            instance.addEventListeners = jest.fn();
+
+            instance.componentDidMount();
+
+            expect(instance.fetchCommunityData).toHaveBeenCalledTimes(1);
+        } finally {
+            // Restore editor URL for subsequent tests
+            window.history.pushState({}, '', '/projects/editor/?tutorial=getStarted');
+        }
+    });
+
+    test('does not fetch community data when session is not yet FETCHED', () => {
+        const props = buildProps({
+            sessionStatus: sessionActions.Status.NOT_FETCHED
+        });
+        const instance = new Preview(props);
+        instance.fetchCommunityData = jest.fn();
+        instance.addEventListeners = jest.fn();
+
+        instance.componentDidMount();
+
+        expect(instance.fetchCommunityData).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Resolves:

- Loading `/projects/editor/` or `/projects/editor/?tutorial=...` can sometimes result in a client-rendered "Whoops" page (no HTTP code visible)

### Changes:

Add `projectId > 0` check to `componentDidMount`, matching the existing guard in `componentDidUpdate`. With React 18's `createRoot`, the initial render is not guaranteed to be synchronous, so the `/session/` response can resolve before `componentDidMount` runs. When this race is lost on `/projects/editor/`, `componentDidMount` sees `sessionStatus=FETCHED` and calls `fetchCommunityData` with `projectId` '0', which 404s against the API and sets `projectNotAvailable=true`, showing the "Whoops" error page instead of the editor.

### Test Coverage:

Added new unit tests to kinda-sorta simulate this situation.