### PR TITLE
[UEPR-591] Redirect native For Educators page and Educator FAQ to Foundation for Educators page

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -167,13 +167,6 @@
         "title": "Scratch Offline Editor"
     },
     {
-        "name": "educator-landing",
-        "pattern": "^/educators/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
-        "view": "teachers/landing/landing",
-        "title": "Educators"
-    },
-    {
         "name": "ethics",
         "pattern": "^/code-of-ethics/?$",
         "routeAlias": "/code-of-ethics/?$",
@@ -352,13 +345,6 @@
         "view": "studio/studio",
         "title": "Scratch Studio",
         "dynamicMetaTags": true
-    },
-    {
-        "name": "teacher-faq",
-        "pattern": "^/educators/faq/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
-        "view": "teachers/faq/faq",
-        "title": "Teacher Accounts FAQ"
     },
     {
         "name": "teacherregistration",


### PR DESCRIPTION
### Resolves:

[UEPR-591](https://scratchfoundation.atlassian.net/browse/UEPR-591)

### Changes:

- Remove native `/educators` and `/educators/faq` views

[UEPR-591]: https://scratchfoundation.atlassian.net/browse/UEPR-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ