### PR TITLE
fix: gap in navigation profile dropdown

### DIFF
--- a/src/components/navigation/www/accountnav.scss
+++ b/src/components/navigation/www/accountnav.scss
@@ -4,7 +4,7 @@
 .account-nav {
     .user-info {
         display: inline-flex;
-        padding: 10px 15px 4px 15px;
+        padding: 10px 15px 7px 15px;
         max-width: 260px;
         height: 33px;
         overflow: hidden;


### PR DESCRIPTION
### Resolves:

[issue](https://scratch.mit.edu/discuss/topic/887896/)

### Changes:

Adjusts padding to `7px`.

### Test Coverage:

#### Before:
<img width="1366" height="768" alt="Screenshot 2026-06-06 11 46 42 AM" src="https://github.com/user-attachments/assets/ffeebe56-8da8-4fa4-8fbc-65871ea8eecb" />

#### After:
<img width="1366" height="768" alt="Screenshot 2026-06-06 11 47 56 AM" src="https://github.com/user-attachments/assets/ffc0ff6d-3b43-4d42-8dba-fc99487b72d8" />
