### PR TITLE
test: drop tests for removed UI and fix selector drift

### DIFF
--- a/test/health/server-health.test.js
+++ b/test/health/server-health.test.js
@@ -21,9 +21,9 @@ describe('www server health check', () => {
     /** @type {SeleniumHelper} */
     let seleniumHelper;
 
-    beforeAll(() => {
+    beforeAll(async () => {
         seleniumHelper = new SeleniumHelper();
-        driver = seleniumHelper.buildDriver('www server health check');
+        driver = await seleniumHelper.buildDriver('www server health check');
     });
 
     afterAll(() => driver.quit());

--- a/test/integration/comments.test.js
+++ b/test/integration/comments.test.js
@@ -8,6 +8,7 @@ const {
     clickXpath,
     containsClass,
     findByXpath,
+    findByXpathWithRefresh,
     navigate,
     signIn
 } = new SeleniumHelper();
@@ -43,7 +44,10 @@ const projectReply = `${projectComment} reply`;
 const profileReply = `${profileComment} reply`;
 const studioReply = `${studioComment} reply`;
 
-jest.setTimeout(60000);
+// findByXpathWithRefresh's default retries=3 plus per-attempt 20s findByXpath waits can
+// push a failing comments-deeplink test past 60s; bump to 120s so the helper's chained
+// error surfaces instead of a generic Jest timeout.
+jest.setTimeout(120000);
 
 let driver;
 
@@ -216,6 +220,10 @@ describe('comment tests', () => {
             expect(uname).toBe(username2);
         });
 
+        // The legacy profile-comments view bails when a deep-linked comment isn't yet in the
+        // public listing API, which can lag a few seconds behind a fresh post. The next two
+        // tests use findByXpathWithRefresh, which refreshes the page between attempts so the
+        // legacy walker re-runs against an updated cache.
         test('profile comment is on profile page', async () => {
             const profileLinkXpath = '//p[@class="emoji-text mod-comment" ' +
                 `and contains(text(), "${profileComment}")]/../../../` +
@@ -225,7 +233,7 @@ describe('comment tests', () => {
 
             // find comment
             const commentXpath = `//div[contains(text(), "${profileComment}")]`;
-            const leftComment = await findByXpath(commentXpath);
+            const leftComment = await findByXpathWithRefresh(commentXpath);
             const commentVisible = await leftComment.isDisplayed();
             expect(commentVisible).toBe(true);
 
@@ -240,7 +248,7 @@ describe('comment tests', () => {
 
             // comment highlighted?
             const containerXpath = `//div[contains(text(), "${profileComment}")]/../../..`;
-            const commentContainer = await findByXpath(containerXpath);
+            const commentContainer = await findByXpathWithRefresh(containerXpath);
             const isHighlighted = await containsClass(commentContainer, 'highlighted');
             expect(isHighlighted).toBe(true);
         });
@@ -267,8 +275,9 @@ describe('comment tests', () => {
 
         test('profile reply to comment', async () => {
             await navigate(profileUrl);
-            // find the comment and click reply
+            // find the comment (refreshing if needed for the legacy listing-cache lag) and click reply
             const commentXpath = `//div[contains(text(), "${profileComment}")]/..`;
+            await findByXpathWithRefresh(commentXpath);
             await clickXpath(`${commentXpath}//a[@class = "reply"]`);
 
             // select reply box and type reply

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -76,15 +76,6 @@ describe('www-integration my_stuff', () => {
         expect(gfVisible).toBe(true);
     });
 
-    test('Add To button should bring up a list of studios', async () => {
-        await navigate(myStuffURL);
-        await clickXpath('//div[@id="sidebar"]/ul/li[@data-tab="shared"]');
-        await clickXpath('//div[@data-control="add-to"]');
-        const dropDown = await findByXpath('//div[@class="dropdown-menu"]/ul/li');
-        const dropDownVisible = await dropDown.isDisplayed();
-        expect(dropDownVisible).toBe(true);
-    });
-
     test('+ New Project button should open the editor', async () => {
         await navigate(myStuffURL);
         await clickText('+ New Project');

--- a/test/integration/my-stuff.test.js
+++ b/test/integration/my-stuff.test.js
@@ -95,7 +95,10 @@ describe('www-integration my_stuff', () => {
         expect(tabsVisible).toBe(true);
     });
 
-    test('New studio rate limited to five', async () => {
+    // Skipped: there is a daily-aggregate cap on studio creation per user that this test
+    // can trip when combined with other runs in the same 24-hour window. Once tripped, the
+    // smoke account ends up in a state that subsequent runs cannot recover from on their own.
+    test.skip('New studio rate limited to five', async () => {
         await navigate(rateLimitCheck);
         // 1st studio
         await navigate(myStuffURL);

--- a/test/integration/navbar.test.js
+++ b/test/integration/navbar.test.js
@@ -6,8 +6,7 @@ const {
     clickXpath,
     buildDriver,
     findByXpath,
-    navigate,
-    waitUntilDocumentReady
+    navigate
 } = new SeleniumHelper();
 
 const rootUrl = process.env.ROOT_URL || 'https://scratch.ly';
@@ -40,10 +39,6 @@ describe('www-integration navbar links', () => {
         const ideasText = await ideas.getText();
         expect(ideasText).toEqual('Ideas');
 
-        const about = await findByXpath('//li[@class="link about"]');
-        const aboutText = await about.getText();
-        expect(aboutText).toEqual('About');
-
         const join = await findByXpath('//a[@class="registrationLink"]');
         const joinText = await join.getText();
         expect(joinText).toEqual('Join Scratch');
@@ -72,13 +67,6 @@ describe('www-integration navbar links', () => {
         const banner = await findByXpath('//iframe[@class="ideas-project"]');
         const bannerVisible = await banner.isDisplayed();
         expect(bannerVisible).toBe(true);
-    });
-
-    test('About link when signed out', async () => {
-        await clickXpath('//li[@class="link about"]');
-        await waitUntilDocumentReady();
-        const url = await driver.getCurrentUrl();
-        expect(url).toMatch(/^https:\/\/www\.scratchfoundation\.org/);
     });
 
     test('Search Bar', async () => {

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -241,7 +241,11 @@ describe('www-integration project-creation signed in', () => {
         expect(areaVisible).toBe(true);
     });
 
-    test('load project from file', async () => {
+    // Skipped: when SMOKE_REMOTE=true, sendKeys to the file input fails with
+    // "File not found : /Users/chef/Downloads/project1.sb3" because the prior
+    // GitHub blob download isn't landing on the Sauce Labs VM at that path.
+    // Needs Sauce-side download verification or a different upload mechanism.
+    test.skip('load project from file', async () => {
         // if remote, projectPath is Saucelabs path to downloaded file
         const projectPath = remote ?
             '/Users/chef/Downloads/project1.sb3' :

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -15,6 +15,7 @@ const {
     isSignedIn,
     signIn,
     navigate,
+    waitForScratchGuiLoadingState,
     waitUntilVisible
 } = new SeleniumHelper();
 
@@ -240,25 +241,51 @@ describe('www-integration project-creation signed in', () => {
         // create a new project so there's unsaved content to trigger an alert
         await clickXpath('//li[@class="link create"]');
 
-        // Open the File menu and click "Load from your computer" to mount the hidden file
-        // input — scratch-gui creates the input element dynamically inside that handler.
-        // sendKeys then sets the value via the WebDriver protocol; on Sauce Labs and on
-        // standard Chrome / Chrome for Testing, chromedriver intercepts the file picker
-        // via Page.fileChooserOpened so no OS dialog blocks. Some non-Chrome chromium
-        // builds (e.g. ungoogled-chromium on Linux) don't emit that event, so this test
-        // can hang locally non-headless; runs against Sauce Labs (CI) work as expected.
-        await clickXpath(FILE_MENU_XPATH);
-        await clickText('Load from your computer');
-        const input = await driver.wait(
-            until.elementLocated(By.xpath('//input[@accept=".sb,.sb2,.sb3"]')),
-            20000
-        );
-        await input.sendKeys(projectPath);
+        // The new-project flow drops us into the editor and eventually settles at
+        // SHOWING_WITH_ID, but state can briefly transition (e.g. AUTO_UPDATING for the
+        // initial title save) any time after that. If the change-event handler runs in
+        // a transitional state, scratch-gui's requestProjectUpload action creator returns
+        // undefined and the redux dispatch crashes, silently dropping the upload. We retry
+        // the whole File → Load → sendKeys sequence until we observe loadingState advance
+        // to LOADING_VM_FILE_UPLOAD. When the redux dev-tools shim is installed (CDP
+        // available — the case on local chromedriver and on Sauce), that's positive proof
+        // the dispatch succeeded. Without the shim, waitForScratchGuiLoadingState resolves
+        // immediately, the loop degenerates to a single trust-the-flow pass, and the test
+        // falls back to whatever pre-shim behavior held on that driver.
+        // TODO: drop the retry loop once scratch-gui's requestProjectUpload always returns
+        // a valid action regardless of loadingState (the reducer already gates).
+        await waitForScratchGuiLoadingState(['SHOWING_WITH_ID', 'SHOWING_WITHOUT_ID']);
 
-        // accept alert
-        await driver.wait(until.alertIsPresent());
-        const alert = await driver.switchTo().alert();
-        await alert.accept();
+        let dispatched = false;
+        for (let attempt = 0; attempt < 5 && !dispatched; attempt++) {
+            await waitForScratchGuiLoadingState(['SHOWING_WITH_ID', 'SHOWING_WITHOUT_ID']);
+            await clickXpath(FILE_MENU_XPATH);
+            await clickText('Load from your computer');
+            const input = await driver.wait(
+                until.elementLocated(By.xpath('//input[@accept=".sb,.sb2,.sb3"]')),
+                20000
+            );
+            await input.sendKeys(projectPath);
+
+            // Accept the "Replace contents" alert if it appears. scratch-gui only shows
+            // the confirm when userOwnsProject || (projectChanged && isShowingWithoutId);
+            // when neither holds (e.g. just-created project's author info isn't fetched
+            // yet) the upload proceeds without a confirm.
+            try {
+                await driver.wait(until.alertIsPresent(), 2000);
+                const alert = await driver.switchTo().alert();
+                await alert.accept();
+            } catch (e) { /* no alert */ }
+
+            // Did the dispatch actually move state into LOADING_VM_FILE_UPLOAD?
+            try {
+                await waitForScratchGuiLoadingState(['LOADING_VM_FILE_UPLOAD'], 2000);
+                dispatched = true;
+            } catch (e) {
+                // dispatch silently dropped; loop and retry
+            }
+        }
+        expect(dispatched).toBe(true);
 
         // check that project is loaded
         const spriteTile = await findText('project1-sprite');

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -3,7 +3,7 @@
 // some tests use projects owned by user #2
 
 const SeleniumHelper = require('./selenium-helpers.js');
-const {until} = require('selenium-webdriver');
+const {By, until} = require('selenium-webdriver');
 import path from 'path';
 
 const {
@@ -41,8 +41,6 @@ const ownedUnsharedScratch2Url = `${rootUrl}/projects/${ownedUnsharedScratch2ID}
 
 const username = `${process.env.SMOKE_USERNAME}6`;
 const password = process.env.SMOKE_PASSWORD;
-
-const remote = process.env.SMOKE_REMOTE || false;
 
 const FILE_MENU_XPATH = '//div[contains(@class, "menu-bar_menu-bar-item")]' +
     '[*[contains(@class, "menu-bar_collapsible-label")]//*[text()="File"]]';
@@ -194,14 +192,6 @@ describe('www-integration project-page signed in', () => {
 describe('www-integration project-creation signed in', () => {
     beforeAll(async () => {
         driver = await buildDriver('www-integration project-creation signed in');
-
-        // SauceLabs doesn't have access to the sb3 used in 'load project from file' test
-        // https://support.saucelabs.com/hc/en-us/articles/115003685593-Uploading-Files-to-a-Sauce-Labs-Virtual-Machine-during-a-Test
-        if (remote) {
-            await navigate('https://github.com/scratchfoundation/scratch-www/blob/develop/test/fixtures/project1.sb3');
-            await clickXpath('//button[@data-testid="download-raw-button"]');
-            await driver.sleep(3000);
-        }
     });
 
     beforeEach(async () => {
@@ -241,23 +231,28 @@ describe('www-integration project-creation signed in', () => {
         expect(areaVisible).toBe(true);
     });
 
-    // Skipped: when SMOKE_REMOTE=true, sendKeys to the file input fails with
-    // "File not found : /Users/chef/Downloads/project1.sb3" because the prior
-    // GitHub blob download isn't landing on the Sauce Labs VM at that path.
-    // Needs Sauce-side download verification or a different upload mechanism.
-    test.skip('load project from file', async () => {
-        // if remote, projectPath is Saucelabs path to downloaded file
-        const projectPath = remote ?
-            '/Users/chef/Downloads/project1.sb3' :
-            path.resolve(__dirname, '../fixtures/project1.sb3');
+    test('load project from file', async () => {
+        // selenium-helpers' buildDriver attaches a FileDetector for remote runs, so sendKeys
+        // to a file input uploads the local fixture transparently regardless of where the
+        // browser is running.
+        const projectPath = path.resolve(__dirname, '../fixtures/project1.sb3');
 
         // create a new project so there's unsaved content to trigger an alert
         await clickXpath('//li[@class="link create"]');
 
-        // upload file
+        // Open the File menu and click "Load from your computer" to mount the hidden file
+        // input — scratch-gui creates the input element dynamically inside that handler.
+        // sendKeys then sets the value via the WebDriver protocol; on Sauce Labs and on
+        // standard Chrome / Chrome for Testing, chromedriver intercepts the file picker
+        // via Page.fileChooserOpened so no OS dialog blocks. Some non-Chrome chromium
+        // builds (e.g. ungoogled-chromium on Linux) don't emit that event, so this test
+        // can hang locally non-headless; runs against Sauce Labs (CI) work as expected.
         await clickXpath(FILE_MENU_XPATH);
         await clickText('Load from your computer');
-        const input = await findByXpath('//input[@accept=".sb,.sb2,.sb3"]');
+        const input = await driver.wait(
+            until.elementLocated(By.xpath('//input[@accept=".sb,.sb2,.sb3"]')),
+            20000
+        );
         await input.sendKeys(projectPath);
 
         // accept alert

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -76,7 +76,7 @@ describe('www-integration project-page signed out', () => {
         expect(guiVisible).toBe(true);
     });
 
-    test.skip('Open Copy Link modal', async () => {
+    test('Open Copy Link modal', async () => {
         await clickXpath('//button[@class="button action-button copy-link-button"]');
         const projectLink = await findByXpath('//input[@name="link"]');
         const linkValue = await projectLink.getAttribute('value');

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -128,6 +128,7 @@ class SeleniumHelper {
             'dragFromXpathToXpath',
             'findByCss',
             'findByXpath',
+            'findByXpathWithRefresh',
             'findText',
             'getKey',
             'getDriver',
@@ -280,6 +281,37 @@ class SeleniumHelper {
         } catch (cause) {
             throw await outerError.chain(cause, this.driver);
         }
+    }
+
+    /**
+     * Find an element by xpath, refreshing the page between attempts. Useful when the page's initial render
+     * depends on backend state that may be eventually consistent (e.g. caches that take a few seconds to catch up
+     * after a write).
+     *
+     * Note: each attempt's `findByXpath` can wait up to {@link DEFAULT_TIMEOUT_MILLISECONDS} when the element is
+     * missing, so the default `retries=3` puts the worst-case total above the typical 60s Jest test timeout.
+     * Tests using this helper should bump their `jest.setTimeout` accordingly so a failure surfaces as the
+     * helper's chained `SeleniumHelperError` rather than a less-informative Jest timeout.
+     * @param {string} xpath The xpath to search for.
+     * @param {object} [options] Optional configuration.
+     * @param {number} [options.retries=3] Number of refresh-and-retry attempts after the initial try.
+     * @returns {Promise<webdriver.WebElement>} A promise that resolves to the element.
+     */
+    async findByXpathWithRefresh (xpath, {retries = 3} = {}) {
+        const outerError = new SeleniumHelperError('findByXpathWithRefresh failed', [{xpath, retries}]);
+        let lastCause;
+        for (let attempt = 0; attempt <= retries; attempt++) {
+            try {
+                return await this.findByXpath(xpath);
+            } catch (cause) {
+                lastCause = cause;
+                if (attempt < retries) {
+                    await this.driver.navigate().refresh();
+                    await this.waitUntilDocumentReady();
+                }
+            }
+        }
+        throw await outerError.chain(lastCause, this.driver);
     }
 
     /**

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -121,6 +121,40 @@ class SeleniumHelperError extends Error {
     }
 }
 
+// Shim for redux's dev-tools `compose`. scratch-gui does
+//   composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+// at module load. By installing this shim via CDP's
+// Page.addScriptToEvaluateOnNewDocument *before* the bundle runs, redux ends up
+// passing every store it creates through us — letting us hold a reference to it.
+// This is the standard redux dev-tools API, so it's API-stable and doesn't depend
+// on React internals (no fiber walking).
+const REDUX_STORE_CAPTURE_SHIM = `
+(function () {
+    if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) return;
+    function realCompose () {
+        var fns = Array.prototype.slice.call(arguments);
+        if (fns.length === 0) return function (x) { return x; };
+        if (fns.length === 1) return fns[0];
+        return fns.reduce(function (a, b) {
+            return function () {
+                return a(b.apply(null, arguments));
+            };
+        });
+    }
+    window.__capturedStores = [];
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = function () {
+        var composed = realCompose.apply(null, arguments);
+        return function (createStore) {
+            return function (reducer, preloadedState) {
+                var store = composed(createStore)(reducer, preloadedState);
+                window.__capturedStores.push(store);
+                return store;
+            };
+        };
+    };
+})();
+`;
+
 class SeleniumHelper {
     constructor () {
         bindAll(this, [
@@ -139,10 +173,12 @@ class SeleniumHelper {
             'getDriver',
             'getLogs',
             'getSauceDriver',
+            'getScratchGuiLoadingState',
             'isSignedIn',
             'navigate',
             'signIn',
             'urlMatches',
+            'waitForScratchGuiLoadingState',
             'waitUntilDocumentReady',
             'waitUntilGone'
         ]);
@@ -177,6 +213,17 @@ class SeleniumHelper {
             this.driver.setFileDetector(new seleniumRemote.FileDetector());
         } else {
             this.driver = this.getDriver();
+        }
+        // Install the redux store-capture shim before any page navigation. If the driver
+        // doesn't support CDP (e.g. some Sauce configurations), the shim simply won't be
+        // installed and getScratchGuiLoadingState will return 'SHIM_NOT_INSTALLED'.
+        try {
+            await this.driver.sendDevToolsCommand('Page.addScriptToEvaluateOnNewDocument', {
+                source: REDUX_STORE_CAPTURE_SHIM
+            });
+        } catch (e) {
+            // CDP unavailable; getScratchGuiLoadingState will return 'SHIM_NOT_INSTALLED'
+            // and waitForScratchGuiLoadingState will resolve immediately.
         }
         return this.driver;
     }
@@ -532,6 +579,54 @@ class SeleniumHelper {
             await word.sendKeys(password + this.getKey('ENTER'));
             await this.waitUntilDocumentReady();
             await this.findByXpath(this.getPathForProfileName());
+        } catch (cause) {
+            throw await outerError.chain(cause, this.driver);
+        }
+    }
+
+    /**
+     * Read scratch-gui's redux loadingState from the captured store. Returns one of:
+     *   - 'SHIM_NOT_INSTALLED' — buildDriver couldn't install the dev-tools shim
+     *     (CDP unavailable, e.g. some Sauce configurations). Callers can treat this
+     *     as "fall back to behavior that doesn't depend on state introspection."
+     *   - null — shim is installed but no captured store contains a scratchGui slice yet.
+     *   - a loadingState string (e.g. 'SHOWING_WITH_ID').
+     * @returns {Promise<string|null>} See above.
+     */
+    getScratchGuiLoadingState () {
+        return this.driver.executeScript(`
+            if (typeof window.__capturedStores === 'undefined') return 'SHIM_NOT_INSTALLED';
+            for (var i = 0; i < window.__capturedStores.length; i++) {
+                var s = window.__capturedStores[i].getState();
+                if (s && s.scratchGui && s.scratchGui.projectState) {
+                    return s.scratchGui.projectState.loadingState;
+                }
+            }
+            return null;
+        `);
+    }
+
+    /**
+     * Wait until scratch-gui's redux loadingState is one of the provided values.
+     * Useful for synchronizing test actions with the editor's lifecycle — for example,
+     * waiting until SHOWING_WITH_ID before invoking File → Load.
+     *
+     * If the dev-tools shim wasn't installed (e.g. on a driver that doesn't expose CDP),
+     * this resolves immediately so tests don't hang on environments where state
+     * introspection isn't available; tests written with this in mind degrade gracefully
+     * to their pre-shim behavior.
+     * @param {Array<string>} validStates The acceptable loadingState values.
+     * @param {number} [timeout] Wait timeout in ms; defaults to {@link DEFAULT_TIMEOUT_MILLISECONDS}.
+     * @returns {Promise} Resolves when the loadingState matches; rejects on timeout.
+     */
+    async waitForScratchGuiLoadingState (validStates, timeout = DEFAULT_TIMEOUT_MILLISECONDS) {
+        const outerError = new SeleniumHelperError('waitForScratchGuiLoadingState failed', [{validStates}]);
+        try {
+            await this.driver.wait(async () => {
+                const ls = await this.getScratchGuiLoadingState();
+                if (ls === 'SHIM_NOT_INSTALLED') return true;
+                return validStates.includes(ls);
+            }, timeout);
         } catch (cause) {
             throw await outerError.chain(cause, this.driver);
         }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -1,11 +1,15 @@
 jest.setTimeout(30000); // eslint-disable-line no-undef
 
 const webdriver = require('selenium-webdriver');
+const chrome = require('selenium-webdriver/chrome');
 const {PageLoadStrategy} = require('selenium-webdriver/lib/capabilities');
 const seleniumRemote = require('selenium-webdriver/remote');
 const bindAll = require('lodash.bindall');
 
-const headless = process.env.SMOKE_HEADLESS || false;
+// Strict 'true' comparison (matching how SMOKE_REMOTE is used at its call site)
+// so that SMOKE_HEADLESS=false / SMOKE_HEADLESS=0 disable headless mode rather
+// than enabling it (any non-empty string is truthy).
+const headless = process.env.SMOKE_HEADLESS === 'true';
 const remote = process.env.SMOKE_REMOTE || false;
 const ciBuildPrefix = process.env.CI ?
     `CI #${process.env.GITHUB_RUN_ID}/${process.env.GITHUB_RUN_ATTEMPT}` :
@@ -183,18 +187,16 @@ class SeleniumHelper {
      * @returns {webdriver.ThenableWebDriver} The new webdriver instance.
      */
     getDriver () {
-        const chromeCapabilities = webdriver.Capabilities.chrome();
-        const args = [];
+        const options = new chrome.Options();
         if (headless) {
-            args.push('--headless');
-            args.push('window-size=1024,1680');
-            args.push('--no-sandbox');
+            options.addArguments('--headless=new');
+            options.addArguments('--window-size=1024,1680');
+            options.addArguments('--no-sandbox');
         }
-        chromeCapabilities.set('chromeOptions', {args});
-        chromeCapabilities.setPageLoadStrategy(PageLoadStrategy.EAGER);
+        options.setPageLoadStrategy(PageLoadStrategy.EAGER);
         const driver = new webdriver.Builder()
             .forBrowser('chrome')
-            .withCapabilities(chromeCapabilities)
+            .setChromeOptions(options)
             .build();
         return driver;
     }

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -2,6 +2,7 @@ jest.setTimeout(30000); // eslint-disable-line no-undef
 
 const webdriver = require('selenium-webdriver');
 const {PageLoadStrategy} = require('selenium-webdriver/lib/capabilities');
+const seleniumRemote = require('selenium-webdriver/remote');
 const bindAll = require('lodash.bindall');
 
 const headless = process.env.SMOKE_HEADLESS || false;
@@ -154,9 +155,9 @@ class SeleniumHelper {
      * Build a new webdriver instance. This will use Sauce Labs if the SMOKE_REMOTE environment variable is 'true', or
      * `chromedriver` otherwise.
      * @param {string} name The name to give to Sauce Labs.
-     * @returns {webdriver.ThenableWebDriver} The new webdriver instance.
+     * @returns {Promise<webdriver.ThenableWebDriver>} A promise resolving to the new webdriver instance.
      */
-    buildDriver (name) {
+    async buildDriver (name) {
         if (remote === 'true'){
             let nameToUse;
             if (ciBuildPrefix){
@@ -164,7 +165,12 @@ class SeleniumHelper {
             } else {
                 nameToUse = name;
             }
-            this.driver = this.getSauceDriver(SAUCE_USERNAME, SAUCE_ACCESS_KEY, nameToUse);
+            this.driver = await this.getSauceDriver(SAUCE_USERNAME, SAUCE_ACCESS_KEY, nameToUse);
+            // FileDetector lets sendKeys to a file input upload the local file to the remote
+            // browser host transparently, so tests can reference the local fixture path
+            // regardless of where the driver is running. Set after the session is established
+            // so the detector is attached to the resolved driver, not just the thenable.
+            this.driver.setFileDetector(new seleniumRemote.FileDetector());
         } else {
             this.driver = this.getDriver();
         }

--- a/test/integration/studios-page.test.js
+++ b/test/integration/studios-page.test.js
@@ -129,7 +129,7 @@ describe('studio management', () => {
         await navigate(curatorTab);
 
         // promote user3
-        const user3href = `/users/${username3}`;
+        const user3href = `/users/${username3}/`;
         // click kebab menu on the user tile
         const kebabMenuXpath = `//a[@href = "${user3href}"]/following-sibling::div[@class="overflow-menu-container"]`;
         await clickXpath(`${kebabMenuXpath}/button[@class="overflow-menu-trigger"]`);
@@ -152,7 +152,7 @@ describe('studio management', () => {
         await navigate(curatorTab);
 
         // open kebab menu
-        const user2href = `/users/${username2}`;
+        const user2href = `/users/${username2}/`;
         // click kebab menu on the user tile
         const kebabMenuXpath = `//a[@href = "${user2href}"]/following-sibling::div[@class="overflow-menu-container"]`;
         await clickXpath(`${kebabMenuXpath}/button[@class="overflow-menu-trigger"]`);


### PR DESCRIPTION
### Resolves

Follow-up to #10193. After the secrets fix landed, [the next master CI run](https://github.com/scratchfoundation/scratch-www/actions/runs/25168764610/job/73800091937) surfaced more failures in `Production Integration Tests`. This PR addresses them, plus a few related stability issues uncovered while investigating.

### Changes

**Selector and UI drift**
- `navbar.test.js`: remove About link checks (link moved to footer; covered by `footer-links.test.js`).
- `my-stuff.test.js`: remove the "Add To button" test (button removed from shared-tile UI).
- `studios-page.test.js`: include trailing slash in `/users/X/` for the promote-to-manager and transfer-host xpaths.

**Re-enabled tests with proper fixes**
- `project-page.test.js: load project from file` — replaced the stale GitHub-blob download with a local fixture plus selenium's `FileDetector`. Wraps File → Load → sendKeys in a retry loop to absorb a separate scratch-gui race (see workaround section).
- `project-page.test.js: Open Copy Link modal` — un-skipped after live-probing confirmed the modal still works.

**Skipped with documented reason**
- `my-stuff.test.js: New studio rate limited to five` — account-state issue (smoke account hits a daily creation cap). Skip comment explains.

**Helper additions**
- `selenium-helpers.js: findByXpathWithRefresh` — refresh-and-retry helper to absorb scratchr2's profile-comment cache lag (used by three comments tests).
- `selenium-helpers.js: waitForScratchGuiLoadingState` / `getScratchGuiLoadingState` — reads scratch-gui's redux loadingState via a dev-tools-compose shim installed via CDP `Page.addScriptToEvaluateOnNewDocument`. Used to gate File → Load on a stable editor state. Falls back gracefully (returns `SHIM_NOT_INSTALLED`) on drivers without CDP.

**Local headless**
- `selenium-helpers.js: getDriver` — switched from the deprecated `chromeOptions` capability key to `selenium-webdriver/chrome`'s `Options` API and `--headless=new`, so `SMOKE_HEADLESS=true` actually runs headless.

### Workaround for an upstream scratch-gui race

While investigating `load project from file`, I traced an `Uncaught TypeError: Cannot read properties of undefined (reading 'type')` to scratch-gui's `requestProjectUpload` action creator returning `undefined` when `loadingState` isn't NOT_LOADED, SHOWING_WITH_ID, or SHOWING_WITHOUT_ID. The reducer already gates on the same set, so the action creator's switch is the redundant layer that produces undefined and silently drops the upload.

The proper fix is one line in scratch-gui (drop the action creator's switch — the reducer already gates). This PR works around it test-side via `waitForScratchGuiLoadingState` plus a retry loop that confirms the dispatch advanced state to `LOADING_VM_FILE_UPLOAD` before declaring success. Each related comment links the workaround back to the upstream bug so the cleanup is signposted for later.

### Test Coverage

- `npm run test:lint` clean.
- Local `SMOKE_HEADLESS=true npx jest test/integration/project-page.test.js` — 15/15 pass.
- Sauce `SMOKE_REMOTE=true npx jest test/integration/project-page.test.js -t "project-creation"` — 3/3 pass; CDP-shim path probed and confirmed working through Sauce.
- Selectors live-probed against `https://scratch.mit.edu/` and `/mystuff/#shared` to confirm the navbar and Add To buttons are genuinely gone (not class-hash drift).

### Remaining failures

Three `comments.test.js` failures (`profile comment is on profile page`, `profile comment is highlighted`, `profile reply to comment`) are environmental — user5's profile has accumulated past scratchr2's profile-comment readability threshold and trips the "more than 40 pages of comments shouldn't be happening" wait-and-retry indicator beyond what the helper can absorb. Will be addressed separately (likely test-account cleanup).