### PR TITLE
test: use hash-tolerant selectors in integration tests

### DIFF
--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -167,7 +167,9 @@ describe('comment tests', () => {
             await clickXpath(projectLinkXpath);
 
             // find green flag overlay
-            const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+            const gfOverlay = await findByXpath(
+                '//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]'
+            );
             await gfOverlay.isDisplayed();
         });
 

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -29,6 +29,8 @@ const profileUrl = `${rootUrl}/users/${username2}`;
 const studioId = process.env.COMMENT_STUDIO_ID || 10005646;
 const studioUrl = `${rootUrl}/studios/${studioId}/comments`;
 
+const STAGE_WRAPPER_XPATH = '//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]';
+
 // setup comments to leave
 // make sure they are unique and will not be censored (avoid numbers that might look like phone numbers or other PII)
 const date = new Date();
@@ -166,11 +168,9 @@ describe('comment tests', () => {
             await navigate(`${rootUrl}/messages`);
             await clickXpath(projectLinkXpath);
 
-            // find green flag overlay
-            const gfOverlay = await findByXpath(
-                '//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]'
-            );
-            await gfOverlay.isDisplayed();
+            // find project stage wrapper
+            const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+            await stageWrapper.isDisplayed();
         });
 
         test('project comment is on project page', async () => {

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -69,7 +69,7 @@ describe('www-integration my_stuff', () => {
         await navigate(myStuffURL);
         await clickXpath('//a[@data-control="edit"]');
         await waitUntilDocumentReady();
-        const gf = await findByXpath('//img[@class="green-flag_green-flag_1kiAo"]');
+        const gf = await findByXpath('//button[contains(concat(" ", @class), " green-flag_green-flag-button")]');
         const gfVisible = await gf.isDisplayed();
         expect(gfVisible).toBe(true);
     });
@@ -87,7 +87,7 @@ describe('www-integration my_stuff', () => {
         await navigate(myStuffURL);
         await clickText('+ New Project');
         await waitUntilDocumentReady();
-        const gf = await findByXpath('//img[@class="green-flag_green-flag_1kiAo"]');
+        const gf = await findByXpath('//button[contains(concat(" ", @class), " green-flag_green-flag-button")]');
         const gfVisible = await gf.isDisplayed();
         expect(gfVisible).toBe(true);
     });

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -20,6 +20,8 @@ const rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
 const myStuffURL = `${rootUrl}/mystuff`;
 const rateLimitCheck = process.env.RATE_LIMIT_CHECK || rootUrl;
 
+const GREEN_FLAG_XPATH = '//button[contains(concat(" ", @class), " green-flag_green-flag-button")]';
+
 jest.setTimeout(60000);
 
 let driver;
@@ -69,7 +71,7 @@ describe('www-integration my_stuff', () => {
         await navigate(myStuffURL);
         await clickXpath('//a[@data-control="edit"]');
         await waitUntilDocumentReady();
-        const gf = await findByXpath('//button[contains(concat(" ", @class), " green-flag_green-flag-button")]');
+        const gf = await findByXpath(GREEN_FLAG_XPATH);
         const gfVisible = await gf.isDisplayed();
         expect(gfVisible).toBe(true);
     });
@@ -87,7 +89,7 @@ describe('www-integration my_stuff', () => {
         await navigate(myStuffURL);
         await clickText('+ New Project');
         await waitUntilDocumentReady();
-        const gf = await findByXpath('//button[contains(concat(" ", @class), " green-flag_green-flag-button")]');
+        const gf = await findByXpath(GREEN_FLAG_XPATH);
         const gfVisible = await gf.isDisplayed();
         expect(gfVisible).toBe(true);
     });

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -46,6 +46,8 @@ const remote = process.env.SMOKE_REMOTE || false;
 
 const FILE_MENU_XPATH = '//div[contains(@class, "menu-bar_menu-bar-item")]' +
     '[*[contains(@class, "menu-bar_collapsible-label")]//*[text()="File"]]';
+const STAGE_WRAPPER_XPATH = '//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]';
+const SPRITE_INFO_XPATH = '//div[contains(concat(" ", @class), " sprite-info_sprite-info")]';
 
 jest.setTimeout(60000);
 
@@ -60,8 +62,8 @@ describe('www-integration project-page signed out', () => {
 
     beforeEach(async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
     });
 
     afterAll(() => driver.quit());
@@ -92,7 +94,7 @@ describe('www-integration project-page signed out', () => {
 
     test('click See Inside to go to the editor', async () => {
         await clickXpath('//button[@class="button button see-inside-button"]');
-        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
+        const infoArea = await findByXpath(SPRITE_INFO_XPATH);
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
@@ -137,28 +139,28 @@ describe('www-integration project-page signed in', () => {
     // Load a shared project you own
     test('Load a shared project you own', async () => {
         await navigate(ownedSharedUrl);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
-        const gfVisible = await gfOverlay.isDisplayed();
-        expect(gfVisible).toBe(true);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
+        const stageWrapperVisible = await stageWrapper.isDisplayed();
+        expect(stageWrapperVisible).toBe(true);
     });
 
     // Load a shared project you don't own
     test('Load a shared project you do not own', async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
-        const gfVisible = await gfOverlay.isDisplayed();
-        expect(gfVisible).toBe(true);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
+        const stageWrapperVisible = await stageWrapper.isDisplayed();
+        expect(stageWrapperVisible).toBe(true);
     });
 
     // Load an unshared project you own
     test('Load an unshared project you own', async () => {
         await navigate(ownedUnsharedUrl);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
-        const gfVisible = await gfOverlay.isDisplayed();
-        expect(gfVisible).toBe(true);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
+        const stageWrapperVisible = await stageWrapper.isDisplayed();
+        expect(stageWrapperVisible).toBe(true);
     });
 
     // Load an unshared project you don't own, get error
@@ -173,19 +175,19 @@ describe('www-integration project-page signed in', () => {
     // Load a shared scratch 2 project you don't own
     test('Load a shared scratch 2 project you do not own', async () => {
         await navigate(unownedSharedScratch2Url);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
-        const gfVisible = await gfOverlay.isDisplayed();
-        expect(gfVisible).toBe(true);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
+        const stageWrapperVisible = await stageWrapper.isDisplayed();
+        expect(stageWrapperVisible).toBe(true);
     });
 
     // Load an unshared scratch 2 project you own
     test('Load an unshared scratch 2 project you own', async () => {
         await navigate(ownedUnsharedScratch2Url);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
-        const gfVisible = await gfOverlay.isDisplayed();
-        expect(gfVisible).toBe(true);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
+        const stageWrapperVisible = await stageWrapper.isDisplayed();
+        expect(stageWrapperVisible).toBe(true);
     });
 });
 
@@ -220,21 +222,21 @@ describe('www-integration project-creation signed in', () => {
         const alertVisible = await successAlert.isDisplayed();
         expect(alertVisible).toBe(true);
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
+        const infoArea = await findByXpath(SPRITE_INFO_XPATH);
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
 
     test('remix a project', async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
-        await waitUntilVisible(gfOverlay, driver);
+        const stageWrapper = await findByXpath(STAGE_WRAPPER_XPATH);
+        await waitUntilVisible(stageWrapper, driver);
         await clickXpath('//button[@class="button remix-button"]');
         const successAlert = await findText('Project saved as a remix.');
         const alertVisible = await successAlert.isDisplayed();
         expect(alertVisible).toBe(true);
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
+        const infoArea = await findByXpath(SPRITE_INFO_XPATH);
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
@@ -266,7 +268,7 @@ describe('www-integration project-creation signed in', () => {
 
         // check that gui is still there after some time has passed
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
+        const infoArea = await findByXpath(SPRITE_INFO_XPATH);
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -60,7 +60,7 @@ describe('www-integration project-page signed out', () => {
 
     beforeEach(async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
     });
 
@@ -92,7 +92,7 @@ describe('www-integration project-page signed out', () => {
 
     test('click See Inside to go to the editor', async () => {
         await clickXpath('//button[@class="button button see-inside-button"]');
-        const infoArea = await findByXpath('//div[@class="sprite-info_sprite-info_3EyZh box_box_2jjDp"]');
+        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
@@ -137,7 +137,7 @@ describe('www-integration project-page signed in', () => {
     // Load a shared project you own
     test('Load a shared project you own', async () => {
         await navigate(ownedSharedUrl);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         const gfVisible = await gfOverlay.isDisplayed();
         expect(gfVisible).toBe(true);
@@ -146,7 +146,7 @@ describe('www-integration project-page signed in', () => {
     // Load a shared project you don't own
     test('Load a shared project you do not own', async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         const gfVisible = await gfOverlay.isDisplayed();
         expect(gfVisible).toBe(true);
@@ -155,7 +155,7 @@ describe('www-integration project-page signed in', () => {
     // Load an unshared project you own
     test('Load an unshared project you own', async () => {
         await navigate(ownedUnsharedUrl);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         const gfVisible = await gfOverlay.isDisplayed();
         expect(gfVisible).toBe(true);
@@ -173,7 +173,7 @@ describe('www-integration project-page signed in', () => {
     // Load a shared scratch 2 project you don't own
     test('Load a shared scratch 2 project you do not own', async () => {
         await navigate(unownedSharedScratch2Url);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         const gfVisible = await gfOverlay.isDisplayed();
         expect(gfVisible).toBe(true);
@@ -182,7 +182,7 @@ describe('www-integration project-page signed in', () => {
     // Load an unshared scratch 2 project you own
     test('Load an unshared scratch 2 project you own', async () => {
         await navigate(ownedUnsharedScratch2Url);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         const gfVisible = await gfOverlay.isDisplayed();
         expect(gfVisible).toBe(true);
@@ -220,21 +220,21 @@ describe('www-integration project-creation signed in', () => {
         const alertVisible = await successAlert.isDisplayed();
         expect(alertVisible).toBe(true);
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[@class="sprite-info_sprite-info_3EyZh box_box_2jjDp"]');
+        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
 
     test('remix a project', async () => {
         await navigate(unownedSharedUrl);
-        const gfOverlay = await findByXpath('//div[@class="stage-wrapper_stage-wrapper_2bejr box_box_2jjDp"]');
+        const gfOverlay = await findByXpath('//section[contains(concat(" ", @class), " stage-wrapper_stage-wrapper")]');
         await waitUntilVisible(gfOverlay, driver);
         await clickXpath('//button[@class="button remix-button"]');
         const successAlert = await findText('Project saved as a remix.');
         const alertVisible = await successAlert.isDisplayed();
         expect(alertVisible).toBe(true);
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[@class="sprite-info_sprite-info_3EyZh box_box_2jjDp"]');
+        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });
@@ -266,7 +266,7 @@ describe('www-integration project-creation signed in', () => {
 
         // check that gui is still there after some time has passed
         await driver.sleep(1000);
-        const infoArea = await findByXpath('//div[@class="sprite-info_sprite-info_3EyZh box_box_2jjDp"]');
+        const infoArea = await findByXpath('//div[contains(concat(" ", @class), " sprite-info_sprite-info")]');
         const areaVisible = await infoArea.isDisplayed();
         expect(areaVisible).toBe(true);
     });


### PR DESCRIPTION
### Resolves:

The `Production Integration Tests` job has been red on every master push for a long while. Several of the failing tests use exact-match xpath selectors that include CSS-modules content hashes (`_2bejr`, `_3EyZh`, `_2jjDp`, `_1kiAo`); those hashes rotate with each scratch-gui build, so the selectors stopped matching.

### Changes:

- Replace exact-match xpath with `contains(concat(" ", @class), " <prefix>")` per the pattern documented in scratch-gui's `selenium-helper.js`. Affects `project-page.test.js`, `comments.test.js`, and `my-stuff.test.js`.
- Update element types to match current scratch-gui DOM: the stage wrapper is now a `<section>` (was `<div>`); the green flag is now a `<button>` (was `<img>`).

### Test Coverage:

- `npm run test:lint` clean.
- All updated selectors verified live against `https://scratch.mit.edu/projects/editor` in a browser.
- Integration tests only run on master pushes; observable on the next master release.

Two tests not addressed here will likely still fail with click-intercept errors: `load project from file` (clicks `//li[@class="link create"]` on the homepage) and `make a copy of a project` (clicks File menu in editor). Both elements were clickable in a signed-out browser check, so the cause is likely signed-in-only or transient. Will follow up if the next master CI confirms.