### PR TITLE
feat(accessibility): Add alt-text to images in Ideas

### DIFF
--- a/src/views/ideas/ideas.jsx
+++ b/src/views/ideas/ideas.jsx
@@ -272,9 +272,9 @@ const Ideas = ({
             <div className="youtube-videos">
                 <div className="inner">
                     <div className="section-header">
-                        <img 
-                            src="/images/ideas/youtube-icon.svg" 
-                            alt="ideas.youTubeImgDescription" 
+                        <img
+                            src="/images/ideas/youtube-icon.svg"
+                            alt="ideas.youTubeImgDescription"
                         />
                         <div>
                             <div className="section-title">

--- a/src/views/ideas/ideas.jsx
+++ b/src/views/ideas/ideas.jsx
@@ -272,8 +272,9 @@ const Ideas = ({
             <div className="youtube-videos">
                 <div className="inner">
                     <div className="section-header">
-                        <img src="/images/ideas/youtube-icon.svg" 
-                             alt="ideas.youTubeImgDescription" 
+                        <img 
+                            src="/images/ideas/youtube-icon.svg" 
+                            alt="ideas.youTubeImgDescription" 
                         />
                         <div>
                             <div className="section-title">

--- a/src/views/ideas/ideas.jsx
+++ b/src/views/ideas/ideas.jsx
@@ -272,7 +272,9 @@ const Ideas = ({
             <div className="youtube-videos">
                 <div className="inner">
                     <div className="section-header">
-                        <img src="/images/ideas/youtube-icon.svg" alt="ideas.youTubeImgDescription" />
+                        <img src="/images/ideas/youtube-icon.svg" 
+                             alt="ideas.youTubeImgDescription" 
+                        />
                         <div>
                             <div className="section-title">
                                 <FormattedMessage id="ideas.scratchYouTubeChannel" />

--- a/src/views/ideas/ideas.jsx
+++ b/src/views/ideas/ideas.jsx
@@ -82,6 +82,7 @@ const tipsSectionData = [
 const physicalIdeasData = [
     {
         physicalIdeasImage: {
+            altTextId: 'ideas.physicalIdeasMicroImageDescription',
             imageSrc: '/images/ideas/micro-bit.png',
             imageClass: 'micro-bit'
         },
@@ -95,6 +96,7 @@ const physicalIdeasData = [
     },
     {
         physicalIdeasImage: {
+            altTextId: 'ideas.physicalIdeasMakeyImageDescription',
             imageSrc: '/images/ideas/make-board.svg',
             imageClass: 'makey-makey-img'
         },
@@ -270,7 +272,7 @@ const Ideas = ({
             <div className="youtube-videos">
                 <div className="inner">
                     <div className="section-header">
-                        <img src="/images/ideas/youtube-icon.svg" />
+                        <img src="/images/ideas/youtube-icon.svg" alt="ideas.youTubeImgDescription" />
                         <div>
                             <div className="section-title">
                                 <FormattedMessage id="ideas.scratchYouTubeChannel" />
@@ -341,6 +343,7 @@ const Ideas = ({
                                 <img
                                     src={physicalIdea.physicalIdeasImage.imageSrc}
                                     className={physicalIdea.physicalIdeasImage.imageClass}
+                                    alt={physicalIdea.physicalIdeasImage.altTextId}
                                 />
                                 <div className="physical-idea-description">
                                     <h3>

--- a/src/views/ideas/l10n.json
+++ b/src/views/ideas/l10n.json
@@ -68,5 +68,8 @@
     "ideas.modalCardNameCustomBlocks": "Make Your Custom My Blocks",
     "ideas.modalCardNameFaceSensing": "Scratch Lab Face Sensing Coding Cards",
     "ideas.modalCardNameComputationalConcepts": "Turtle Graphics Coding Cards",
-    "ideas.downloadGuides": "<strong>Computer doesn’t allow Youtube?</strong> Download <a>written guides</a> for these topics."
+    "ideas.downloadGuides": "<strong>Computer doesn’t allow Youtube?</strong> Download <a>written guides</a> for these topics.",
+    "ideas.physicalIdeasMicroImageDescription": "An illustration of a micro:bit device.",
+    "ideas.physicalIdeasMakeyImageDescription": "An illustration of a Makey Makey device.",
+    "ideas.youTubeImgDescription": "An illustration of the Youtube logo."
 }


### PR DESCRIPTION
### Resolves:

Parts of [Issue](https://github.com/scratchfoundation/scratch-www/issues/7178)

Expands on [PR](https://github.com/scratchfoundation/scratch-www/pull/7309)

### Changes:

Updates `physicalIdeasImage` object class to introduce support for alt-text & updated the Youtube img class for support too. Added translation strings.

Adds `alt={physicalIdea.physicalIdeasImage.altTextId}` to support it.

### Test Coverage:

Should work!