### PR TITLE
Chore: Revert educators route redirects

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -349,14 +349,14 @@
     {
         "name": "teacherregistration",
         "pattern": "^/educators/register/?(\\?.*)?$",
-        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
+        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
         "view": "teacherregistration/teacherregistration",
         "title": "Teacher Registration"
     },
     {
         "name": "teacherwaitingroom",
         "pattern": "^/educators/waiting",
-        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
+        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
         "view": "teacherwaitingroom/teacherwaitingroom",
         "title": "Thank you for requesting a Scratch Teacher Account"
     },

--- a/src/routes.json
+++ b/src/routes.json
@@ -167,6 +167,13 @@
         "title": "Scratch Offline Editor"
     },
     {
+        "name": "educator-landing",
+        "pattern": "^/educators/?(\\?.*)?$",
+        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "view": "teachers/landing/landing",
+        "title": "Educators"
+    },
+    {
         "name": "ethics",
         "pattern": "^/code-of-ethics/?$",
         "routeAlias": "/code-of-ethics/?$",
@@ -345,6 +352,13 @@
         "view": "studio/studio",
         "title": "Scratch Studio",
         "dynamicMetaTags": true
+    },
+    {
+        "name": "teacher-faq",
+        "pattern": "^/educators/faq/?(\\?.*)?$",
+        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "view": "teachers/faq/faq",
+        "title": "Teacher Accounts FAQ"
     },
     {
         "name": "teacherregistration",


### PR DESCRIPTION
### Resolves:

- Exclude changes that are not meant to be released from develop

### Changes:

- Revert commit https://github.com/scratchfoundation/scratch-www/commit/393bd49af611489854f778ab5d636a8b687c3b01.
- Revert commit https://github.com/scratchfoundation/scratch-www/commit/cba91668611242f086424eebb0febd97bd7d1cf2.