### PR TITLE
redirect: Redirect Code of Ethics page to a freshdesk article

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -174,6 +174,11 @@
         "title": "Educators"
     },
     {
+        "name": "ethics-redirect", 
+        "pattern": "^/code-of-ethics/?$",
+        "redirect": "https://mitscratch.freshdesk.com/support/solutions/articles/..."  
+    },
+    {
         "name": "explore",
         "pattern": "^/explore/:projects(projects|studios)/:all/?$",
         "routeAlias": "/explore(?!/ajax)",

--- a/src/routes.json
+++ b/src/routes.json
@@ -174,13 +174,6 @@
         "title": "Educators"
     },
     {
-        "name": "ethics",
-        "pattern": "^/code-of-ethics/?$",
-        "routeAlias": "/code-of-ethics/?$",
-        "view": "ethics/ethics",
-        "title": "Research Code of Ethics"
-    },
-    {
         "name": "explore",
         "pattern": "^/explore/:projects(projects|studios)/:all/?$",
         "routeAlias": "/explore(?!/ajax)",


### PR DESCRIPTION
### Resolves:

https://github.com/scratchfoundation/scratch-www/issues/10196

### Changes:

Updates `routes.json` to make code-of-ethics a redirect to a future FreshDesk article Scratch Team has to make.

Or it can be removed if we do not need that page anymore.

### Test Coverage:

I can't get testing to work (not this isn't working, my machine fails to load www even without this change)