### PR TITLE
chore: Update scratch-gui version to accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.7.4-svg",
+        "@scratch/scratch-gui": "14.0.0-accessibility-improvements.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5186,18 +5186,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.7.4-svg",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.7.4-svg.tgz",
-      "integrity": "sha512-Z+O9u52uirbbyoZo+jGI8x0DgWrnoAXoQbYuzKU9TqQF9MfoPv9VGrxVtFqik0muEp38CO6otVe0/g5qFP3PEw==",
+      "version": "14.0.0-accessibility-improvements.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-14.0.0-accessibility-improvements.3.tgz",
+      "integrity": "sha512-g5bS3L+QMG1PXBqeOqFgzo0hhrAsirFXYPyTKwns2XxqR+jGX935zJzx19En7OwAgGqUNLJYnBEQMZNoDYADMg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.7.4-svg",
-        "@scratch/scratch-svg-renderer": "13.7.4-svg",
-        "@scratch/scratch-vm": "13.7.4-svg",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-vm": "14.0.0-accessibility-improvements.3",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5249,9 +5249,9 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.19",
-        "scratch-l10n": "6.1.72",
-        "scratch-paint": "4.1.52",
+        "scratch-blocks": "2.1.10",
+        "scratch-l10n": "6.1.68",
+        "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
         "startaudiocontext": "1.2.1",
@@ -5267,6 +5267,31 @@
         "react-dom": "^18.0.0",
         "react-redux": "^8.0.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/@transifex/api": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@transifex/api/-/api-7.1.5.tgz",
+      "integrity": "sha512-YJPJBD6sZ1ax1MGzv2Nta3W5lES2If8qSExlyshHSx85S8Hs3MglWHKjJcaUmbXsdGzscJ1qQYJaXAZq12zWvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "core-js": "^3.35.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/@transifex/api/node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/autoprefixer": {
@@ -5398,13 +5423,13 @@
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.72",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.72.tgz",
-      "integrity": "sha512-mpAdOT/JI25LwW8Q/mi+qzDxCnvcWOlYKaJQNxYwlpNko6IafKPSwGYKmmsePiBLzlcUWK2g73FN9WHeXT3UwQ==",
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.68.tgz",
+      "integrity": "sha512-mHYV66ARrMvswoNmKnEnhNG5QUPzzXvHLvuwZR4FcbEC8EKY9kg3cNnZjYNGjxiBqJGUYD+DJLSL2m9vSr50gg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@transifex/api": "7.1.6",
+        "@transifex/api": "7.1.5",
         "async": "3.2.6",
         "format-message-parse": "6.2.4",
         "glob": "7.2.3",
@@ -5419,13 +5444,13 @@
       }
     },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.7.4-svg",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.7.4-svg.tgz",
-      "integrity": "sha512-1rGbxhjtHU9rsce5yg8wTZU3lOPVpZxcoL6/EWmUT6ZtJFsi9408rfL56uwOYrKZx5MsuKLsZgj6Lk2Ip19Isw==",
+      "version": "14.0.0-accessibility-improvements.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-14.0.0-accessibility-improvements.3.tgz",
+      "integrity": "sha512-i5SzT6nqWzvzYwue09mH1I9DMOKgLnBBdZ+xnUgn9sUkG02fNG8PYDCUU4T7+yvv2yBqYuN2jf+BN5IefC36Gg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.7.4-svg",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5435,7 +5460,7 @@
         "twgl.js": "4.24.0"
       },
       "peerDependencies": {
-        "scratch-render-fonts": "1.0.252"
+        "scratch-render-fonts": "^1.0.0"
       }
     },
     "node_modules/@scratch/scratch-render/node_modules/raw-loader": {
@@ -5445,9 +5470,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.7.4-svg",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.4-svg.tgz",
-      "integrity": "sha512-5txvuru7ux57yDwXmqg1l9Qn8XfRXbKxZpEaJE82Pgi92l2fShfxkGVh91o4Yw4fsyKsYp+i/1ge/wSzNVDmqw==",
+      "version": "14.0.0-accessibility-improvements.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-14.0.0-accessibility-improvements.3.tgz",
+      "integrity": "sha512-7Rxu6K7+xFAwYvW34u1y/p/sWLU1DG9DudpmEnsYOSuxNmG04jpzs0htOBWHIMcy9lILUYyVPRsZQ57ew+l4Pw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5460,7 +5485,7 @@
         "tslog": "4.10.2"
       },
       "peerDependencies": {
-        "scratch-render-fonts": "1.0.252"
+        "scratch-render-fonts": "^1.0.0"
       }
     },
     "node_modules/@scratch/scratch-svg-renderer/node_modules/css-tree": {
@@ -5485,14 +5510,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.7.4-svg",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.7.4-svg.tgz",
-      "integrity": "sha512-KcsRyqCu1dDVfXsixyk/MYteDa9qpdC8edPDngnN2eBU9rsIryYFkhZfGlQ5cMvmaMIHPDQoYZbQeEU9TQ8o8w==",
+      "version": "14.0.0-accessibility-improvements.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-14.0.0-accessibility-improvements.3.tgz",
+      "integrity": "sha512-1CD5gfRd6wXpOwxr/TZJr2YOZ0XrSyVo/aPkJu5wsxEUX9Auhw1XIOCyjkCoBMC7RV5lTBtJ9uSn/H2y/o9SNA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.7.4-svg",
-        "@scratch/scratch-svg-renderer": "13.7.4-svg",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -10979,9 +11004,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -23382,9 +23407,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.19.tgz",
-      "integrity": "sha512-FgRoGhUkiGEmjblwmd5k+0HPlonoXkk1arwnnZBcSE05MKoZjWiP/ksHCfCcr2w/qqYQBrCynBk6flmwkcsUnA==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.10.tgz",
+      "integrity": "sha512-PgzTINYAd0KT3bAxShiGeQOJ/9sWpUc6kJN8J2MicSShk/6fXNhwUZEaDIykzNKLLHetFy5Q43HJTeGajSqxmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23453,14 +23478,13 @@
       }
     },
     "node_modules/scratch-paint": {
-      "version": "4.1.52",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.52.tgz",
-      "integrity": "sha512-yPx3OqGEuqvhBfqfK2nfT0YUnnhzIL+A4JliaATEl8VQA+Nn/jC8LMk48/mXW8UVJjYsmejkTEjYY325aFyinQ==",
+      "version": "4.1.50",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.50.tgz",
+      "integrity": "sha512-K9kYFxGWYI2VF8+ACrUih6iEu8C3T++JHo8YhDqw84VfoN/h3W/Z+fGk8/kyrCUuutOr3u6VZY/w4CbjDBGCAw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@scratch/paper": "^0.11.20221201200345",
-        "@scratch/scratch-svg-renderer": "13.7.2",
         "classnames": "^2.2.5",
         "keymirror": "^0.1.1",
         "lodash.bindall": "^4.4.0",
@@ -23480,40 +23504,7 @@
         "react-style-proptype": "^3",
         "react-tooltip": "^4",
         "redux": "^4",
-        "scratch-render-fonts": "1.0.252"
-      }
-    },
-    "node_modules/scratch-paint/node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.7.2",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.2.tgz",
-      "integrity": "sha512-GgCRewlvKvhWY50+4RmsCnWf17opQmcGxEO7bykoWS9a+SVdhYC048aa4QbMK9/sDto/MmwHUc0wqAXXHB4G0g==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "base64-js": "1.5.1",
-        "base64-loader": "1.0.0",
-        "css-tree": "3.2.1",
-        "fastestsmallesttextencoderdecoder": "1.0.22",
-        "isomorphic-dompurify": "2.36.0",
-        "transformation-matrix": "1.15.3",
-        "tslog": "4.10.2"
-      },
-      "peerDependencies": {
-        "scratch-render-fonts": "1.0.252"
-      }
-    },
-    "node_modules/scratch-paint/node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+        "scratch-render-fonts": "^1.0.0"
       }
     },
     "node_modules/scratch-paint/node_modules/lodash.omit": {
@@ -23522,13 +23513,6 @@
       "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/scratch-paint/node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/scratch-paint/node_modules/microee": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-gui": "14.0.0-accessibility-improvements.4",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5186,18 +5186,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "14.0.0-accessibility-improvements.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-14.0.0-accessibility-improvements.3.tgz",
-      "integrity": "sha512-g5bS3L+QMG1PXBqeOqFgzo0hhrAsirFXYPyTKwns2XxqR+jGX935zJzx19En7OwAgGqUNLJYnBEQMZNoDYADMg==",
+      "version": "14.0.0-accessibility-improvements.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-14.0.0-accessibility-improvements.4.tgz",
+      "integrity": "sha512-PwFpO25awf+v31I2BFJy0+Xv+aUPLGIh+RYDP/di48wq6NGuqNVXBbtc9uguNtWz3JMF/esmTBpao8ExBxAkrQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "14.0.0-accessibility-improvements.3",
-        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
-        "@scratch/scratch-vm": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.4",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.4",
+        "@scratch/scratch-vm": "14.0.0-accessibility-improvements.4",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -5249,9 +5249,9 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.10",
-        "scratch-l10n": "6.1.68",
-        "scratch-paint": "4.1.50",
+        "scratch-blocks": "2.1.19",
+        "scratch-l10n": "6.1.75",
+        "scratch-paint": "4.1.54",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
         "startaudiocontext": "1.2.1",
@@ -5267,31 +5267,6 @@
         "react-dom": "^18.0.0",
         "react-redux": "^8.0.0",
         "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/@transifex/api": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@transifex/api/-/api-7.1.5.tgz",
-      "integrity": "sha512-YJPJBD6sZ1ax1MGzv2Nta3W5lES2If8qSExlyshHSx85S8Hs3MglWHKjJcaUmbXsdGzscJ1qQYJaXAZq12zWvg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "core-js": "^3.35.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/@transifex/api/node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@scratch/scratch-gui/node_modules/autoprefixer": {
@@ -5337,50 +5312,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/@scratch/scratch-gui/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@scratch/scratch-gui/node_modules/lodash.omit": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
       "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@scratch/scratch-gui/node_modules/picocolors": {
       "version": "0.2.1",
@@ -5422,35 +5359,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.68",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.68.tgz",
-      "integrity": "sha512-mHYV66ARrMvswoNmKnEnhNG5QUPzzXvHLvuwZR4FcbEC8EKY9kg3cNnZjYNGjxiBqJGUYD+DJLSL2m9vSr50gg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@transifex/api": "7.1.5",
-        "async": "3.2.6",
-        "format-message-parse": "6.2.4",
-        "glob": "7.2.3",
-        "lodash.defaultsdeep": "4.6.1",
-        "mkdirp": "3.0.1",
-        "transifex": "1.6.6",
-        "tsx": "4.21.0"
-      },
-      "bin": {
-        "build-i18n-src": "scripts/build-i18n-src.mts",
-        "tx-push-src": "scripts/tx-push-src.mts"
-      }
-    },
     "node_modules/@scratch/scratch-render": {
-      "version": "14.0.0-accessibility-improvements.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-14.0.0-accessibility-improvements.3.tgz",
-      "integrity": "sha512-i5SzT6nqWzvzYwue09mH1I9DMOKgLnBBdZ+xnUgn9sUkG02fNG8PYDCUU4T7+yvv2yBqYuN2jf+BN5IefC36Gg==",
+      "version": "14.0.0-accessibility-improvements.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-14.0.0-accessibility-improvements.4.tgz",
+      "integrity": "sha512-s9Rcls1W8KO3/JbibqFisOu84PX2FaDcmlO1cIQNfzXi916LPHizLoI703MNrBcsWvFaP26qSUrgjrfExFrjLg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.4",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5460,7 +5376,7 @@
         "twgl.js": "4.24.0"
       },
       "peerDependencies": {
-        "scratch-render-fonts": "^1.0.0"
+        "scratch-render-fonts": "1.0.252"
       }
     },
     "node_modules/@scratch/scratch-render/node_modules/raw-loader": {
@@ -5470,9 +5386,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "14.0.0-accessibility-improvements.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-14.0.0-accessibility-improvements.3.tgz",
-      "integrity": "sha512-7Rxu6K7+xFAwYvW34u1y/p/sWLU1DG9DudpmEnsYOSuxNmG04jpzs0htOBWHIMcy9lILUYyVPRsZQ57ew+l4Pw==",
+      "version": "14.0.0-accessibility-improvements.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-14.0.0-accessibility-improvements.4.tgz",
+      "integrity": "sha512-dsiiRPMYfnsDMD4uit7dmxUZShSCXtb4F8pQw2KVJRiFK09yti+zkMi3doJbYFAQPL74HIwMkt5MIL/6gW6Xxg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5485,7 +5401,7 @@
         "tslog": "4.10.2"
       },
       "peerDependencies": {
-        "scratch-render-fonts": "^1.0.0"
+        "scratch-render-fonts": "1.0.252"
       }
     },
     "node_modules/@scratch/scratch-svg-renderer/node_modules/css-tree": {
@@ -5510,14 +5426,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "14.0.0-accessibility-improvements.3",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-14.0.0-accessibility-improvements.3.tgz",
-      "integrity": "sha512-1CD5gfRd6wXpOwxr/TZJr2YOZ0XrSyVo/aPkJu5wsxEUX9Auhw1XIOCyjkCoBMC7RV5lTBtJ9uSn/H2y/o9SNA==",
+      "version": "14.0.0-accessibility-improvements.4",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-14.0.0-accessibility-improvements.4.tgz",
+      "integrity": "sha512-9JpbBM6iW8UhDc5fuPiwuvxaOyiY8T50+InOID3Na6NX97c0UhIcEVVUQUonoLf7kERYU3xdBvAC23HJDMoK7Q==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "14.0.0-accessibility-improvements.3",
-        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.3",
+        "@scratch/scratch-render": "14.0.0-accessibility-improvements.4",
+        "@scratch/scratch-svg-renderer": "14.0.0-accessibility-improvements.4",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -23407,9 +23323,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.10.tgz",
-      "integrity": "sha512-PgzTINYAd0KT3bAxShiGeQOJ/9sWpUc6kJN8J2MicSShk/6fXNhwUZEaDIykzNKLLHetFy5Q43HJTeGajSqxmg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.19.tgz",
+      "integrity": "sha512-FgRoGhUkiGEmjblwmd5k+0HPlonoXkk1arwnnZBcSE05MKoZjWiP/ksHCfCcr2w/qqYQBrCynBk6flmwkcsUnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23478,13 +23394,14 @@
       }
     },
     "node_modules/scratch-paint": {
-      "version": "4.1.50",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.50.tgz",
-      "integrity": "sha512-K9kYFxGWYI2VF8+ACrUih6iEu8C3T++JHo8YhDqw84VfoN/h3W/Z+fGk8/kyrCUuutOr3u6VZY/w4CbjDBGCAw==",
+      "version": "4.1.54",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.1.54.tgz",
+      "integrity": "sha512-j+sQ05i9zcb+I7PhtGPzL82ASM1C7zU0oBl/DzBTI121w1DPs9jpHw5nEj5pjwd1ldL7dM+FV7XQZ1i73HDVCg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@scratch/paper": "^0.11.20221201200345",
+        "@scratch/scratch-svg-renderer": "13.7.3",
         "classnames": "^2.2.5",
         "keymirror": "^0.1.1",
         "lodash.bindall": "^4.4.0",
@@ -23504,7 +23421,40 @@
         "react-style-proptype": "^3",
         "react-tooltip": "^4",
         "redux": "^4",
-        "scratch-render-fonts": "^1.0.0"
+        "scratch-render-fonts": "1.0.252"
+      }
+    },
+    "node_modules/scratch-paint/node_modules/@scratch/scratch-svg-renderer": {
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.7.3.tgz",
+      "integrity": "sha512-fjkChA7yZBDjakOXTALR55ID0ht6BfwCEi4URn4dX64o4In9W6RXmfBFxO+fu78T4eaHGrtBfFo5zVIYWn0XDQ==",
+      "dev": true,
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "base64-loader": "1.0.0",
+        "css-tree": "3.2.1",
+        "fastestsmallesttextencoderdecoder": "1.0.22",
+        "isomorphic-dompurify": "2.36.0",
+        "transformation-matrix": "1.15.3",
+        "tslog": "4.10.2"
+      },
+      "peerDependencies": {
+        "scratch-render-fonts": "1.0.252"
+      }
+    },
+    "node_modules/scratch-paint/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/scratch-paint/node_modules/lodash.omit": {
@@ -23513,6 +23463,13 @@
       "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/scratch-paint/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/scratch-paint/node_modules/microee": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "14.0.0-accessibility-improvements.3",
+    "@scratch/scratch-gui": "14.0.0-accessibility-improvements.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.7.4-svg",
+    "@scratch/scratch-gui": "14.0.0-accessibility-improvements.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Update scratch-gui verison to `v14.0.0-accessibility-improvements.4`