### PR TITLE
feat: add about back into navigation

### DIFF
--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -125,7 +125,7 @@ class Navigation extends React.Component {
                         </a>
                     </li>
                     <li className="link about">
-                        <a href="{externalLinks.scratchFoundation.homepage}">
+                        <a href={externalLinks.scratchFoundation.homepage}>
                             <FormattedMessage id="general.about" />
                         </a>
                     </li>

--- a/src/components/navigation/www/navigation.jsx
+++ b/src/components/navigation/www/navigation.jsx
@@ -19,6 +19,7 @@ const CanceledDeletionModal = require('../../login/canceled-deletion-modal.jsx')
 const NavigationBox = require('../base/navigation.jsx');
 const Registration = require('../../registration/registration.jsx');
 const AccountNav = require('./accountnav.jsx');
+const externalLinks = require('../../../lib/external-links.js');
 
 require('./navigation.scss');
 
@@ -121,6 +122,11 @@ class Navigation extends React.Component {
                     <li className="link ideas">
                         <a href="/ideas">
                             <FormattedMessage id="general.ideas" />
+                        </a>
+                    </li>
+                    <li className="link about">
+                        <a href="{externalLinks.scratchFoundation.homepage}">
+                            <FormattedMessage id="general.about" />
                         </a>
                     </li>
                     <li className="search">


### PR DESCRIPTION
### Resolves:

[PR
](https://github.com/scratchfoundation/scratch-www/pull/10226) ( @KManolov3 )

&

[Suggestion on Scratch](https://scratch.mit.edu/discuss/topic/887389/?page=1#post-9217985)

### Changes:

imports externalLinks for the header to add back about. The about link should redirect to https://scratchfoundation.org

### Test Coverage:

Should work.