### PR TITLE
chore: add CLAUDE.md bridge so Claude Code loads AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### Resolves:

N/A. Small maintainer tooling change; follows the convention added to the org `AGENTS.md` template in scratchfoundation/.github#9.

### Changes:

Add a one-line `CLAUDE.md` whose only content is `@AGENTS.md`. Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so this repo's existing agent guide otherwise doesn't load, most noticeably when the repo is opened from a parent directory holding several repos. A plain import file is used rather than a symlink so the bridge survives Windows checkouts.

### Test Coverage:

No code change. Verified against the installed Claude Code (2.1.158) that a `CLAUDE.md` containing `@AGENTS.md` loads the imported content.