### PR TITLE
use: add copyright back to the footer

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -201,11 +201,11 @@ const Footer = props => (
         </MediaQuery>
         <LanguageChooser locale={getLocale()} />
         <div className="copyright">
-                  <p>
-                        <span>
-                            <FormattedMessage id="footer.copyright" />
-                        </span>
-                  </p>
+            <p>
+                <span>
+                    <FormattedMessage id="footer.copyright" />
+                </span>
+            </p>
         </div>
     </FooterBox>
 );

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -200,12 +200,12 @@ const Footer = props => (
             </div>
         </MediaQuery>
         <LanguageChooser locale={getLocale()} />
-        <div class="copyright">
-        <p>
-            <span>
-         <FormattedMessage id="footer.copyright" />
-            </span>
-        </p>
+        <div className="copyright">
+                  <p>
+                        <span>
+                            <FormattedMessage id="footer.copyright" />
+                        </span>
+                  </p>
         </div>
     </FooterBox>
 );

--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -200,6 +200,13 @@ const Footer = props => (
             </div>
         </MediaQuery>
         <LanguageChooser locale={getLocale()} />
+        <div class="copyright">
+        <p>
+            <span>
+         <FormattedMessage id="footer.copyright" />
+            </span>
+        </p>
+        </div>
     </FooterBox>
 );
 

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -143,6 +143,8 @@
     "general.3faq": "To learn more, go to the {faqLink}.",
     "general.year": "Year",
 
+    "footer.copyright": "Scratch is a project of the Scratch Foundation",
+
     "footer.discuss": "Discussion Forums",
     "footer.scratchFamily": "Scratch Family",
 


### PR DESCRIPTION
### Changes:

Adds back copyright class to footer component from 2019 but with Scratch Foundation, there was unused CSS for it so why not add it back?

### Test Coverage:

2019
<img width="421" height="130" alt="Screenshot 2026-04-25 9 56 26 PM" src="https://github.com/user-attachments/assets/515b839e-b8db-497d-b533-8ae7a949759e" />

2026
<img width="421" height="130" alt="Screenshot 2026-04-25 9 56 35 PM" src="https://github.com/user-attachments/assets/55efab76-e3fa-4340-abde-ac765dd551c7" />

