### PR TITLE
fix(deps): update to scratch-gui@13.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.7.1",
+        "@scratch/scratch-gui": "13.7.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5168,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.7.1.tgz",
-      "integrity": "sha512-dWnksDHa/OVPnpp/Do2Poe56N68R65Pv1WU6hcUzRbrA2BLpYAUZsVeqLIRYdrfZgZhVJ5ha5IlqLdc+wdG4xg==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.7.2.tgz",
+      "integrity": "sha512-2MsIIqYY4koMkzAXeLq4lp7R6E11csiCJv59zDfC05mJ8cDWwWevOzV6Fozn81ZIL+1dQ7wzE3gjtqconFzuPA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.7.1",
-        "@scratch/scratch-svg-renderer": "13.7.1",
-        "@scratch/scratch-vm": "13.7.1",
+        "@scratch/scratch-render": "13.7.2",
+        "@scratch/scratch-svg-renderer": "13.7.2",
+        "@scratch/scratch-vm": "13.7.2",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5231,7 +5231,7 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.17",
+        "scratch-blocks": "2.1.19",
         "scratch-l10n": "6.1.72",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
@@ -5401,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.7.1.tgz",
-      "integrity": "sha512-/tKrutO5ND9eJ1TSjMm8h/yCRVr+a/rVKof3JxRRMuUZM6cVtO9PRu/DcaqPJ5RaKAo6c4UdBHfWNmqDzO3UtQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.7.2.tgz",
+      "integrity": "sha512-lXOMZJ/D2JVe6KPRKWHd5fJBSGXLPe7eoBKs1yDLlBiEqw58f5oHnX/qit66J4N8WCYRqA3z0ATgAyHTfvjJgg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.7.1",
+        "@scratch/scratch-svg-renderer": "13.7.2",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5427,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.1.tgz",
-      "integrity": "sha512-68KTzFboMPESjv95aP52W9IfltWIcWFfJ284Ku3kK7qePgBdL6gNQxUeZ63PEkxUA59MBhZNcIGOxWy6H6Bztw==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.2.tgz",
+      "integrity": "sha512-GgCRewlvKvhWY50+4RmsCnWf17opQmcGxEO7bykoWS9a+SVdhYC048aa4QbMK9/sDto/MmwHUc0wqAXXHB4G0g==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5467,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.7.1.tgz",
-      "integrity": "sha512-5TXzhDjDfowLUmKlq9mVVWWn+ylqkqIva7JsI/JFyOxhRpgc5XQ1qmxFy8l2rm8NnLavloZ6qri+eQdJaqLVhw==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.7.2.tgz",
+      "integrity": "sha512-1FvL3LgMXvkY0XEqTR01yFU6uA2F2YKHEwiGBZZkQJnRfEaj0MZXXKHF1iPZmMqEZhepfjRQa0XNEYtC8UOHOA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.7.1",
-        "@scratch/scratch-svg-renderer": "13.7.1",
+        "@scratch/scratch-render": "13.7.2",
+        "@scratch/scratch-svg-renderer": "13.7.2",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -23364,9 +23364,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.17.tgz",
-      "integrity": "sha512-ORmXc6m+qxbHUZeaJbVyQa2EyQmaUFDULhL1qUy14EE0JQQcdXfwUQpuUb25HoVkkjD/k8Fz5yNg8RHIUK0cAA==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.19.tgz",
+      "integrity": "sha512-FgRoGhUkiGEmjblwmd5k+0HPlonoXkk1arwnnZBcSE05MKoZjWiP/ksHCfCcr2w/qqYQBrCynBk6flmwkcsUnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -27565,22 +27565,22 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.29"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.7.1",
+    "@scratch/scratch-gui": "13.7.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
### Changes:

#### General

Fix/shadow top level scripts by @cwillisf in https://github.com/scratchfoundation/scratch-editor/pull/543

#### scratch-blocks

prevent stripIds from mutating original block's shadow state ([d7d6b76](https://github.com/scratchfoundation/scratch-blocks/commit/d7d6b762d6b03a9b0de5be0ee150b6dbd64e0656))
clear angle field event wrappers ([3416849](https://github.com/scratchfoundation/scratch-blocks/commit/3416849248315aab0802c7a41e17f1d33562a8c5))
