### PR TITLE
Only show student account banner if the user is a student

### DIFF
--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -9,6 +9,7 @@ const ErrorBoundary = require('../../errorboundary/errorboundary.jsx');
 const PrivacyBanner = require('../../privacy-banner/privacy-banner.jsx');
 const TosModal = require('../../modal/tos/modal.jsx');
 const ParentalConsentView = require('../../../views/parental-consent/parental-consent-view.jsx');
+const StudentDeactivationBanner = require('../../student-deactivation-banner/student-deactivation-banner.jsx');
 const ALLOWED_PAGES = ['community_guidelines','contact_us'];
 const today = new Date();
 const semi = today.getDate() === 1 && today.getMonth() === 3;
@@ -43,6 +44,8 @@ const Page = ({
         !user.acceptedTermsOfService &&
         !isAllowedPage &&
         !shouldDisplayTosModal;
+
+    const shouldDisplayStudentDeactivationBanner = !!(user.isStudent && user);
     
     return (
         <ErrorBoundary componentName="Page">

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -9,8 +9,7 @@ const ErrorBoundary = require('../../errorboundary/errorboundary.jsx');
 const PrivacyBanner = require('../../privacy-banner/privacy-banner.jsx');
 const TosModal = require('../../modal/tos/modal.jsx');
 const ParentalConsentView = require('../../../views/parental-consent/parental-consent-view.jsx');
-const ALLOWED_PAGES = ['community_guidelines'];
-const StudentDeactivationBanner = require('../../student-deactivation-banner/student-deactivation-banner.jsx');
+const ALLOWED_PAGES = ['community_guidelines','contact_us'];
 const today = new Date();
 const semi = today.getDate() === 1 && today.getMonth() === 3;
 
@@ -44,8 +43,6 @@ const Page = ({
         !user.acceptedTermsOfService &&
         !isAllowedPage &&
         !shouldDisplayTosModal;
-
-    const shouldDisplayStudentDeactivationBanner = !!user;
     
     return (
         <ErrorBoundary componentName="Page">

--- a/src/components/page/www/page.jsx
+++ b/src/components/page/www/page.jsx
@@ -10,7 +10,7 @@ const PrivacyBanner = require('../../privacy-banner/privacy-banner.jsx');
 const TosModal = require('../../modal/tos/modal.jsx');
 const ParentalConsentView = require('../../../views/parental-consent/parental-consent-view.jsx');
 const StudentDeactivationBanner = require('../../student-deactivation-banner/student-deactivation-banner.jsx');
-const ALLOWED_PAGES = ['community_guidelines','contact_us'];
+const ALLOWED_PAGES = ['community_guidelines', 'contact_us'];
 const today = new Date();
 const semi = today.getDate() === 1 && today.getMonth() === 3;
 

--- a/src/components/student-deactivation-banner/student-deactivation-banner.jsx
+++ b/src/components/student-deactivation-banner/student-deactivation-banner.jsx
@@ -1,4 +1,4 @@
-/* const React = require('react');
+const React = require('react');
 const {useState, useCallback} = React;
 const PropTypes = require('prop-types');
 const {FormattedMessage, useIntl} = require('react-intl');
@@ -68,4 +68,4 @@ StudentDeactivationBanner.propTypes = {
     username: PropTypes.string
 };
 
-module.exports = StudentDeactivationBanner; */
+module.exports = StudentDeactivationBanner;

--- a/src/components/student-deactivation-banner/student-deactivation-banner.jsx
+++ b/src/components/student-deactivation-banner/student-deactivation-banner.jsx
@@ -1,4 +1,4 @@
-const React = require('react');
+/* const React = require('react');
 const {useState, useCallback} = React;
 const PropTypes = require('prop-types');
 const {FormattedMessage, useIntl} = require('react-intl');
@@ -68,4 +68,4 @@ StudentDeactivationBanner.propTypes = {
     username: PropTypes.string
 };
 
-module.exports = StudentDeactivationBanner;
+module.exports = StudentDeactivationBanner; */


### PR DESCRIPTION
### Resolves:

[Issue](https://scratch.mit.edu/discuss/post/9178648/)

### Changes:

Adds a check to fetch `session` to grab `.isStudent` to show the banner.

A side note, `contact_us` is added to `ALLOWED_PAGES` for blocked users to contact the Scratch Team.
