### PR TITLE
Fix eslint-plugin-json v2+ breaking change: require config in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-    extends: ['scratch', 'scratch/node', 'scratch/es6'],
+    extends: ['scratch', 'scratch/node', 'scratch/es6', 'plugin:json/recommended'],
     plugins: ['json']
 };


### PR DESCRIPTION
The eslint-plugin-json v2+ changed how it is configured. Previously it automatically applied its rules when added as a plugin, but now you must explicitly set the 'json/*' rules or extend 'plugin:json/recommended'. Without this, the plugin does nothing, and JSON files are not linted. The fix adds `extends: ['plugin:json/recommended']` to the root .eslintrc.js (where JSON linting is intended) and adds the 'json' plugin in the correct place.