### PR TITLE
chore: Bring back commits for removing native educator pages

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -167,13 +167,6 @@
         "title": "Scratch Offline Editor"
     },
     {
-        "name": "educator-landing",
-        "pattern": "^/educators/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
-        "view": "teachers/landing/landing",
-        "title": "Educators"
-    },
-    {
         "name": "ethics",
         "pattern": "^/code-of-ethics/?$",
         "routeAlias": "/code-of-ethics/?$",
@@ -351,13 +344,6 @@
         "view": "studio/studio",
         "title": "Scratch Studio",
         "dynamicMetaTags": true
-    },
-    {
-        "name": "teacher-faq",
-        "pattern": "^/educators/faq/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
-        "view": "teachers/faq/faq",
-        "title": "Teacher Accounts FAQ"
     },
     {
         "name": "teacherregistration",

--- a/src/routes.json
+++ b/src/routes.json
@@ -348,14 +348,14 @@
     {
         "name": "teacherregistration",
         "pattern": "^/educators/register/?(\\?.*)?$",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
         "view": "teacherregistration/teacherregistration",
         "title": "Teacher Registration"
     },
     {
         "name": "teacherwaitingroom",
         "pattern": "^/educators/waiting",
-        "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
+        "routeAlias": "/educators/(register|waiting)/?(\\?.*)?$",
         "view": "teacherwaitingroom/teacherwaitingroom",
         "title": "Thank you for requesting a Scratch Teacher Account"
     },


### PR DESCRIPTION
## Proposed changes

Re-apply commits removing native educator pages

## Reason for changes

These were temporarily reverted to avoid interfering with the ongoing release at that time.