### PR TITLE
[UEPR-591] Exclude removed /educators and /educators-faq from the route alias

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -349,14 +349,14 @@
     {
         "name": "teacherregistration",
         "pattern": "^/educators/register/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
         "view": "teacherregistration/teacherregistration",
         "title": "Teacher Registration"
     },
     {
         "name": "teacherwaitingroom",
         "pattern": "^/educators/waiting",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
         "view": "teacherwaitingroom/teacherwaitingroom",
         "title": "Thank you for requesting a Scratch Teacher Account"
     },


### PR DESCRIPTION
### Resolves:

- Issues with [UEPR-591](https://scratchfoundation.atlassian.net/browse/UEPR-591) redirects

### Changes:

- Exclude removed `/educators` and `/educators/faq` pages from the route alias

[UEPR-591]: https://scratchfoundation.atlassian.net/browse/UEPR-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ