### PR TITLE
fix: Fix text-wrap on Community Guidelines page

### DIFF
--- a/src/views/guidelines/guidelines.scss
+++ b/src/views/guidelines/guidelines.scss
@@ -47,7 +47,7 @@
         justify-content: center;
         gap: 4.5rem;
         margin: 6rem 0 0 0;
-        padding: 0 15%;
+        padding: 0 10%;
         box-sizing: border-box;
         padding-bottom: 6rem;
 


### PR DESCRIPTION
### Resolves:
[Issue](https://github.com/scratchfoundation/scratch-www/pull/10151)

### Changes:

Changes `padding` from `0 15%` to `0 10%`.
This should hopefully fix it from the last PR where it added a text wrap to it.

### Test Coverage:

<img width="1366" height="768" alt="Screenshot 2026-05-19 10 10 52 PM" src="https://github.com/user-attachments/assets/bd3e2571-4a04-4de4-8cef-de888de641bb" />
