### PR TITLE
fix(deps): update to scratch-gui@13.7.4-svg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.7.2",
+        "@scratch/scratch-gui": "13.7.4-svg",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5168,18 +5168,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.7.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.7.2.tgz",
-      "integrity": "sha512-2MsIIqYY4koMkzAXeLq4lp7R6E11csiCJv59zDfC05mJ8cDWwWevOzV6Fozn81ZIL+1dQ7wzE3gjtqconFzuPA==",
+      "version": "13.7.4-svg",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.7.4-svg.tgz",
+      "integrity": "sha512-Z+O9u52uirbbyoZo+jGI8x0DgWrnoAXoQbYuzKU9TqQF9MfoPv9VGrxVtFqik0muEp38CO6otVe0/g5qFP3PEw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.7.2",
-        "@scratch/scratch-svg-renderer": "13.7.2",
-        "@scratch/scratch-vm": "13.7.2",
+        "@scratch/scratch-render": "13.7.4-svg",
+        "@scratch/scratch-svg-renderer": "13.7.4-svg",
+        "@scratch/scratch-vm": "13.7.4-svg",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5222,7 +5222,7 @@
         "react-intl": "6.8.9",
         "react-modal": "3.16.3",
         "react-popover": "0.5.10",
-        "react-redux": "8.1.3",
+        "react-redux": "^8.0.0",
         "react-responsive": "9.0.2",
         "react-style-proptype": "3.2.2",
         "react-tabs": "5.2.0",
@@ -5233,7 +5233,7 @@
         "scratch-audio": "2.0.268",
         "scratch-blocks": "2.1.19",
         "scratch-l10n": "6.1.72",
-        "scratch-paint": "4.1.50",
+        "scratch-paint": "4.1.52",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
         "startaudiocontext": "1.2.1",
@@ -5401,13 +5401,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.7.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.7.2.tgz",
-      "integrity": "sha512-lXOMZJ/D2JVe6KPRKWHd5fJBSGXLPe7eoBKs1yDLlBiEqw58f5oHnX/qit66J4N8WCYRqA3z0ATgAyHTfvjJgg==",
+      "version": "13.7.4-svg",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.7.4-svg.tgz",
+      "integrity": "sha512-1rGbxhjtHU9rsce5yg8wTZU3lOPVpZxcoL6/EWmUT6ZtJFsi9408rfL56uwOYrKZx5MsuKLsZgj6Lk2Ip19Isw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.7.2",
+        "@scratch/scratch-svg-renderer": "13.7.4-svg",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5427,9 +5427,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.7.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.2.tgz",
-      "integrity": "sha512-GgCRewlvKvhWY50+4RmsCnWf17opQmcGxEO7bykoWS9a+SVdhYC048aa4QbMK9/sDto/MmwHUc0wqAXXHB4G0g==",
+      "version": "13.7.4-svg",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.4-svg.tgz",
+      "integrity": "sha512-5txvuru7ux57yDwXmqg1l9Qn8XfRXbKxZpEaJE82Pgi92l2fShfxkGVh91o4Yw4fsyKsYp+i/1ge/wSzNVDmqw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5467,14 +5467,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.7.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.7.2.tgz",
-      "integrity": "sha512-1FvL3LgMXvkY0XEqTR01yFU6uA2F2YKHEwiGBZZkQJnRfEaj0MZXXKHF1iPZmMqEZhepfjRQa0XNEYtC8UOHOA==",
+      "version": "13.7.4-svg",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.7.4-svg.tgz",
+      "integrity": "sha512-KcsRyqCu1dDVfXsixyk/MYteDa9qpdC8edPDngnN2eBU9rsIryYFkhZfGlQ5cMvmaMIHPDQoYZbQeEU9TQ8o8w==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.7.2",
-        "@scratch/scratch-svg-renderer": "13.7.2",
+        "@scratch/scratch-render": "13.7.4-svg",
+        "@scratch/scratch-svg-renderer": "13.7.4-svg",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -10001,9 +10001,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10961,9 +10961,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -23435,13 +23435,14 @@
       }
     },
     "node_modules/scratch-paint": {
-      "version": "4.1.50",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.50.tgz",
-      "integrity": "sha512-K9kYFxGWYI2VF8+ACrUih6iEu8C3T++JHo8YhDqw84VfoN/h3W/Z+fGk8/kyrCUuutOr3u6VZY/w4CbjDBGCAw==",
+      "version": "4.1.52",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.52.tgz",
+      "integrity": "sha512-yPx3OqGEuqvhBfqfK2nfT0YUnnhzIL+A4JliaATEl8VQA+Nn/jC8LMk48/mXW8UVJjYsmejkTEjYY325aFyinQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@scratch/paper": "^0.11.20221201200345",
+        "@scratch/scratch-svg-renderer": "13.7.2",
         "classnames": "^2.2.5",
         "keymirror": "^0.1.1",
         "lodash.bindall": "^4.4.0",
@@ -23461,16 +23462,55 @@
         "react-style-proptype": "^3",
         "react-tooltip": "^4",
         "redux": "^4",
-        "scratch-render-fonts": "^1.0.0"
+        "scratch-render-fonts": "1.0.252"
+      }
+    },
+    "node_modules/scratch-paint/node_modules/@scratch/scratch-svg-renderer": {
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.2.tgz",
+      "integrity": "sha512-GgCRewlvKvhWY50+4RmsCnWf17opQmcGxEO7bykoWS9a+SVdhYC048aa4QbMK9/sDto/MmwHUc0wqAXXHB4G0g==",
+      "dev": true,
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "base64-loader": "1.0.0",
+        "css-tree": "3.2.1",
+        "fastestsmallesttextencoderdecoder": "1.0.22",
+        "isomorphic-dompurify": "2.36.0",
+        "transformation-matrix": "1.15.3",
+        "tslog": "4.10.2"
+      },
+      "peerDependencies": {
+        "scratch-render-fonts": "1.0.252"
+      }
+    },
+    "node_modules/scratch-paint/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/scratch-paint/node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/scratch-paint/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/scratch-paint/node_modules/microee": {
       "version": "0.0.6",
@@ -27565,22 +27605,22 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
-      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.29"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
-      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.7.2",
+    "@scratch/scratch-gui": "13.7.4-svg",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
### Changes:

Updates scratch-gui to [v13.7.4-svg](https://github.com/scratchfoundation/scratch-editor/releases/tag/v13.7.4-svg), which updates scratch-paint to [v4.1.52](https://github.com/scratchfoundation/scratch-paint/releases/tag/v4.1.52), which adds an SVG sanitization pass before loading an SVG into Paper.js for the paint editor.

Further SVG fixes are coming, but this is the quickest "right now" fix we could manage.

### Test Coverage:

See scratchfoundation/scratch-paint#3536
Also tested manually in staging