### PR TITLE
accessibility: refactor leftover $color.ui-orange to red

### DIFF
--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -148,7 +148,7 @@
                 top: .5rem;
                 right: .25rem;
                 border-radius: 1rem;
-                background-color: colors.$ui-orange;
+                background-color: colors.$ui-red-dark;
                 padding: 0 .25rem;
                 text-indent: 0;
                 line-height: 1rem;

--- a/src/views/preview/preview.scss
+++ b/src/views/preview/preview.scss
@@ -203,7 +203,7 @@ $stage-width: 480px;
         &.has-error {
             .inplace-input,
             .inplace-textarea {
-                border: 1px solid colors.$ui-orange;
+                border: 1px solid colors.$ui-red;
             }
         }
 

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -581,7 +581,7 @@ $radius: 8px;
     }
     &.studio-info-box-error {
         background: #FFF0DF;
-        border: 1px solid colors.$ui-dark-orange;
+        border: 1px solid colors.$ui-dark-red;
     }
 
     .studio-info-close-button {
@@ -659,7 +659,7 @@ $radius: 8px;
 }
 
 .mod-form-error { /* When a field contains a value is causing an error */
-    border-color: colors.$ui-orange !important;
+    border-color: colors.$ui-red !important;
 }
 
 .studio-curator-mute-box {

--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -581,7 +581,7 @@ $radius: 8px;
     }
     &.studio-info-box-error {
         background: #FFF0DF;
-        border: 1px solid colors.$ui-dark-red;
+        border: 1px solid colors.$ui-red-dark;
     }
 
     .studio-info-close-button {


### PR DESCRIPTION
### Resolves:

https://github.com/scratchfoundation/scratch-www/issues/7256

### Changes:

Updates `scss` to swap out `colors.$ui-orange;` with `colors.$ui-red-dark;` and `colors.$ui-red` as orange failed WCAG guidelines.

### Test Coverage:

Before with `colors.$ui-orange`:
<img width="921" height="692" alt="Screenshot 2026-05-01 4 53 47 PM (1)" src="https://github.com/user-attachments/assets/7db7ce22-345a-4f8c-ac61-9024beb25415" />

After with `colors.$ui-red-dark`:
<img width="816" height="684" alt="Screenshot 2026-05-01 4 54 49 PM (1)" src="https://github.com/user-attachments/assets/7ab446d1-f4a1-427b-a988-4ae8645b1b7d" />

Yes WCAG AAA fails but it is better than the current color. 

@cwillisf @adzhindzhi @KManolov3 