### PR TITLE
chore: Update scratch-gui version to v14.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.6",
         "@formatjs/intl-pluralrules": "5.4.6",
         "@formatjs/intl-relativetimeformat": "11.4.13",
-        "@scratch/scratch-gui": "13.8.0-UEPR-297-accessibility-improvements.1",
+        "@scratch/scratch-gui": "14.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4778,18 +4778,18 @@
       }
     },
     "node_modules/@scratch/scratch-gui": {
-      "version": "13.8.0-UEPR-297-accessibility-improvements.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-13.8.0-UEPR-297-accessibility-improvements.1.tgz",
-      "integrity": "sha512-i47EIXYHizk2wQWge/sQlyw4IhJgZBaQjxnAWn4789KIYb6AgTqz3zr0cYFqCkPtUSEc75+TJTl6sXdhfkUUhQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-14.0.0.tgz",
+      "integrity": "sha512-DIdpKtLOdhvkUw2FVLCqeT/D97b5RSo84X0nuwCHNTw0QmzNZz3yf54tl6oi/pkTASxIc95FDTGEtH2smQlgSw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/face_detection": "0.4.1646425229",
         "@microbit/microbit-universal-hex": "0.2.2",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "13.8.0-UEPR-297-accessibility-improvements.1",
-        "@scratch/scratch-svg-renderer": "13.8.0-UEPR-297-accessibility-improvements.1",
-        "@scratch/scratch-vm": "13.8.0-UEPR-297-accessibility-improvements.1",
+        "@scratch/scratch-render": "14.0.0",
+        "@scratch/scratch-svg-renderer": "14.0.0",
+        "@scratch/scratch-vm": "14.0.0",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -4842,8 +4842,8 @@
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
         "scratch-blocks": "2.1.19",
-        "scratch-l10n": "6.1.81",
-        "scratch-paint": "4.2.2",
+        "scratch-l10n": "6.1.84",
+        "scratch-paint": "4.2.3",
         "scratch-render-fonts": "1.0.252",
         "scratch-storage": "6.2.1",
         "startaudiocontext": "1.2.1",
@@ -4904,50 +4904,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/@scratch/scratch-gui/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@scratch/scratch-gui/node_modules/lodash.omit": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
       "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scratch/scratch-gui/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@scratch/scratch-gui/node_modules/picocolors": {
       "version": "0.2.1",
@@ -4989,35 +4951,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
-      "version": "6.1.81",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-6.1.81.tgz",
-      "integrity": "sha512-lUKfKfLf27uZTcvyhb9clkHwitEqM+yhO41sna1pmgSRr91jivPRhEfs3uBO5bVqSWTlwOUWNyU+ShQ1BCQ47Q==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@transifex/api": "7.1.6",
-        "async": "3.2.6",
-        "format-message-parse": "6.2.4",
-        "glob": "7.2.3",
-        "lodash.defaultsdeep": "4.6.1",
-        "mkdirp": "3.0.1",
-        "transifex": "1.6.6",
-        "tsx": "4.22.2"
-      },
-      "bin": {
-        "build-i18n-src": "scripts/build-i18n-src.mts",
-        "tx-push-src": "scripts/tx-push-src.mts"
-      }
-    },
     "node_modules/@scratch/scratch-render": {
-      "version": "13.8.0-UEPR-297-accessibility-improvements.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-13.8.0-UEPR-297-accessibility-improvements.1.tgz",
-      "integrity": "sha512-frCSdj6hOblC6fzYAkVJ9/sSdcxF9yFtOapkJ3YlqTM35xHoxh1reXqjdhSMb4pMxuRSzdiIYCsDwJnTQtrvOQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-14.0.0.tgz",
+      "integrity": "sha512-Xx8dumUB3Q3dMIG8GOvSu1w55HrJDHmgCm8JoTpuAf9VanlEbZHplqso+BXO8/V4YNJLtFIM1djLgN7JENFGpg==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "13.8.0-UEPR-297-accessibility-improvements.1",
+        "@scratch/scratch-svg-renderer": "14.0.0",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -5037,9 +4978,9 @@
       "dev": true
     },
     "node_modules/@scratch/scratch-svg-renderer": {
-      "version": "13.8.0-UEPR-297-accessibility-improvements.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-13.8.0-UEPR-297-accessibility-improvements.1.tgz",
-      "integrity": "sha512-9hK7v50jorZlQw6oEcc2q6BG0bGfbByXhwyBvzhSkIjyRQty0IXaY4bqIVEWEXo7fY88IchmZTHdA9+uhtygTQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-14.0.0.tgz",
+      "integrity": "sha512-E/OExhMOvPiAnG/TTmyN5xkxQ4wsUaS1HGb40HjLInYNMV/naBeDiXB7nZ2J3SS1+z8CTu0Dnpa/x/s6DTh2cA==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -5077,14 +5018,14 @@
       "license": "CC0-1.0"
     },
     "node_modules/@scratch/scratch-vm": {
-      "version": "13.8.0-UEPR-297-accessibility-improvements.1",
-      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-13.8.0-UEPR-297-accessibility-improvements.1.tgz",
-      "integrity": "sha512-8AqnYfIlGIuJjXZKhJxz2sEouu3gtZo2GFut/SFwsgmNNNEvzAwRVNTHO8aH0YfBx2gREtWdpW685+yq9epcdg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-14.0.0.tgz",
+      "integrity": "sha512-XDdFe8MLkO+ATv/78rrKHHrqtQLJp6bHMpBJ5ShYcYyFnjiOFkJqX0G92eWX2WoJMCo2ijXtOmBcotPAV3dOKQ==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "13.8.0-UEPR-297-accessibility-improvements.1",
-        "@scratch/scratch-svg-renderer": "13.8.0-UEPR-297-accessibility-improvements.1",
+        "@scratch/scratch-render": "14.0.0",
+        "@scratch/scratch-svg-renderer": "14.0.0",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",
@@ -9618,9 +9559,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10578,9 +10519,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
-      "integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -23529,9 +23470,9 @@
       }
     },
     "node_modules/scratch-paint": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.2.2.tgz",
-      "integrity": "sha512-iWPGfTnAnx6LrvNzr6/H+IKReGnCR/cQw0ObSrqqfl6MGPAkYcExoCPQ3ZDXhht/y4J+ZOQjZF0v4apyjwsXCQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-4.2.3.tgz",
+      "integrity": "sha512-fO7wG+iXYcL4MtnbPRS6R9geR+Nz43lDi/hosa8D4qMkSeTNta2t5Gg2fcYxZcpGaTJ74N1E7Nuw1MOS3outTw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -27726,22 +27667,22 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
-      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.0"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
-      "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
       "license": "MIT"
     },
@@ -28069,25 +28010,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
-      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.28.0"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@formatjs/intl-numberformat": "8.15.6",
     "@formatjs/intl-pluralrules": "5.4.6",
     "@formatjs/intl-relativetimeformat": "11.4.13",
-    "@scratch/scratch-gui": "13.8.0-UEPR-297-accessibility-improvements.1",
+    "@scratch/scratch-gui": "14.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Update `scratch-gui` version to the latest stable version - `v14.0.0`, which includes the accessibility improvements changes